### PR TITLE
Frontend - Puzzle Browsing QoL update

### DIFF
--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Clock, Star, Circle, Users, Info } from 'lucide-react';
+import { Clock, Star, Circle, Users, Info, MessageSquare } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
@@ -25,6 +25,7 @@ export const PuzzlesList = () => {
   const page = searchParams?.get('page') ? Number(searchParams.get('page')) : 1;
 
   const [detailsPuzzleId, setDetailsPuzzleId] = useState<string | null>(null);
+  const [commentPuzzleId, setCommentPuzzleId] = useState<string | null>(null);
 
   const puzzlesQuery = usePuzzles({
     page: page,
@@ -45,6 +46,11 @@ export const PuzzlesList = () => {
     if (!detailsPuzzleId || !puzzles) return undefined;
     return puzzles.find((p) => p.id === detailsPuzzleId);
   }, [detailsPuzzleId, puzzles]);
+
+  const selectedCommentPuzzle: Puzzle | undefined = useMemo(() => {
+    if (!commentPuzzleId || !puzzles) return undefined;
+    return puzzles.find((p) => p.id === commentPuzzleId);
+  }, [commentPuzzleId, puzzles]);
 
   if (!puzzles) return null;
 
@@ -141,15 +147,29 @@ export const PuzzlesList = () => {
             </div>
 
             {/* Actions */}
-            <div className="mt-4 flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1"
-                onClick={() => setDetailsPuzzleId(puzzle.id)}
-              >
-                <Info className="mr-2 size-4" /> Puzzle details
-              </Button>
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+              <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => setDetailsPuzzleId(puzzle.id)}
+                >
+                  <Info className="mr-2 size-4" /> Puzzle details
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                  disabled={!puzzle.creatorComment}
+                  onClick={() => {
+                    if (puzzle.creatorComment) setCommentPuzzleId(puzzle.id);
+                  }}
+                >
+                  <MessageSquare className="mr-2 size-4" />
+                  {puzzle.creatorComment ? 'Creator comment' : 'No creator comment'}
+                </Button>
+              </div>
               <Link
                 href={paths.app.puzzle.getHref(puzzle.id)}
                 className="flex-1 rounded bg-blue-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
@@ -231,6 +251,43 @@ export const PuzzlesList = () => {
             {selectedPuzzle ? (
               <Link
                 href={paths.app.puzzle.getHref(selectedPuzzle.id)}
+                className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Go to puzzle
+              </Link>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(selectedCommentPuzzle)}
+        onOpenChange={(open) => {
+          if (!open) setCommentPuzzleId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {selectedCommentPuzzle?.title ?? 'Creator comment'}
+            </DialogTitle>
+            <DialogDescription>Notes from the puzzle creator.</DialogDescription>
+          </DialogHeader>
+
+          <div className="text-sm text-gray-700">
+            <div className="font-medium text-gray-900">Creator comment</div>
+            <div className="mt-1 whitespace-pre-wrap">
+              {selectedCommentPuzzle?.creatorComment}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCommentPuzzleId(null)}>
+              Close
+            </Button>
+            {selectedCommentPuzzle ? (
+              <Link
+                href={paths.app.puzzle.getHref(selectedCommentPuzzle.id)}
                 className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
               >
                 Go to puzzle

--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Clock, Star, Circle, Users, Info, MessageSquare } from 'lucide-react';
+import {
+  Clock,
+  Star,
+  Circle,
+  Users,
+  Info,
+  MessageSquare,
+  Medal,
+} from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
@@ -93,19 +101,25 @@ export const PuzzlesList = () => {
             key={puzzle.id}
             className="relative cursor-pointer rounded-lg border border-gray-300 bg-white p-5 transition-all hover:border-blue-400 hover:shadow-lg"
           >
-            {/* Title & Creator */}
-            <div className="mb-3">
-              <h3 className="mb-1 font-medium text-gray-900">{puzzle.title}</h3>
-              <p className="text-sm text-gray-500">
-                by{' '}
-                {puzzle.creator
-                  ? `${puzzle.creator.firstName} ${puzzle.creator.lastName}`
-                  : 'Anonymous'}
-              </p>
+            {/* Title & Creator with status badge */}
+            <div className="mb-3 flex flex-wrap items-start gap-2">
+              <div className="flex-1">
+                <h3 className="mb-1 font-medium text-gray-900">{puzzle.title}</h3>
+                <p className="text-sm text-gray-500">
+                  by{' '}
+                  {puzzle.creator
+                    ? `${puzzle.creator.firstName} ${puzzle.creator.lastName}`
+                    : 'Anonymous'}
+                </p>
+              </div>
+              <div className="flex items-center gap-1 rounded bg-gray-50 px-2 py-1 text-xs text-gray-700">
+                <Medal className="size-3.5" />
+                <span>Unsolved</span>
+              </div>
             </div>
 
-            {/* Difficulty & Time Limit */}
-            <div className="mb-3 flex items-center gap-2">
+            {/* Difficulty, plays, and details */}
+            <div className="mb-3 flex flex-wrap items-center gap-2">
               <span
                 className={`rounded border px-2 py-1 text-xs ${getDifficultyColor(
                   puzzle.difficulty,
@@ -115,52 +129,34 @@ export const PuzzlesList = () => {
                   puzzle.difficulty.slice(1).toLowerCase()}
               </span>
               <div className="flex items-center gap-1 text-gray-600">
-                <Clock className="size-3.5" />
-                <span className="text-xs">
-                  {Math.floor(puzzle.timeLimit / 60)}:
-                  {(puzzle.timeLimit % 60).toString().padStart(2, '0')}
-                </span>
-              </div>
-              <div className="flex items-center gap-1 text-gray-600">
                 <Users className="size-3.5" />
                 <span className="text-xs">
                   {puzzle.solvedCount || 0} solved
                 </span>
               </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="ml-auto w-full shadow-md ring-1 ring-blue-100 sm:w-40"
+                onClick={() => setDetailsPuzzleId(puzzle.id)}
+              >
+                <Info className="mr-2 size-4" /> Puzzle details
+              </Button>
             </div>
 
-            {/* Rating & Solved Status */}
-            <div className="flex items-center justify-between border-t border-gray-200 pt-3">
-              {/* Rating */}
+            {/* Rating and creator comment */}
+            <div className="flex flex-wrap items-start gap-3 border-t border-gray-200 pt-3">
               <div className="flex items-center gap-1">
                 {renderStars(puzzle.rating || 0)}
                 <span className="ml-1 text-xs text-gray-600">
                   {(puzzle.rating || 0).toFixed(1)}
                 </span>
               </div>
-
-              {/* Solved Status */}
-              <div className="flex items-center gap-1 rounded bg-gray-50 px-2 py-1 text-xs text-gray-500">
-                <Circle className="size-3.5" />
-                <span>Unsolved</span>
-              </div>
-            </div>
-
-            {/* Actions */}
-            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-              <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+              <div className="ml-auto">
                 <Button
                   variant="outline"
                   size="sm"
-                  className="flex-1"
-                  onClick={() => setDetailsPuzzleId(puzzle.id)}
-                >
-                  <Info className="mr-2 size-4" /> Puzzle details
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="flex-1"
+                  className="flex items-center w-full sm:w-40"
                   disabled={!puzzle.creatorComment}
                   onClick={() => {
                     if (puzzle.creatorComment) setCommentPuzzleId(puzzle.id);
@@ -170,9 +166,13 @@ export const PuzzlesList = () => {
                   {puzzle.creatorComment ? 'Creator comment' : 'No creator comment'}
                 </Button>
               </div>
+            </div>
+
+            {/* Primary action */}
+            <div className="mt-4 flex justify-center">
               <Link
                 href={paths.app.puzzle.getHref(puzzle.id)}
-                className="flex-1 rounded bg-blue-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                className="w-full max-w-xs rounded bg-blue-600 px-4 py-3 text-center text-sm font-semibold text-white shadow-md transition-colors hover:bg-blue-700"
               >
                 Solve Puzzle
               </Link>

--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -1,17 +1,30 @@
 'use client';
 
-import { Clock, Star, Circle, Users } from 'lucide-react';
+import { Clock, Star, Circle, Users, Info } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
 
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Link } from '@/components/ui/link';
 import { Spinner } from '@/components/ui/spinner';
 import { paths } from '@/config/paths';
+import type { Puzzle } from '@/types/api';
 
 import { usePuzzles } from '../api/get-puzzles';
 
 export const PuzzlesList = () => {
   const searchParams = useSearchParams();
   const page = searchParams?.get('page') ? Number(searchParams.get('page')) : 1;
+
+  const [detailsPuzzleId, setDetailsPuzzleId] = useState<string | null>(null);
 
   const puzzlesQuery = usePuzzles({
     page: page,
@@ -27,6 +40,11 @@ export const PuzzlesList = () => {
 
   const puzzles = puzzlesQuery.data?.data;
   const meta = puzzlesQuery.data?.meta;
+
+  const selectedPuzzle: Puzzle | undefined = useMemo(() => {
+    if (!detailsPuzzleId || !puzzles) return undefined;
+    return puzzles.find((p) => p.id === detailsPuzzleId);
+  }, [detailsPuzzleId, puzzles]);
 
   if (!puzzles) return null;
 
@@ -122,11 +140,19 @@ export const PuzzlesList = () => {
               </div>
             </div>
 
-            {/* Action Button */}
-            <div className="mt-4">
+            {/* Actions */}
+            <div className="mt-4 flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={() => setDetailsPuzzleId(puzzle.id)}
+              >
+                <Info className="mr-2 size-4" /> Puzzle details
+              </Button>
               <Link
                 href={paths.app.puzzle.getHref(puzzle.id)}
-                className="w-full rounded bg-blue-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                className="flex-1 rounded bg-blue-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-700"
               >
                 Solve Puzzle
               </Link>
@@ -134,6 +160,85 @@ export const PuzzlesList = () => {
           </div>
         ))}
       </div>
+
+      <Dialog
+        open={Boolean(selectedPuzzle)}
+        onOpenChange={(open) => {
+          if (!open) setDetailsPuzzleId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{selectedPuzzle?.title ?? 'Puzzle details'}</DialogTitle>
+            <DialogDescription>
+              Key information before you start solving.
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedPuzzle ? (
+            <div className="space-y-3 text-sm text-gray-700">
+              <div>
+                <div className="font-medium text-gray-900">Description</div>
+                <div className="mt-1 whitespace-pre-wrap">
+                  {selectedPuzzle.description}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-2 rounded border border-gray-200 bg-gray-50 p-3 text-sm sm:grid-cols-2">
+                <div>
+                  <span className="font-medium text-gray-900">Time:</span>{' '}
+                  {Math.floor(selectedPuzzle.timeLimit / 60)}m{' '}
+                  {(selectedPuzzle.timeLimit % 60).toString().padStart(2, '0')}
+                  s
+                </div>
+                <div>
+                  <span className="font-medium text-gray-900">Budget:</span>{' '}
+                  {selectedPuzzle.budgetLimit}
+                </div>
+                <div>
+                  <span className="font-medium text-gray-900">Tight budget:</span>{' '}
+                  {selectedPuzzle.tightBudgetLimit ?? '—'}
+                </div>
+              </div>
+
+              <div>
+                <div className="font-medium text-gray-900">Additional constraints (optional)</div>
+                <div className="mt-1 space-y-1">
+                  {Array.isArray(selectedPuzzle.additionalConstraints) ? (
+                    selectedPuzzle.additionalConstraints.length > 0 ? (
+                      <ul className="list-disc space-y-1 pl-5">
+                        {selectedPuzzle.additionalConstraints.map((c) => (
+                          <li key={c}>{c}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="text-gray-500">None provided.</div>
+                    )
+                  ) : selectedPuzzle.additionalConstraints ? (
+                    <div>{selectedPuzzle.additionalConstraints}</div>
+                  ) : (
+                    <div className="text-gray-500">None provided.</div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDetailsPuzzleId(null)}>
+              Close
+            </Button>
+            {selectedPuzzle ? (
+              <Link
+                href={paths.app.puzzle.getHref(selectedPuzzle.id)}
+                className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Go to puzzle
+              </Link>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Pagination */}
       {meta && meta.totalPages > 1 && (

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -54,6 +54,7 @@ export type Puzzle = Entity<{
   timeLimit: number; // in seconds
   budgetLimit: number;
   tightBudgetLimit?: number;
+  additionalConstraints?: string[] | string;
   inputs: string[];
   outputs: string[];
   creator: User;


### PR DESCRIPTION
### Description
Added puzzle information and creator comments popups in the puzzle browser.
Reordered the information shown to be more legible

### Related Issues
<!-- use #<number-of-issue> to link issues -->
Closes #19 

### Checklist
- [x] I am confident this code can be pushed to deployment

### Screenshots 
Puzzle Browser:
<img width="1361" height="639" alt="image" src="https://github.com/user-attachments/assets/a00b7af7-8233-4e20-8b7a-c2c3f70fa1e9" />
Puzzle Details:
<img width="944" height="542" alt="image" src="https://github.com/user-attachments/assets/bad14aa8-9d72-4c63-b6a0-61f132feb222" />
Creator Comment:
<img width="968" height="353" alt="image" src="https://github.com/user-attachments/assets/42778589-d21e-4cd8-86ea-8d6d8503321f" />