### PR TITLE
feat: Workstation UX Overhaul & Finalize Riddle Upload (#48)

### DIFF
--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -347,12 +347,17 @@ export const WorkstationGrid = ({
   };
 
   const [visible, setVisible] = useState(() => getVisibleRange());
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    const update = () => setVisible(getVisibleRange());
+    const update = () => {
+      setVisible(getVisibleRange());
+      const r = el.getBoundingClientRect();
+      setContainerSize({ w: r.width, h: r.height });
+    };
     update();
 
     const ro = new ResizeObserver(update);
@@ -552,8 +557,12 @@ export const WorkstationGrid = ({
 
     for (let i = 0; i < outputs.length; i++) {
       const id = `IO:OUT:${outputs[i]}`;
-      const row = Math.min(i, GRID_ROWS - 1);
-      const anchor = toScreenCenter(row, GRID_COLS + 0.8); // Margin from grid
+      // Distribute along the bottom (Layout Update: Outputs to Bottom)
+      const colStep = GRID_COLS / (outputs.length + 1);
+      // Center based on step
+      const col = (i + 1) * colStep - 0.5;
+      const row = GRID_ROWS + 0.5;
+      const anchor = toScreenCenter(row, col);
       outputsPos[id] = { x: anchor.x, y: anchor.y };
     }
 
@@ -677,7 +686,8 @@ export const WorkstationGrid = ({
       wireDraft.start.portId === port.portId
     ) {
       // Clicked on the same port that started the draft.
-      // Keep drafting (Click-to-wire behavior).
+      // Cancel wiring (Toggle/Cancel Logic).
+      setWireDraft(null);
       return;
     }
 
@@ -688,9 +698,17 @@ export const WorkstationGrid = ({
   const onStartWireDrag = (port: PortAddress, e: ReactPointerEvent) => {
     e.stopPropagation();
 
-    // If we are already drafting a wire, don't restart it from this new port.
-    // We will let onPointerUp handle the connection.
-    if (wireDraft) return;
+    // Wiring UX: Toggle/Cancel Logic
+    // If clicking a pin that is already the source, cancel.
+    if (wireDraft) {
+      if (
+        wireDraft.start.ownerId === port.ownerId &&
+        wireDraft.start.portId === port.portId
+      ) {
+        setWireDraft(null);
+      }
+      return;
+    }
 
     const el = containerRef.current;
     if (!el) return;
@@ -1323,6 +1341,73 @@ export const WorkstationGrid = ({
             );
           })}
         </div>
+
+        {/* Navigation Indicators */}
+        {(() => {
+          if (containerSize.w === 0) return null;
+          const indicators: {
+            id: string;
+            label: string;
+            cls: string;
+          }[] = [];
+
+          const In0 = inputs[0] ? ioLayout.inputs[`IO:IN:${inputs[0]}`] : null;
+          const InN =
+            inputs.length > 0
+              ? ioLayout.inputs[`IO:IN:${inputs[inputs.length - 1]}`]
+              : null;
+
+          if (In0 && InN) {
+            // If the bottom-most input is above the visible area
+            if (InN.y < 0) {
+              indicators.push({
+                id: 'in-up',
+                label: 'Inputs ↑',
+                cls: 'top-2 left-4',
+              });
+            }
+            // If the top-most input is below the visible area
+            else if (In0.y > containerSize.h) {
+              indicators.push({
+                id: 'in-down',
+                label: 'Inputs ↓',
+                cls: 'bottom-2 left-4',
+              });
+            }
+          }
+
+          const Out0 = outputs[0]
+            ? ioLayout.outputs[`IO:OUT:${outputs[0]}`]
+            : null;
+          if (Out0) {
+            // If outputs are above (unlikely given bottom placement, but possible with zoom/pan)
+            if (Out0.y < 0) {
+              indicators.push({
+                id: 'out-up',
+                label: 'Outputs ↑',
+                cls: 'top-2 left-1/2 -translate-x-1/2',
+              });
+            } else if (Out0.y > containerSize.h) {
+              indicators.push({
+                id: 'out-down',
+                label: 'Outputs ↓',
+                cls: 'bottom-2 left-1/2 -translate-x-1/2',
+              });
+            }
+          }
+
+          return indicators.map((ind) => (
+            <div
+              key={ind.id}
+              className={cn(
+                'absolute z-40 animate-bounce rounded bg-white/90 px-3 py-1.5 text-xs font-bold shadow-md ring-1 ring-gray-200 backdrop-blur-sm',
+                ind.cls,
+              )}
+            >
+              {ind.label}
+            </div>
+          ));
+        })()}
       </div>
     </div>
   );

--- a/riddles/riddle_01_binary_adder_config.json
+++ b/riddles/riddle_01_binary_adder_config.json
@@ -1,0 +1,45 @@
+{
+  "puzzle": {
+    "name": "Binary Adder Quiz",
+    "description": "Design a full adder circuit using AND, NAND, and DFF gates. Implement the sum and carry-out logic for two input bits and a carry-in bit.",
+    "budget": 200,
+    "time_limit_seconds": null,
+    "default_gate_set": ["XOR", "AND", "OR"],
+    "inputs": ["A", "B", "C_in"],
+    "outputs": ["S", "C_out"]
+  },
+  "test_cases": [
+    {
+      "inputs": {"A": 0, "B": 0, "C_in": 0},
+      "expected_outputs": {"S": 0, "C_out": 0}
+    },
+    {
+      "inputs": {"A": 0, "B": 0, "C_in": 1},
+      "expected_outputs": {"S": 1, "C_out": 0}
+    },
+    {
+      "inputs": {"A": 0, "B": 1, "C_in": 0},
+      "expected_outputs": {"S": 1, "C_out": 0}
+    },
+    {
+      "inputs": {"A": 0, "B": 1, "C_in": 1},
+      "expected_outputs": {"S": 0, "C_out": 1}
+    },
+    {
+      "inputs": {"A": 1, "B": 0, "C_in": 0},
+      "expected_outputs": {"S": 1, "C_out": 0}
+    },
+    {
+      "inputs": {"A": 1, "B": 0, "C_in": 1},
+      "expected_outputs": {"S": 0, "C_out": 1}
+    },
+    {
+      "inputs": {"A": 1, "B": 1, "C_in": 0},
+      "expected_outputs": {"S": 0, "C_out": 1}
+    },
+    {
+      "inputs": {"A": 1, "B": 1, "C_in": 1},
+      "expected_outputs": {"S": 1, "C_out": 1}
+    }
+  ]
+}

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "Starting EscapeCircuit (Backend and Frontend)..."
+echo ""
+
+# 1. Initialize Database
+echo "Initializing database..."
+# Changed slash to / and added python3 safety
+python3 src/init_db.py
+if [ $? -ne 0 ]; then
+    echo "Database initialization failed."
+    exit 1
+fi
+
+# 2. Load Riddles
+echo ""
+echo "Loading riddles..."
+python3 src/insert_riddles.py
+if [ $? -ne 0 ]; then
+    echo "Riddle loading failed."
+    exit 1
+fi
+
+echo ""
+echo "Starting servers..."
+echo "Press Ctrl+C to stop both servers."
+
+# 3. Start Servers
+# Changed line continuation to \
+# Changed paths to / (apps/nextjs-app)
+npx -y concurrently -k -n "API,WEB" -c "blue,magenta" \
+  "pip install -r requirements.txt && cd src && python3 -m uvicorn Backend.main:app --reload --host 127.0.0.1 --port 8080" \
+  "cd apps/nextjs-app && npm run dev"


### PR DESCRIPTION
🌿 Branch
48-uxui-move-outputs-to-bottom-add-off-screen-indicators-improve-wiring-cancel-logic

📝 Description
This PR delivers a major upgrade to the Puzzle Workstation UI/UX to improve usability on larger circuits and refines the wiring interaction.

Additionally, this PR fully completes the "Upload Python Riddle" feature (originally tracked in #42). The previously missing database integration is now implemented, meaning uploaded riddles are properly registered in the system.

🔗 Related Issues
Closes #48 (UX/UI Improvements)

Closes #42 (Finalizes Python Riddle Upload & DB Integration)

🛠️ Key Changes
1. 🎨 Workstation UX/UI (#48)
🔌 Wiring Toggle/Cancel Logic:

Refined the wiring interaction. Clicking a pin that is already the source of the current wire now cancels the drag action.

Resets isWiring state immediately instead of attempting an invalid self-connection.

📐 Layout Refactor:

Moved Puzzle Outputs from the right sidebar to the bottom of the workspace.

Outputs now span the full width, creating a clearer top-to-bottom logic flow.

compass Navigation Indicators:

Implemented off-screen detection for Input and Output containers.

"Inputs ↑" and "Outputs ↓" floating arrows now appear when these elements are scrolled out of the viewport.

2. 🗄️ Backend & Database (#42 Completed)
Database Integration: Implemented the missing connectivity logic from the previous partial PR.

Metadata Storage: When a riddle is uploaded via the Admin panel, a database entry is now successfully created, linking the file paths stored in riddles/ to the application logic.

✅ Checklist
[x] Wiring: Clicking the source pin cancels the wire drag.

[x] Layout: Puzzle Outputs are positioned at the bottom.

[x] Navigation: Directional arrows appear when elements are off-screen.

[x] Backend: Riddle database entries are created successfully on upload.

[x] Completion: Issue #42 is now fully resolved (Files + DB).

[x] Ready for Merge: All tests passed.