### PR TITLE
Discussion Forum — Full Feature, Bug Fixes, Testing & Polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "uvicorn", "Backend.main:app", "--reload", "--host", "127.0.0.1", "--port", "8080", "--app-dir", "src"],
+      "port": 8080,
+      "autoPort": false
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "cwd": "apps/nextjs-app",
+      "autoPort": false
+    }
+  ]
+}

--- a/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
+++ b/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Home, PanelLeft, Folder, Users, User2, Gamepad2, Zap, Bell, Shield } from 'lucide-react';
+import { Home, PanelLeft, MessageSquare, Users, User2, Gamepad2, Zap, Bell, Shield } from 'lucide-react';
 import NextLink from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -49,7 +49,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   const navigation = [
     { name: 'Puzzles', to: paths.app.puzzles.getHref(), icon: Gamepad2 },
     { name: 'Arsenal', to: paths.app.arsenal.root.getHref(), icon: Zap },
-    { name: 'Discussions', to: paths.app.discussions.getHref(), icon: Folder },
+    {
+      name: 'Discussions',
+      to: paths.app.discussions.getHref(),
+      icon: MessageSquare,
+    },
     (userRole === 'creator' || userRole === 'admin') && {
       name: 'Notifications',
       to: paths.app.notifications.getHref(),

--- a/apps/nextjs-app/src/app/app/discussions/[id]/page.tsx
+++ b/apps/nextjs-app/src/app/app/discussions/[id]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { DiscussionView } from '@/features/discussions/components/discussion-view';
+
+const DiscussionPage = () => {
+  const params = useParams<{ id: string }>();
+
+  return <DiscussionView discussionId={params.id} />;
+};
+
+export default DiscussionPage;

--- a/apps/nextjs-app/src/app/app/discussions/new/page.tsx
+++ b/apps/nextjs-app/src/app/app/discussions/new/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { paths } from '@/config/paths';
+
+import { CreateDiscussion } from '@/features/discussions/components/create-discussion';
+
+const NewDiscussionPage = () => {
+  const router = useRouter();
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <CreateDiscussion
+        onSuccess={(discussion) => {
+          router.push(paths.app.discussion.getHref(String(discussion.id)));
+        }}
+      />
+    </div>
+  );
+};
+
+export default NewDiscussionPage;

--- a/apps/nextjs-app/src/app/app/discussions/page.tsx
+++ b/apps/nextjs-app/src/app/app/discussions/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import NextLink from 'next/link';
+import { Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { paths } from '@/config/paths';
+import { DiscussionsList } from '@/features/discussions/components/discussions-list';
+import { useUser } from '@/lib/auth';
+import { canCreateDiscussion } from '@/lib/authorization';
+
+const DiscussionsPage = () => {
+  const user = useUser();
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-gray-900">Discussions</h1>
+        {canCreateDiscussion(user.data) && (
+          <NextLink href={paths.app.newDiscussion.getHref()}>
+            <Button size="sm" icon={<Plus className="size-4" />}>
+              New Discussion
+            </Button>
+          </NextLink>
+        )}
+      </div>
+      <DiscussionsList />
+    </div>
+  );
+};
+
+export default DiscussionsPage;

--- a/apps/nextjs-app/src/app/app/notifications/page.tsx
+++ b/apps/nextjs-app/src/app/app/notifications/page.tsx
@@ -70,11 +70,13 @@ const NotificationsPage = () => {
               <select
                 className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
                 value={filters.notifType || ''}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, notifType: (e.target.value || undefined) as 'solve' | 'rating' | undefined })}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, notifType: (e.target.value || undefined) as 'solve' | 'rating' | 'warning' | 'ban' | undefined })}
               >
                 <option value="">All Types</option>
                 <option value="solve">Puzzle Solved</option>
                 <option value="rating">Rating</option>
+                <option value="warning">Warning</option>
+                <option value="ban">Ban</option>
               </select>
             </div>
 
@@ -168,10 +170,14 @@ const NotificationsPage = () => {
                         className={`inline-flex rounded-full px-3 py-1 text-xs font-medium ${
                           notification.type === 'solve'
                             ? 'bg-green-100 text-green-800'
+                            : notification.type === 'warning'
+                            ? 'bg-yellow-100 text-yellow-800'
+                            : notification.type === 'ban'
+                            ? 'bg-red-100 text-red-800'
                             : 'bg-blue-100 text-blue-800'
                         }`}
                       >
-                        {notification.type === 'solve' ? 'Puzzle Solved' : 'Rating'}
+                        {notification.type === 'solve' ? 'Puzzle Solved' : notification.type === 'warning' ? 'Warning' : notification.type === 'ban' ? 'Account Restriction' : 'Rating'}
                       </span>
                       <span className="text-sm font-medium text-gray-700">
                         {notification.puzzle_name}

--- a/apps/nextjs-app/src/app/app/users/_components/admin-panel.tsx
+++ b/apps/nextjs-app/src/app/app/users/_components/admin-panel.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { useState } from 'react';
-import { Users, Gamepad2, ClipboardList } from 'lucide-react';
+import { Users, Gamepad2, ClipboardList, Flag } from 'lucide-react';
 
 import { UsersList } from '@/features/users/components/users-list';
 import { AdminPuzzlesList } from '@/features/admin/components/admin-puzzles-list';
 import { AuditLogList } from '@/features/admin/components/audit-log-list';
+import { ReportsList } from '@/features/admin/components/reports-list';
 import { cn } from '@/utils/cn';
 
-type Tab = 'users' | 'puzzles' | 'audit';
+type Tab = 'users' | 'puzzles' | 'audit' | 'reports';
 
 const tabs: { id: Tab; label: string; icon: any }[] = [
   { id: 'users', label: 'Users', icon: Users },
   { id: 'puzzles', label: 'Puzzles', icon: Gamepad2 },
+  { id: 'reports', label: 'Reports', icon: Flag },
   { id: 'audit', label: 'Audit Log', icon: ClipboardList },
 ];
 
@@ -46,6 +48,7 @@ export const AdminPanel = () => {
       {/* Tab Content */}
       {activeTab === 'users' && <UsersList />}
       {activeTab === 'puzzles' && <AdminPuzzlesList />}
+      {activeTab === 'reports' && <ReportsList />}
       {activeTab === 'audit' && <AuditLogList />}
     </div>
   );

--- a/apps/nextjs-app/src/app/page.tsx
+++ b/apps/nextjs-app/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import NextLink from 'next/link';
 
 import { Button } from '@/components/ui/button';
 import { paths } from '@/config/paths';
@@ -19,29 +20,95 @@ const HomePage = () => {
     }
   }, [user.status, user.data, router]);
 
-  // Show a simple landing with a login button when not authenticated
-  const showLogin = user.status !== 'pending' && !user.data;
+  // Show landing content when not authenticated
+  const showLanding = user.status !== 'pending' && !user.data;
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
-      <header className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-        <div className="text-lg font-semibold text-gray-900">EscapeCircuit</div>
-        {showLogin ? (
-          <Button onClick={() => router.push(paths.auth.login.getHref())}>
-            Login
-          </Button>
+    <div className="flex min-h-screen flex-col bg-gray-50">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
+        <div className="flex items-center gap-3">
+          <img className="h-8 w-auto" src="/logo.svg" alt="EscapeCircuit" />
+          <span className="text-xl font-bold text-gray-900">EscapeCircuit</span>
+        </div>
+        {showLanding ? (
+          <div className="flex items-center gap-3">
+            <NextLink href={paths.auth.login.getHref()}>
+              <Button variant="outline">Log in</Button>
+            </NextLink>
+            <NextLink href={paths.auth.register.getHref()}>
+              <Button>Register</Button>
+            </NextLink>
+          </div>
         ) : (
-          <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
         )}
       </header>
-      <main className="flex flex-1 items-center justify-center px-4 py-10 text-gray-700">
-        <div className="max-w-xl text-center">
-          <h1 className="text-2xl font-semibold text-gray-900">Welcome</h1>
-          <p className="mt-2 text-gray-600">
-            Please log in to access puzzles and your dashboard.
+
+      {/* Hero */}
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
+        <div className="max-w-2xl text-center">
+          <img className="mx-auto mb-8 h-24 w-auto" src="/logo.svg" alt="" />
+          <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">
+            Wire your way out
+          </h1>
+          <p className="mt-4 text-lg text-gray-600">
+            Create and solve logic-circuit puzzles, compete on the leaderboard,
+            and discuss strategies with the community.
           </p>
+
+          {showLanding && (
+            <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <NextLink href={paths.auth.register.getHref()}>
+                <Button className="w-48 py-3 text-base">Get Started</Button>
+              </NextLink>
+              <NextLink href={paths.auth.login.getHref()}>
+                <Button variant="outline" className="w-48 py-3 text-base">
+                  Log in
+                </Button>
+              </NextLink>
+            </div>
+          )}
         </div>
+
+        {/* Feature highlights */}
+        {showLanding && (
+          <div className="mt-20 grid max-w-4xl grid-cols-1 gap-8 sm:grid-cols-3">
+            <div className="rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 text-2xl">
+                <span role="img" aria-label="Puzzle">&#x1F9E9;</span>
+              </div>
+              <h3 className="font-semibold text-gray-900">Solve Puzzles</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Challenge yourself with logic-circuit puzzles of varying difficulty.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-2xl">
+                <span role="img" aria-label="Trophy">&#x1F3C6;</span>
+              </div>
+              <h3 className="font-semibold text-gray-900">Earn XP</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Gain experience points, level up, and climb the leaderboard.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-purple-50 text-2xl">
+                <span role="img" aria-label="Discussion">&#x1F4AC;</span>
+              </div>
+              <h3 className="font-semibold text-gray-900">Discuss</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Share tips, ask for help, and connect with the community.
+              </p>
+            </div>
+          </div>
+        )}
       </main>
+
+      {/* Footer */}
+      <footer className="border-t border-gray-200 bg-white px-6 py-4 text-center text-xs text-gray-400">
+        EscapeCircuit &mdash; Wire your way out.
+      </footer>
     </div>
   );
 };

--- a/apps/nextjs-app/src/app/public/discussions/[discussionId]/page.tsx
+++ b/apps/nextjs-app/src/app/public/discussions/[discussionId]/page.tsx
@@ -1,59 +1,13 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
+'use client';
 
-import { Discussion } from '@/app/app/discussions/[discussionId]/_components/discussion';
-import { getInfiniteCommentsQueryOptions } from '@/features/comments/api/get-comments';
-import {
-  getDiscussion,
-  getDiscussionQueryOptions,
-} from '@/features/discussions/api/get-discussion';
+import { useParams } from 'next/navigation';
 
-export const generateMetadata = async ({
-  params,
-}: {
-  params: Promise<{ discussionId: string }>;
-}) => {
-  const discussionId = (await params).discussionId;
+import { DiscussionView } from '@/features/discussions/components/discussion-view';
 
-  const discussion = await getDiscussion({ discussionId });
+const PublicDiscussionPage = () => {
+  const params = useParams<{ discussionId: string }>();
 
-  return {
-    title: discussion.data?.title,
-    description: discussion.data?.title,
-  };
-};
-
-const preloadData = async (discussionId: string) => {
-  const queryClient = new QueryClient();
-
-  await Promise.all([
-    queryClient.prefetchQuery(getDiscussionQueryOptions(discussionId)),
-    queryClient.prefetchInfiniteQuery(
-      getInfiniteCommentsQueryOptions(discussionId),
-    ),
-  ]);
-
-  return {
-    dehydratedState: dehydrate(queryClient),
-  };
-};
-
-const PublicDiscussionPage = async ({
-  params: { discussionId },
-}: {
-  params: {
-    discussionId: string;
-  };
-}) => {
-  const { dehydratedState } = await preloadData(discussionId);
-  return (
-    <HydrationBoundary state={dehydratedState}>
-      <Discussion discussionId={discussionId} />
-    </HydrationBoundary>
-  );
+  return <DiscussionView discussionId={params.discussionId} />;
 };
 
 export default PublicDiscussionPage;

--- a/apps/nextjs-app/src/components/ui/notifications/notification.tsx
+++ b/apps/nextjs-app/src/components/ui/notifications/notification.tsx
@@ -18,21 +18,23 @@ export type NotificationProps = {
     type: keyof typeof icons;
     title: string;
     message?: string;
+    persistent?: boolean;
   };
   onDismiss: (id: string) => void;
 };
 
 export const Notification = ({
-  notification: { id, type, title, message },
+  notification: { id, type, title, message, persistent },
   onDismiss,
 }: NotificationProps) => {
   useEffect(() => {
+    if (persistent) return;
     const timer = setTimeout(() => {
       onDismiss(id);
     }, 5000);
 
     return () => clearTimeout(timer);
-  }, [id, onDismiss]);
+  }, [id, onDismiss, persistent]);
 
   return (
     <div className="flex w-full flex-col items-center space-y-4 sm:items-end">

--- a/apps/nextjs-app/src/components/ui/notifications/notifications-store.ts
+++ b/apps/nextjs-app/src/components/ui/notifications/notifications-store.ts
@@ -6,6 +6,7 @@ export type Notification = {
   type: 'info' | 'warning' | 'success' | 'error';
   title: string;
   message?: string;
+  persistent?: boolean;
 };
 
 type NotificationsStore = {

--- a/apps/nextjs-app/src/config/paths.ts
+++ b/apps/nextjs-app/src/config/paths.ts
@@ -44,6 +44,9 @@ export const paths = {
     discussion: {
       getHref: (id: string) => `/app/discussions/${id}`,
     },
+    newDiscussion: {
+      getHref: () => '/app/discussions/new',
+    },
     users: {
       getHref: () => '/app/users',
     },

--- a/apps/nextjs-app/src/features/admin/api/accept-creator.ts
+++ b/apps/nextjs-app/src/features/admin/api/accept-creator.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api-client';
 import { MutationConfig } from '@/lib/react-query';
 
-export const acceptCreatorRole = () => {
+export const acceptCreatorRole = (_?: void) => {
   return api.post('/users/me/accept-creator');
 };
 
@@ -28,7 +28,7 @@ export const useAcceptCreator = ({
   });
 };
 
-export const declineCreatorRole = () => {
+export const declineCreatorRole = (_?: void) => {
   return api.post('/users/me/decline-creator');
 };
 

--- a/apps/nextjs-app/src/features/admin/api/get-reports.ts
+++ b/apps/nextjs-app/src/features/admin/api/get-reports.ts
@@ -1,0 +1,44 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+import { Report } from '@/types/api';
+
+type ReportsResponse = {
+  reports: Report[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+export const getReports = (
+  status?: string,
+  limit: number = 50,
+  offset: number = 0,
+): Promise<ReportsResponse> => {
+  return api.get('/reports', {
+    params: { status: status || undefined, limit, offset },
+  });
+};
+
+export const getReportsQueryOptions = (status?: string) => {
+  return queryOptions({
+    queryKey: ['admin-reports', status],
+    queryFn: () => getReports(status),
+  });
+};
+
+type UseReportsOptions = {
+  status?: string;
+  queryConfig?: QueryConfig<typeof getReportsQueryOptions>;
+};
+
+export const useReports = ({
+  status,
+  queryConfig,
+}: UseReportsOptions = {}) => {
+  return useQuery({
+    ...getReportsQueryOptions(status),
+    ...queryConfig,
+  });
+};

--- a/apps/nextjs-app/src/features/admin/api/report-actions.ts
+++ b/apps/nextjs-app/src/features/admin/api/report-actions.ts
@@ -1,0 +1,109 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const warnReportAuthor = ({
+  reportId,
+}: {
+  reportId: number;
+}): Promise<{ action: string; report_id: number; warned_user_id: number }> => {
+  return api.post(`/reports/${reportId}/warn`);
+};
+
+export const useWarnReportAuthor = ({
+  mutationConfig,
+}: { mutationConfig?: MutationConfig<typeof warnReportAuthor> } = {}) => {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: warnReportAuthor,
+  });
+};
+
+export const banReportAuthor = ({
+  reportId,
+}: {
+  reportId: number;
+}): Promise<{ action: string; report_id: number; banned_user_id: number }> => {
+  return api.post(`/reports/${reportId}/ban`);
+};
+
+export const useBanReportAuthor = ({
+  mutationConfig,
+}: { mutationConfig?: MutationConfig<typeof banReportAuthor> } = {}) => {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: banReportAuthor,
+  });
+};
+
+export const deleteReportedContent = ({
+  reportId,
+}: {
+  reportId: number;
+}): Promise<{
+  action: string;
+  report_id: number;
+  target_type: string;
+  target_id: number;
+}> => {
+  return api.post(`/reports/${reportId}/delete-content`);
+};
+
+export const useDeleteReportedContent = ({
+  mutationConfig,
+}: {
+  mutationConfig?: MutationConfig<typeof deleteReportedContent>;
+} = {}) => {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: deleteReportedContent,
+  });
+};
+
+export const lockReportedDiscussion = ({
+  reportId,
+}: {
+  reportId: number;
+}): Promise<{
+  action: string;
+  report_id: number;
+  discussion_id: number;
+}> => {
+  return api.post(`/reports/${reportId}/lock`);
+};
+
+export const useLockReportedDiscussion = ({
+  mutationConfig,
+}: {
+  mutationConfig?: MutationConfig<typeof lockReportedDiscussion>;
+} = {}) => {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: lockReportedDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/admin/api/update-report-status.ts
+++ b/apps/nextjs-app/src/features/admin/api/update-report-status.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { Report } from '@/types/api';
+
+export type UpdateReportStatusDTO = {
+  reportId: number;
+  status: string;
+};
+
+export const updateReportStatus = ({
+  reportId,
+  status,
+}: UpdateReportStatusDTO): Promise<Report> => {
+  return api.patch(`/reports/${reportId}`, { status });
+};
+
+type UseUpdateReportStatusOptions = {
+  mutationConfig?: MutationConfig<typeof updateReportStatus>;
+};
+
+export const useUpdateReportStatus = ({
+  mutationConfig,
+}: UseUpdateReportStatusOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: ['admin-reports'],
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: updateReportStatus,
+  });
+};

--- a/apps/nextjs-app/src/features/admin/components/admin-puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/admin/components/admin-puzzles-list.tsx
@@ -105,7 +105,7 @@ export const AdminPuzzlesList = () => {
           },
           {
             title: 'Creator',
-            field: 'creator_user_id',
+            field: 'creator' as any,
             Cell({ entry }: { entry: any }) {
               return (
                 <span>{entry.creator?.username || 'Unknown'}</span>
@@ -140,7 +140,7 @@ export const AdminPuzzlesList = () => {
           },
           {
             title: 'Created',
-            field: 'created_at',
+            field: 'createdAt',
             Cell({ entry }: { entry: any }) {
               const ts = entry.created_at || entry.createdAt;
               return (

--- a/apps/nextjs-app/src/features/admin/components/reports-list.tsx
+++ b/apps/nextjs-app/src/features/admin/components/reports-list.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  AlertTriangle,
+  Ban,
+  Lock,
+  Trash2,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmationDialog } from '@/components/ui/dialog';
+import { useNotifications } from '@/components/ui/notifications';
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/utils/cn';
+
+import { useReports } from '../api/get-reports';
+import {
+  useBanReportAuthor,
+  useDeleteReportedContent,
+  useLockReportedDiscussion,
+  useWarnReportAuthor,
+} from '../api/report-actions';
+import { useUpdateReportStatus } from '../api/update-report-status';
+
+const formatDate = (dateStr: string) => {
+  try {
+    return new Date(dateStr).toLocaleString();
+  } catch {
+    return dateStr;
+  }
+};
+
+const reasonLabels: Record<string, string> = {
+  spam: 'Spam',
+  harassment: 'Harassment',
+  off_topic: 'Off Topic',
+  inappropriate: 'Inappropriate',
+  other: 'Other',
+};
+
+const reasonColors: Record<string, string> = {
+  spam: 'bg-red-50 text-red-700',
+  harassment: 'bg-red-100 text-red-800',
+  off_topic: 'bg-yellow-50 text-yellow-700',
+  inappropriate: 'bg-orange-50 text-orange-700',
+  other: 'bg-gray-50 text-gray-700',
+};
+
+const statusColors: Record<string, string> = {
+  pending: 'bg-yellow-50 text-yellow-700',
+  reviewed: 'bg-green-50 text-green-700',
+  dismissed: 'bg-gray-100 text-gray-500',
+};
+
+const STATUS_FILTERS = [
+  { value: '', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'dismissed', label: 'Dismissed' },
+] as const;
+
+export const ReportsList = () => {
+  const [statusFilter, setStatusFilter] = useState('');
+  const query = useReports({ status: statusFilter || undefined });
+  const updateMutation = useUpdateReportStatus();
+  const { addNotification } = useNotifications();
+
+  const warnMutation = useWarnReportAuthor({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({ type: 'success', title: 'Warning sent to author' });
+      },
+    },
+  });
+
+  const banMutation = useBanReportAuthor({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({
+          type: 'success',
+          title: 'Author banned from discussions',
+        });
+      },
+    },
+  });
+
+  const deleteMutation = useDeleteReportedContent({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({ type: 'success', title: 'Reported content deleted' });
+      },
+    },
+  });
+
+  const lockMutation = useLockReportedDiscussion({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({ type: 'success', title: 'Discussion locked' });
+      },
+    },
+  });
+
+  if (query.isLoading) {
+    return (
+      <div className="flex h-48 w-full items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+        <p className="text-sm text-red-700">Failed to load reports.</p>
+      </div>
+    );
+  }
+
+  const reports = query.data?.reports || [];
+
+  return (
+    <div className="space-y-3">
+      {/* Status filter tabs */}
+      <div className="flex gap-1">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setStatusFilter(f.value)}
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+              statusFilter === f.value
+                ? 'bg-blue-100 text-blue-700'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <p className="text-gray-600">
+            {statusFilter
+              ? `No ${statusFilter} reports.`
+              : 'No reports yet.'}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {reports.map((report) => (
+            <div
+              key={report.id}
+              className="rounded-lg border border-gray-200 bg-white p-3 text-sm"
+            >
+              {/* Top row: reason badge, status badge, date */}
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs font-medium ${
+                      reasonColors[report.reason] || 'bg-gray-50 text-gray-700'
+                    }`}
+                  >
+                    {reasonLabels[report.reason] || report.reason}
+                  </span>
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs font-medium ${
+                      statusColors[report.status] ||
+                      'bg-gray-50 text-gray-700'
+                    }`}
+                  >
+                    {report.status}
+                  </span>
+                </div>
+                <span className="text-xs text-gray-500">
+                  {formatDate(report.created_at)}
+                </span>
+              </div>
+
+              {/* Content info: target link, reporter, author */}
+              <div className="mt-1.5 flex flex-wrap items-center gap-x-2 text-gray-600">
+                <span className="font-medium capitalize">
+                  {report.target_type}
+                </span>
+                <Link
+                  href={`/app/discussions/${report.target_type === 'discussion' ? report.target_id : ''}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  #{report.target_id}
+                </Link>
+                {report.target_author_username && (
+                  <>
+                    <span className="text-gray-300">|</span>
+                    <span className="text-xs">
+                      Author:{' '}
+                      <span className="font-medium">
+                        {report.target_author_username}
+                      </span>
+                    </span>
+                  </>
+                )}
+                <span className="text-gray-300">|</span>
+                <span className="text-xs">
+                  Reporter:{' '}
+                  <span className="font-medium">
+                    {report.reporter_username || `#${report.reporter_id}`}
+                  </span>
+                </span>
+              </div>
+
+              {report.details && (
+                <div className="mt-1 text-xs text-gray-400">
+                  {report.details}
+                </div>
+              )}
+
+              {/* Actions for pending reports */}
+              {report.status === 'pending' && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {/* Status actions */}
+                  <button
+                    onClick={() =>
+                      updateMutation.mutate({
+                        reportId: report.id,
+                        status: 'reviewed',
+                      })
+                    }
+                    disabled={updateMutation.isPending}
+                    className="rounded bg-green-50 px-2 py-1 text-xs font-medium text-green-700 hover:bg-green-100 disabled:opacity-50"
+                  >
+                    Mark Reviewed
+                  </button>
+                  <button
+                    onClick={() =>
+                      updateMutation.mutate({
+                        reportId: report.id,
+                        status: 'dismissed',
+                      })
+                    }
+                    disabled={updateMutation.isPending}
+                    className="rounded bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+                  >
+                    Dismiss
+                  </button>
+
+                  <span className="mx-1 border-l border-gray-200" />
+
+                  {/* Moderation actions */}
+                  <button
+                    onClick={() =>
+                      warnMutation.mutate({ reportId: report.id })
+                    }
+                    disabled={warnMutation.isPending}
+                    className="flex items-center gap-1 rounded bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+                  >
+                    <AlertTriangle className="size-3" />
+                    Warn Author
+                  </button>
+
+                  {report.target_type === 'discussion' && (
+                    <button
+                      onClick={() =>
+                        lockMutation.mutate({ reportId: report.id })
+                      }
+                      disabled={lockMutation.isPending}
+                      className="flex items-center gap-1 rounded bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-50"
+                    >
+                      <Lock className="size-3" />
+                      Lock
+                    </button>
+                  )}
+
+                  <ConfirmationDialog
+                    icon="danger"
+                    title="Delete Reported Content"
+                    body={`Permanently delete this ${report.target_type}? This action cannot be undone.`}
+                    triggerButton={
+                      <button className="flex items-center gap-1 rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100">
+                        <Trash2 className="size-3" />
+                        Delete Content
+                      </button>
+                    }
+                    confirmButton={
+                      <Button
+                        isLoading={deleteMutation.isPending}
+                        type="button"
+                        variant="destructive"
+                        onClick={() =>
+                          deleteMutation.mutate({ reportId: report.id })
+                        }
+                      >
+                        Delete
+                      </Button>
+                    }
+                  />
+
+                  <ConfirmationDialog
+                    icon="danger"
+                    title="Ban Author from Discussions"
+                    body={`Ban ${report.target_author_username || 'this user'} from creating discussions and replies?`}
+                    triggerButton={
+                      <button className="flex items-center gap-1 rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100">
+                        <Ban className="size-3" />
+                        Ban Author
+                      </button>
+                    }
+                    confirmButton={
+                      <Button
+                        isLoading={banMutation.isPending}
+                        type="button"
+                        variant="destructive"
+                        onClick={() =>
+                          banMutation.mutate({ reportId: report.id })
+                        }
+                      >
+                        Ban User
+                      </Button>
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/admin/components/reports-list.tsx
+++ b/apps/nextjs-app/src/features/admin/components/reports-list.tsx
@@ -185,7 +185,7 @@ export const ReportsList = () => {
                   {report.target_type}
                 </span>
                 <Link
-                  href={`/app/discussions/${report.target_type === 'discussion' ? report.target_id : ''}`}
+                  href={`/app/discussions/${report.target_type === 'discussion' ? report.target_id : report.discussion_id || ''}`}
                   className="text-blue-600 hover:underline"
                 >
                   #{report.target_id}

--- a/apps/nextjs-app/src/features/discussions/api/accept-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/accept-reply.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { Reply } from '@/types/api';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const acceptReply = ({
+  replyId,
+}: {
+  replyId: string;
+}): Promise<Reply> => {
+  return api.post(`/replies/${replyId}/accept`);
+};
+
+type UseAcceptReplyOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof acceptReply>;
+};
+
+export const useAcceptReply = ({
+  discussionId,
+  mutationConfig,
+}: UseAcceptReplyOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: acceptReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/bookmark-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/bookmark-discussion.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const bookmarkDiscussion = ({
+  discussionId,
+}: {
+  discussionId: string;
+}): Promise<{
+  discussion_id: number;
+  is_bookmarked: boolean;
+}> => {
+  return api.post(`/discussions/${discussionId}/bookmark`);
+};
+
+type UseBookmarkDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof bookmarkDiscussion>;
+};
+
+export const useBookmarkDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UseBookmarkDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: bookmarkDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/create-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/create-discussion.ts
@@ -8,9 +8,10 @@ import { Discussion } from '@/types/api';
 import { getDiscussionsQueryOptions } from './get-discussions';
 
 export const createDiscussionInputSchema = z.object({
-  title: z.string().min(1, 'Required'),
-  body: z.string().min(1, 'Required'),
-  public: z.boolean(),
+  title: z.string().min(1, 'Title is required'),
+  body: z.string().min(1, 'Body is required'),
+  category: z.string().default('general'),
+  puzzle_id: z.number().nullable().optional(),
 });
 
 export type CreateDiscussionInput = z.infer<typeof createDiscussionInputSchema>;

--- a/apps/nextjs-app/src/features/discussions/api/create-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/create-reply.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { Reply } from '@/types/api';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const createReplyInputSchema = z.object({
+  body: z.string().min(1, 'Reply body is required'),
+  parent_reply_id: z.number().nullable().optional(),
+});
+
+export type CreateReplyInput = z.infer<typeof createReplyInputSchema>;
+
+export const createReply = ({
+  data,
+  discussionId,
+}: {
+  data: CreateReplyInput;
+  discussionId: string;
+}): Promise<Reply> => {
+  return api.post(`/discussions/${discussionId}/replies`, data);
+};
+
+type UseCreateReplyOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof createReply>;
+};
+
+export const useCreateReply = ({
+  discussionId,
+  mutationConfig,
+}: UseCreateReplyOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: createReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/delete-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/delete-reply.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const deleteReply = ({ replyId }: { replyId: string }) => {
+  return api.delete(`/replies/${replyId}`);
+};
+
+type UseDeleteReplyOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof deleteReply>;
+};
+
+export const useDeleteReply = ({
+  discussionId,
+  mutationConfig,
+}: UseDeleteReplyOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: deleteReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/follow-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/follow-discussion.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const followDiscussion = ({
+  discussionId,
+}: {
+  discussionId: string;
+}): Promise<{
+  discussion_id: number;
+  is_following: boolean;
+}> => {
+  return api.post(`/discussions/${discussionId}/follow`);
+};
+
+type UseFollowDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof followDiscussion>;
+};
+
+export const useFollowDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UseFollowDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: followDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/get-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/get-discussion.ts
@@ -2,13 +2,17 @@ import { useQuery, queryOptions } from '@tanstack/react-query';
 
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
-import { Discussion } from '@/types/api';
+import { Discussion, Reply } from '@/types/api';
+
+type DiscussionWithReplies = Discussion & {
+  replies: (Reply & { children?: Reply[] })[];
+};
 
 export const getDiscussion = ({
   discussionId,
 }: {
   discussionId: string;
-}): Promise<{ data: Discussion }> => {
+}): Promise<DiscussionWithReplies> => {
   return api.get(`/discussions/${discussionId}`);
 };
 

--- a/apps/nextjs-app/src/features/discussions/api/get-discussions.ts
+++ b/apps/nextjs-app/src/features/discussions/api/get-discussions.ts
@@ -2,41 +2,57 @@ import { queryOptions, useQuery } from '@tanstack/react-query';
 
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
-import { Discussion, Meta } from '@/types/api';
+import { Discussion, ThreadCategory } from '@/types/api';
+
+export type DiscussionFilters = {
+  limit?: number;
+  offset?: number;
+  category?: ThreadCategory;
+  puzzle_id?: number;
+  author_id?: number;
+  sort?: 'newest' | 'oldest' | 'most_replies' | 'most_upvotes' | 'trending';
+  search?: string;
+};
 
 export const getDiscussions = (
-  { page }: { page?: number } = { page: 1 },
+  filters: DiscussionFilters = {},
 ): Promise<{
-  data: Discussion[];
-  meta: Meta;
+  discussions: Discussion[];
+  total: number;
+  limit: number;
+  offset: number;
 }> => {
   return api.get(`/discussions`, {
     params: {
-      page,
+      limit: filters.limit ?? 20,
+      offset: filters.offset ?? 0,
+      category: filters.category,
+      puzzle_id: filters.puzzle_id,
+      author_id: filters.author_id,
+      sort: filters.sort ?? 'newest',
+      search: filters.search || undefined,
     },
   });
 };
 
-export const getDiscussionsQueryOptions = ({
-  page = 1,
-}: { page?: number } = {}) => {
+export const getDiscussionsQueryOptions = (filters: DiscussionFilters = {}) => {
   return queryOptions({
-    queryKey: ['discussions', { page }],
-    queryFn: () => getDiscussions({ page }),
+    queryKey: ['discussions', filters],
+    queryFn: () => getDiscussions(filters),
   });
 };
 
 type UseDiscussionsOptions = {
-  page?: number;
+  filters?: DiscussionFilters;
   queryConfig?: QueryConfig<typeof getDiscussionsQueryOptions>;
 };
 
 export const useDiscussions = ({
+  filters = {},
   queryConfig,
-  page,
-}: UseDiscussionsOptions) => {
+}: UseDiscussionsOptions = {}) => {
   return useQuery({
-    ...getDiscussionsQueryOptions({ page }),
+    ...getDiscussionsQueryOptions(filters),
     ...queryConfig,
   });
 };

--- a/apps/nextjs-app/src/features/discussions/api/lock-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/lock-discussion.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const lockDiscussion = ({
+  discussionId,
+}: {
+  discussionId: string;
+}): Promise<{
+  id: number;
+  is_locked: boolean;
+}> => {
+  return api.post(`/discussions/${discussionId}/lock`);
+};
+
+type UseLockDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof lockDiscussion>;
+};
+
+export const useLockDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UseLockDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: lockDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/pin-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/pin-discussion.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const pinDiscussion = ({
+  discussionId,
+}: {
+  discussionId: string;
+}): Promise<{
+  id: number;
+  is_pinned: boolean;
+}> => {
+  return api.post(`/discussions/${discussionId}/pin`);
+};
+
+type UsePinDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof pinDiscussion>;
+};
+
+export const usePinDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UsePinDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: pinDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/react-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/react-discussion.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { ReactionCount, ReactionType } from '@/types/api';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const reactToDiscussion = ({
+  discussionId,
+  reactionType,
+}: {
+  discussionId: string;
+  reactionType: string;
+}): Promise<{
+  discussion_id: number;
+  is_active: boolean;
+  reactions: ReactionCount[];
+  user_reactions: ReactionType[];
+}> => {
+  return api.post(`/discussions/${discussionId}/react`, {
+    reaction_type: reactionType,
+  });
+};
+
+type UseReactToDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof reactToDiscussion>;
+};
+
+export const useReactToDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UseReactToDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: reactToDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/react-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/react-reply.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+import { ReactionCount, ReactionType } from '@/types/api';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const reactToReply = ({
+  replyId,
+  reactionType,
+}: {
+  replyId: string;
+  reactionType: string;
+}): Promise<{
+  reply_id: number;
+  is_active: boolean;
+  reactions: ReactionCount[];
+  user_reactions: ReactionType[];
+}> => {
+  return api.post(`/replies/${replyId}/react`, {
+    reaction_type: reactionType,
+  });
+};
+
+type UseReactToReplyOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof reactToReply>;
+};
+
+export const useReactToReply = ({
+  discussionId,
+  mutationConfig,
+}: UseReactToReplyOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: reactToReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/report-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/report-discussion.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const reportDiscussion = ({
+  discussionId,
+  reason,
+  details,
+}: {
+  discussionId: string;
+  reason: string;
+  details?: string;
+}): Promise<{
+  id: number;
+  reporter_id: number;
+  target_type: string;
+  target_id: number;
+  reason: string;
+  details: string;
+  status: string;
+  created_at: string;
+}> => {
+  return api.post(`/discussions/${discussionId}/report`, {
+    reason,
+    details: details || '',
+  });
+};
+
+type UseReportDiscussionOptions = {
+  mutationConfig?: MutationConfig<typeof reportDiscussion>;
+};
+
+export const useReportDiscussion = ({
+  mutationConfig,
+}: UseReportDiscussionOptions = {}) => {
+  return useMutation({
+    ...mutationConfig,
+    mutationFn: reportDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/report-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/report-reply.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const reportReply = ({
+  replyId,
+  reason,
+  details,
+}: {
+  replyId: string;
+  reason: string;
+  details?: string;
+}): Promise<{
+  id: number;
+  reporter_id: number;
+  target_type: string;
+  target_id: number;
+  reason: string;
+  details: string;
+  status: string;
+  created_at: string;
+}> => {
+  return api.post(`/replies/${replyId}/report`, {
+    reason,
+    details: details || '',
+  });
+};
+
+type UseReportReplyOptions = {
+  mutationConfig?: MutationConfig<typeof reportReply>;
+};
+
+export const useReportReply = ({
+  mutationConfig,
+}: UseReportReplyOptions = {}) => {
+  return useMutation({
+    ...mutationConfig,
+    mutationFn: reportReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/update-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/update-discussion.ts
@@ -8,9 +8,9 @@ import { Discussion } from '@/types/api';
 import { getDiscussionQueryOptions } from './get-discussion';
 
 export const updateDiscussionInputSchema = z.object({
-  title: z.string().min(1, 'Required'),
-  body: z.string().min(1, 'Required'),
-  public: z.boolean(),
+  title: z.string().min(1, 'Title is required').optional(),
+  body: z.string().min(1, 'Body is required').optional(),
+  category: z.string().optional(),
 });
 
 export type UpdateDiscussionInput = z.infer<typeof updateDiscussionInputSchema>;

--- a/apps/nextjs-app/src/features/discussions/api/vote-discussion.ts
+++ b/apps/nextjs-app/src/features/discussions/api/vote-discussion.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const voteDiscussion = ({
+  discussionId,
+  value,
+}: {
+  discussionId: string;
+  value: number;
+}): Promise<{
+  discussion_id: number;
+  user_vote: number | null;
+  upvotes: number;
+  downvotes: number;
+}> => {
+  return api.post(`/discussions/${discussionId}/vote`, { value });
+};
+
+type UseVoteDiscussionOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof voteDiscussion>;
+};
+
+export const useVoteDiscussion = ({
+  discussionId,
+  mutationConfig,
+}: UseVoteDiscussionOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: voteDiscussion,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/api/vote-reply.ts
+++ b/apps/nextjs-app/src/features/discussions/api/vote-reply.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getDiscussionQueryOptions } from './get-discussion';
+
+export const voteReply = ({
+  replyId,
+  value,
+}: {
+  replyId: string;
+  value: number;
+}): Promise<{
+  reply_id: number;
+  user_vote: number | null;
+  upvotes: number;
+  downvotes: number;
+}> => {
+  return api.post(`/replies/${replyId}/vote`, { value });
+};
+
+type UseVoteReplyOptions = {
+  discussionId: string;
+  mutationConfig?: MutationConfig<typeof voteReply>;
+};
+
+export const useVoteReply = ({
+  discussionId,
+  mutationConfig,
+}: UseVoteReplyOptions) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getDiscussionQueryOptions(discussionId).queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: voteReply,
+  });
+};

--- a/apps/nextjs-app/src/features/discussions/components/category-badge.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/category-badge.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+import { ThreadCategory } from '@/types/api';
+
+const categoryConfig: Record<
+  ThreadCategory,
+  { label: string; color: string }
+> = {
+  general: { label: 'General', color: 'bg-gray-100 text-gray-700' },
+  puzzle_help: { label: 'Puzzle Help', color: 'bg-blue-100 text-blue-700' },
+  puzzle_tips: { label: 'Tips & Tricks', color: 'bg-green-100 text-green-700' },
+  solutions: { label: 'Solutions', color: 'bg-purple-100 text-purple-700' },
+  bug_report: { label: 'Bug Report', color: 'bg-red-100 text-red-700' },
+  feature_request: { label: 'Feature Request', color: 'bg-yellow-100 text-yellow-700' },
+  showcase: { label: 'Showcase', color: 'bg-indigo-100 text-indigo-700' },
+};
+
+export const CategoryBadge = ({
+  category,
+  className,
+}: {
+  category: ThreadCategory;
+  className?: string;
+}) => {
+  const config = categoryConfig[category] || categoryConfig.general;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+        config.color,
+        className,
+      )}
+    >
+      {config.label}
+    </span>
+  );
+};
+
+export const CATEGORY_OPTIONS: { label: string; value: ThreadCategory }[] = [
+  { label: 'All Categories', value: '' as ThreadCategory },
+  { label: 'General', value: 'general' },
+  { label: 'Puzzle Help', value: 'puzzle_help' },
+  { label: 'Tips & Tricks', value: 'puzzle_tips' },
+  { label: 'Solutions', value: 'solutions' },
+  { label: 'Bug Report', value: 'bug_report' },
+  { label: 'Feature Request', value: 'feature_request' },
+  { label: 'Showcase', value: 'showcase' },
+];

--- a/apps/nextjs-app/src/features/discussions/components/create-discussion.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/create-discussion.tsx
@@ -1,34 +1,45 @@
 'use client';
 
-import { Plus } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
+import NextLink from 'next/link';
 
 import { Button } from '@/components/ui/button';
-import {
-  Form,
-  FormDrawer,
-  Input,
-  Label,
-  Switch,
-  Textarea,
-} from '@/components/ui/form';
+import { Form, Input, Select, Textarea } from '@/components/ui/form';
 import { useNotifications } from '@/components/ui/notifications';
+import { paths } from '@/config/paths';
 import { useUser } from '@/lib/auth';
 import { canCreateDiscussion } from '@/lib/authorization';
+import { Discussion } from '@/types/api';
 
 import {
   createDiscussionInputSchema,
   useCreateDiscussion,
 } from '../api/create-discussion';
 
-export const CreateDiscussion = () => {
+const categoryOptions = [
+  { label: 'General', value: 'general' },
+  { label: 'Puzzle Help', value: 'puzzle_help' },
+  { label: 'Tips & Tricks', value: 'puzzle_tips' },
+  { label: 'Solutions', value: 'solutions' },
+  { label: 'Bug Report', value: 'bug_report' },
+  { label: 'Feature Request', value: 'feature_request' },
+  { label: 'Showcase', value: 'showcase' },
+];
+
+type CreateDiscussionProps = {
+  onSuccess?: (discussion: Discussion) => void;
+};
+
+export const CreateDiscussion = ({ onSuccess }: CreateDiscussionProps) => {
   const { addNotification } = useNotifications();
   const createDiscussionMutation = useCreateDiscussion({
     mutationConfig: {
-      onSuccess: () => {
+      onSuccess: (data) => {
         addNotification({
           type: 'success',
           title: 'Discussion Created',
         });
+        onSuccess?.(data);
       },
     },
   });
@@ -40,66 +51,72 @@ export const CreateDiscussion = () => {
   }
 
   return (
-    <FormDrawer
-      isDone={createDiscussionMutation.isSuccess}
-      triggerButton={
-        <Button size="sm" icon={<Plus className="size-4" />}>
-          Create Discussion
-        </Button>
-      }
-      title="Create Discussion"
-      submitButton={
-        <Button
-          form="create-discussion"
-          type="submit"
-          size="sm"
-          isLoading={createDiscussionMutation.isPending}
-        >
-          Submit
-        </Button>
-      }
-    >
-      <Form
-        id="create-discussion"
-        onSubmit={(values) => {
-          createDiscussionMutation.mutate({ data: values });
-        }}
-        schema={createDiscussionInputSchema}
-        options={{
-          defaultValues: {
-            title: '',
-            body: '',
-            public: false,
-          },
-        }}
+    <div className="space-y-4">
+      <NextLink
+        href={paths.app.discussions.getHref()}
+        className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
       >
-        {({ register, formState, setValue, watch }) => (
-          <>
-            <Input
-              label="Title"
-              error={formState.errors['title']}
-              registration={register('title')}
-            />
+        <ArrowLeft className="size-4" />
+        Back to Discussions
+      </NextLink>
 
-            <Textarea
-              label="Body"
-              error={formState.errors['body']}
-              registration={register('body')}
-            />
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <h1 className="mb-6 text-xl font-bold text-gray-900">New Discussion</h1>
 
-            <div className="flex items-center space-x-2">
-              <Switch
-                name="public"
-                onCheckedChange={(value) => setValue('public', value)}
-                checked={watch('public')}
-                className={` relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2`}
-                id="public"
+        <Form
+          id="create-discussion"
+          onSubmit={(values) => {
+            createDiscussionMutation.mutate({ data: values });
+          }}
+          schema={createDiscussionInputSchema}
+          options={{
+            defaultValues: {
+              title: '',
+              body: '',
+              category: 'general',
+              puzzle_id: null,
+            },
+          }}
+        >
+          {({ register, formState }) => (
+            <div className="space-y-4">
+              <Input
+                label="Title"
+                error={formState.errors['title']}
+                registration={register('title')}
               />
-              <Label htmlFor="airplane-mode">Public</Label>
+
+              <Select
+                label="Category"
+                error={formState.errors['category']}
+                registration={register('category')}
+                options={categoryOptions}
+                defaultValue="general"
+              />
+
+              <Textarea
+                label="Body"
+                error={formState.errors['body']}
+                registration={register('body')}
+              />
+
+              <div className="flex justify-end gap-2 pt-2">
+                <NextLink href={paths.app.discussions.getHref()}>
+                  <Button variant="outline" type="button">
+                    Cancel
+                  </Button>
+                </NextLink>
+                <Button
+                  type="submit"
+                  isLoading={createDiscussionMutation.isPending}
+                >
+                  Create Discussion
+                </Button>
+              </div>
             </div>
-          </>
-        )}
-      </Form>
-    </FormDrawer>
+          )}
+        </Form>
+      </div>
+    </div>
   );
 };

--- a/apps/nextjs-app/src/features/discussions/components/discussion-card.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/discussion-card.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { MessageSquare, Eye, Pin, Lock, CheckCircle } from 'lucide-react';
+import NextLink from 'next/link';
+
+import { paths } from '@/config/paths';
+import { Discussion } from '@/types/api';
+import { cn } from '@/utils/cn';
+
+import { CategoryBadge } from './category-badge';
+import { UserBadge } from './user-badge';
+
+function timeAgo(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+export const DiscussionCard = ({ discussion }: { discussion: Discussion }) => {
+  const hasAcceptedSolution = discussion.accepted_reply_id != null;
+
+  return (
+    <NextLink
+      href={paths.app.discussion.getHref(discussion.id)}
+      className={cn(
+        'block rounded-lg border border-gray-200 bg-white p-4 transition-all hover:border-blue-300 hover:shadow-sm',
+        discussion.is_pinned && 'border-l-4 border-l-blue-500',
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            {discussion.is_pinned && (
+              <Pin className="size-3.5 text-blue-500" />
+            )}
+            {discussion.is_locked && (
+              <Lock className="size-3.5 text-gray-400" />
+            )}
+            <h3 className="truncate text-sm font-semibold text-gray-900">
+              {discussion.title}
+            </h3>
+          </div>
+
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <CategoryBadge category={discussion.category} />
+            {hasAcceptedSolution && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                <CheckCircle className="size-3" />
+                Solved
+              </span>
+            )}
+          </div>
+
+          <p className="line-clamp-1 text-xs text-gray-500">
+            {discussion.body.slice(0, 120)}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-4 text-xs text-gray-400">
+        <span className="font-medium text-gray-600">
+          {discussion.author?.username || 'Unknown'}
+        </span>
+        <UserBadge user={discussion.author} />
+        <span className="flex items-center gap-1">
+          <MessageSquare className="size-3" />
+          {discussion.reply_count}
+        </span>
+        <span className="flex items-center gap-1">
+          <Eye className="size-3" />
+          {discussion.view_count}
+        </span>
+        <span className="ml-auto">{timeAgo(discussion.createdAt)}</span>
+      </div>
+    </NextLink>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/discussion-view.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/discussion-view.tsx
@@ -20,6 +20,8 @@ import { useBookmarkDiscussion } from '../api/bookmark-discussion';
 import { useDeleteDiscussion } from '../api/delete-discussion';
 import { useFollowDiscussion } from '../api/follow-discussion';
 import { useDiscussion } from '../api/get-discussion';
+import { useLockDiscussion } from '../api/lock-discussion';
+import { usePinDiscussion } from '../api/pin-discussion';
 import { useReactToDiscussion } from '../api/react-discussion';
 import { useReportDiscussion } from '../api/report-discussion';
 import { useVoteDiscussion } from '../api/vote-discussion';
@@ -63,10 +65,36 @@ export const DiscussionView = ({ discussionId }: { discussionId: string }) => {
 
   const reportMutation = useReportDiscussion();
 
+  const pinMutation = usePinDiscussion({
+    discussionId,
+  });
+
+  const lockMutation = useLockDiscussion({
+    discussionId,
+  });
+
   if (discussionQuery.isLoading) {
     return (
       <div className="flex h-48 w-full items-center justify-center">
         <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (discussionQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+        <p className="text-sm text-red-700">
+          Failed to load discussion. It may have been deleted or you may not
+          have permission to view it.
+        </p>
+        <NextLink
+          href={paths.app.discussions.getHref()}
+          className="mt-2 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          Back to Discussions
+        </NextLink>
       </div>
     );
   }
@@ -205,13 +233,23 @@ export const DiscussionView = ({ discussionId }: { discussionId: string }) => {
           <div className="flex-1" />
 
           {canPinDiscussion(user.data) && (
-            <Button variant="outline" size="sm">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => pinMutation.mutate({ discussionId })}
+              isLoading={pinMutation.isPending}
+            >
               <Pin className="mr-1 size-3" />
               {discussion.is_pinned ? 'Unpin' : 'Pin'}
             </Button>
           )}
           {canLockDiscussion(user.data) && (
-            <Button variant="outline" size="sm">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => lockMutation.mutate({ discussionId })}
+              isLoading={lockMutation.isPending}
+            >
               <Lock className="mr-1 size-3" />
               {discussion.is_locked ? 'Unlock' : 'Lock'}
             </Button>

--- a/apps/nextjs-app/src/features/discussions/components/discussion-view.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/discussion-view.tsx
@@ -1,24 +1,67 @@
 'use client';
 
-import { Link as LinkIcon } from 'lucide-react';
-import { usePathname } from 'next/navigation';
+import { Pin, Lock, ArrowLeft, Bell, BellOff, Bookmark } from 'lucide-react';
+import NextLink from 'next/link';
 
-import { Link } from '@/components/ui/link';
+import { Button } from '@/components/ui/button';
 import { MDPreview } from '@/components/ui/md-preview';
 import { Spinner } from '@/components/ui/spinner';
+import { useNotifications } from '@/components/ui/notifications';
 import { paths } from '@/config/paths';
-import { formatDate } from '@/utils/format';
+import { useUser } from '@/lib/auth';
+import {
+  canPinDiscussion,
+  canLockDiscussion,
+  canDeleteDiscussion,
+} from '@/lib/authorization';
+import { cn } from '@/utils/cn';
 
+import { useBookmarkDiscussion } from '../api/bookmark-discussion';
+import { useDeleteDiscussion } from '../api/delete-discussion';
+import { useFollowDiscussion } from '../api/follow-discussion';
 import { useDiscussion } from '../api/get-discussion';
-import { UpdateDiscussion } from '../components/update-discussion';
+import { useReactToDiscussion } from '../api/react-discussion';
+import { useReportDiscussion } from '../api/report-discussion';
+import { useVoteDiscussion } from '../api/vote-discussion';
+import { CategoryBadge } from './category-badge';
+import { ReactionPicker } from './reaction-picker';
+import { ReplyComposer } from './reply-composer';
+import { ReplyTree } from './reply-tree';
+import { ReportDialog } from './report-dialog';
+import { UserBadge } from './user-badge';
+import { VoteButtons } from './vote-buttons';
 
 export const DiscussionView = ({ discussionId }: { discussionId: string }) => {
-  const pathname = usePathname();
-  const isPublicView = pathname?.startsWith?.('/public/');
+  const discussionQuery = useDiscussion({ discussionId });
+  const user = useUser();
+  const { addNotification } = useNotifications();
 
-  const discussionQuery = useDiscussion({
+  const deleteMutation = useDeleteDiscussion({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({ type: 'success', title: 'Discussion deleted' });
+        window.location.href = paths.app.discussions.getHref();
+      },
+    },
+  });
+
+  const voteMutation = useVoteDiscussion({
     discussionId,
   });
+
+  const reactMutation = useReactToDiscussion({
+    discussionId,
+  });
+
+  const followMutation = useFollowDiscussion({
+    discussionId,
+  });
+
+  const bookmarkMutation = useBookmarkDiscussion({
+    discussionId,
+  });
+
+  const reportMutation = useReportDiscussion();
 
   if (discussionQuery.isLoading) {
     return (
@@ -28,49 +71,190 @@ export const DiscussionView = ({ discussionId }: { discussionId: string }) => {
     );
   }
 
-  const discussion = discussionQuery?.data?.data;
-
+  const discussion = discussionQuery.data;
   if (!discussion) return null;
 
+  const engagement = discussion.engagement;
+  const isFollowing = engagement?.is_following ?? false;
+  const isBookmarked = engagement?.is_bookmarked ?? false;
+
   return (
-    <div>
-      <div className="flex justify-between">
-        <span>
-          <span className="text-xs font-bold">
-            {formatDate(discussion.createdAt)}
-          </span>
-          {discussion.author && (
-            <span className="ml-2 text-sm font-bold">
-              by {discussion.author.username}
-            </span>
-          )}
-        </span>
-        {!isPublicView && discussion.public && (
-          <Link
-            className="ml-2 flex items-center gap-2 text-sm font-bold"
-            href={paths.public.discussion.getHref(discussionId)}
-            target="_blank"
-          >
-            View Public Version <LinkIcon size={16} />
-          </Link>
-        )}
-      </div>
-      <div className="mt-6 flex flex-col space-y-16">
-        {!isPublicView && (
-          <div className="flex justify-end">
-            <UpdateDiscussion discussionId={discussionId} />
-          </div>
-        )}
-        <div>
-          <div className="overflow-hidden bg-white shadow sm:rounded-lg">
-            <div className="px-4 py-5 sm:px-6">
-              <div className="mt-1 max-w-2xl text-sm text-gray-500">
-                <MDPreview value={discussion.body} />
-              </div>
+    <div className="mx-auto max-w-3xl space-y-6">
+      <NextLink
+        href={paths.app.discussions.getHref()}
+        className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+      >
+        <ArrowLeft className="size-4" />
+        Back to Discussions
+      </NextLink>
+
+      {/* Thread header */}
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          {discussion.is_pinned && <Pin className="size-4 text-blue-500" />}
+          {discussion.is_locked && <Lock className="size-4 text-gray-400" />}
+          <CategoryBadge category={discussion.category} />
+        </div>
+
+        <div className="flex gap-4">
+          {/* Vote buttons */}
+          {engagement && (
+            <div className="flex flex-col items-center pt-1">
+              <VoteButtons
+                upvotes={engagement.upvotes}
+                downvotes={engagement.downvotes}
+                userVote={engagement.user_vote}
+                onVote={(value) =>
+                  voteMutation.mutate({ discussionId, value })
+                }
+                isLoading={voteMutation.isPending}
+                size="md"
+              />
             </div>
+          )}
+
+          <div className="flex-1">
+            <h1 className="mb-2 text-xl font-bold text-gray-900">
+              {discussion.title}
+            </h1>
+
+            <div className="mb-4 flex items-center gap-2 text-sm text-gray-500">
+              <span className="font-medium text-gray-700">
+                {discussion.author?.username || 'Unknown'}
+              </span>
+              <UserBadge user={discussion.author} />
+              <span>
+                {new Date(discussion.createdAt).toLocaleDateString(undefined, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </span>
+              <span>{discussion.view_count} views</span>
+              <span>{discussion.reply_count} replies</span>
+            </div>
+
+            <div className="prose prose-sm max-w-none text-gray-700">
+              <MDPreview value={discussion.body} />
+            </div>
+
+            {/* Reactions */}
+            {engagement && (
+              <div className="mt-3">
+                <ReactionPicker
+                  reactions={engagement.reactions}
+                  userReactions={engagement.user_reactions}
+                  onReact={(type) =>
+                    reactMutation.mutate({
+                      discussionId,
+                      reactionType: type,
+                    })
+                  }
+                  isLoading={reactMutation.isPending}
+                />
+              </div>
+            )}
           </div>
         </div>
+
+        {/* Action bar: follow, bookmark, admin actions */}
+        <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(isFollowing && 'border-blue-300 bg-blue-50')}
+            onClick={() => followMutation.mutate({ discussionId })}
+            isLoading={followMutation.isPending}
+          >
+            {isFollowing ? (
+              <BellOff className="mr-1 size-3" />
+            ) : (
+              <Bell className="mr-1 size-3" />
+            )}
+            {isFollowing ? 'Unfollow' : 'Follow'}
+          </Button>
+
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn(isBookmarked && 'border-yellow-300 bg-yellow-50')}
+            onClick={() => bookmarkMutation.mutate({ discussionId })}
+            isLoading={bookmarkMutation.isPending}
+          >
+            <Bookmark
+              className={cn(
+                'mr-1 size-3',
+                isBookmarked && 'fill-yellow-500 text-yellow-500',
+              )}
+            />
+            {isBookmarked ? 'Bookmarked' : 'Bookmark'}
+          </Button>
+
+          <ReportDialog
+            targetLabel="discussion"
+            onSubmit={({ reason, details }) =>
+              reportMutation.mutate({
+                discussionId,
+                reason,
+                details,
+              })
+            }
+            isLoading={reportMutation.isPending}
+          />
+
+          <div className="flex-1" />
+
+          {canPinDiscussion(user.data) && (
+            <Button variant="outline" size="sm">
+              <Pin className="mr-1 size-3" />
+              {discussion.is_pinned ? 'Unpin' : 'Pin'}
+            </Button>
+          )}
+          {canLockDiscussion(user.data) && (
+            <Button variant="outline" size="sm">
+              <Lock className="mr-1 size-3" />
+              {discussion.is_locked ? 'Unlock' : 'Lock'}
+            </Button>
+          )}
+          {canDeleteDiscussion(user.data, discussion) && (
+            <Button
+              variant="destructive"
+              size="sm"
+              isLoading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate({ discussionId })}
+            >
+              Delete
+            </Button>
+          )}
+        </div>
       </div>
+
+      {/* Replies */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Replies ({discussion.reply_count})
+        </h2>
+        <ReplyTree
+          replies={discussion.replies || []}
+          discussionId={discussionId}
+          discussionAuthorId={discussion.author_id}
+        />
+      </div>
+
+      {/* Reply composer */}
+      {!discussion.is_locked ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-medium text-gray-700">
+            Post a Reply
+          </h3>
+          <ReplyComposer discussionId={discussionId} />
+        </div>
+      ) : (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center text-sm text-gray-500">
+          <Lock className="mx-auto mb-2 size-5" />
+          This discussion is locked. No new replies can be posted.
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/nextjs-app/src/features/discussions/components/discussions-list.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/discussions-list.tsx
@@ -1,95 +1,144 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { Search } from 'lucide-react';
 
-import { Link } from '@/components/ui/link';
 import { Spinner } from '@/components/ui/spinner';
-import { Table } from '@/components/ui/table';
-import { paths } from '@/config/paths';
-import { formatDate } from '@/utils/format';
+import { ThreadCategory } from '@/types/api';
+import { cn } from '@/utils/cn';
 
-import { getDiscussionQueryOptions } from '../api/get-discussion';
-import { useDiscussions } from '../api/get-discussions';
+import { useDiscussions, DiscussionFilters } from '../api/get-discussions';
+import { CATEGORY_OPTIONS } from './category-badge';
+import { DiscussionCard } from './discussion-card';
 
-import { DeleteDiscussion } from './delete-discussion';
-
-export type DiscussionsListProps = {
-  onDiscussionPrefetch?: (id: string) => void;
-};
-
-export const DiscussionsList = ({
-  onDiscussionPrefetch,
-}: DiscussionsListProps) => {
-  const searchParams = useSearchParams();
-  const page = searchParams?.get('page') ? Number(searchParams.get('page')) : 1;
-
-  const discussionsQuery = useDiscussions({
-    page: page,
+export const DiscussionsList = () => {
+  const [filters, setFilters] = useState<DiscussionFilters>({
+    limit: 20,
+    offset: 0,
+    sort: 'newest',
   });
-  const queryClient = useQueryClient();
+  const [searchInput, setSearchInput] = useState('');
 
-  if (discussionsQuery.isLoading) {
-    return (
-      <div className="flex h-48 w-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters((prev) => ({
+        ...prev,
+        search: searchInput || undefined,
+        offset: 0,
+      }));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
-  const discussions = discussionsQuery.data?.data;
-  const meta = discussionsQuery.data?.meta;
+  const discussionsQuery = useDiscussions({ filters });
 
-  if (!discussions) return null;
+  const discussions = discussionsQuery.data?.discussions;
+  const total = discussionsQuery.data?.total ?? 0;
+  const limit = filters.limit ?? 20;
+  const offset = filters.offset ?? 0;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const totalPages = Math.ceil(total / limit);
 
   return (
-    <Table
-      data={discussions}
-      columns={[
-        {
-          title: 'Title',
-          field: 'title',
-        },
-        {
-          title: 'Created At',
-          field: 'createdAt',
-          Cell({ entry: { createdAt } }) {
-            return <span>{formatDate(createdAt)}</span>;
-          },
-        },
-        {
-          title: '',
-          field: 'id',
-          Cell({ entry: { id } }) {
-            return (
-              <Link
-                onMouseEnter={() => {
-                  // Prefetch the discussion data when the user hovers over the link
-                  queryClient.prefetchQuery(getDiscussionQueryOptions(id));
-                  onDiscussionPrefetch?.(id);
-                }}
-                href={paths.app.discussion.getHref(id)}
-              >
-                View
-              </Link>
-            );
-          },
-        },
-        {
-          title: '',
-          field: 'id',
-          Cell({ entry: { id } }) {
-            return <DeleteDiscussion id={id} />;
-          },
-        },
-      ]}
-      pagination={
-        meta && {
-          totalPages: meta.totalPages,
-          currentPage: meta.page,
-          rootUrl: '',
-        }
-      }
-    />
+    <div className="space-y-4">
+      {/* Search bar */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          placeholder="Search discussions..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 bg-white py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        {CATEGORY_OPTIONS.map((opt) => (
+          <button
+            key={opt.value || 'all'}
+            onClick={() =>
+              setFilters((prev) => ({
+                ...prev,
+                category: opt.value ? (opt.value as ThreadCategory) : undefined,
+                offset: 0,
+              }))
+            }
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+              filters.category === opt.value || (!filters.category && !opt.value)
+                ? 'bg-blue-100 text-blue-700'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+
+        <select
+          value={filters.sort ?? 'newest'}
+          onChange={(e) =>
+            setFilters((prev) => ({
+              ...prev,
+              sort: e.target.value as DiscussionFilters['sort'],
+              offset: 0,
+            }))
+          }
+          className="ml-auto rounded-md border border-gray-300 px-2 py-1 text-xs"
+        >
+          <option value="newest">Newest</option>
+          <option value="oldest">Oldest</option>
+          <option value="most_replies">Most Replies</option>
+          <option value="most_upvotes">Most Upvotes</option>
+          <option value="trending">Trending</option>
+        </select>
+      </div>
+
+      {discussionsQuery.isLoading ? (
+        <div className="flex h-48 items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : !discussions || discussions.length === 0 ? (
+        <div className="py-12 text-center text-sm text-gray-400">
+          {searchInput
+            ? 'No discussions match your search.'
+            : 'No discussions found. Start the conversation!'}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {discussions.map((d) => (
+            <DiscussionCard key={d.id} discussion={d} />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 pt-2">
+          <button
+            disabled={currentPage <= 1}
+            onClick={() =>
+              setFilters((prev) => ({ ...prev, offset: (currentPage - 2) * limit }))
+            }
+            className="rounded px-3 py-1 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-gray-500">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            disabled={currentPage >= totalPages}
+            onClick={() =>
+              setFilters((prev) => ({ ...prev, offset: currentPage * limit }))
+            }
+            className="rounded px-3 py-1 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
   );
 };

--- a/apps/nextjs-app/src/features/discussions/components/reaction-picker.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/reaction-picker.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import { SmilePlus } from 'lucide-react';
+
+import { ReactionCount, ReactionType } from '@/types/api';
+import { cn } from '@/utils/cn';
+
+const REACTION_EMOJIS: Record<ReactionType, { emoji: string; label: string }> =
+  {
+    insightful: { emoji: '💡', label: 'Insightful' },
+    helpful: { emoji: '🙏', label: 'Helpful' },
+    genius: { emoji: '🧠', label: 'Genius' },
+    spot_on: { emoji: '🎯', label: 'Spot On' },
+    thinking: { emoji: '🤔', label: 'Thinking' },
+  };
+
+type ReactionPickerProps = {
+  reactions: ReactionCount[];
+  userReactions: ReactionType[];
+  onReact: (type: string) => void;
+  isLoading?: boolean;
+};
+
+export const ReactionPicker = ({
+  reactions,
+  userReactions,
+  onReact,
+  isLoading,
+}: ReactionPickerProps) => {
+  const [showPicker, setShowPicker] = useState(false);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {/* Existing reactions */}
+      {reactions.map((r) => {
+        const config = REACTION_EMOJIS[r.type];
+        if (!config) return null;
+        const isActive = userReactions.includes(r.type);
+        return (
+          <button
+            key={r.type}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors',
+              isActive
+                ? 'border-blue-300 bg-blue-50 text-blue-700'
+                : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-gray-300',
+            )}
+            onClick={() => onReact(r.type)}
+            disabled={isLoading}
+            title={config.label}
+          >
+            <span>{config.emoji}</span>
+            <span>{r.count}</span>
+          </button>
+        );
+      })}
+
+      {/* Add reaction button */}
+      <div className="relative">
+        <button
+          className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          onClick={() => setShowPicker(!showPicker)}
+          title="Add reaction"
+        >
+          <SmilePlus className="size-4" />
+        </button>
+
+        {showPicker && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setShowPicker(false)}
+            />
+            <div className="absolute bottom-full left-0 z-20 mb-1 flex gap-1 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg">
+              {Object.entries(REACTION_EMOJIS).map(([type, config]) => (
+                <button
+                  key={type}
+                  className={cn(
+                    'rounded p-1.5 text-lg transition-colors hover:bg-gray-100',
+                    userReactions.includes(type as ReactionType) &&
+                      'bg-blue-50',
+                  )}
+                  onClick={() => {
+                    onReact(type);
+                    setShowPicker(false);
+                  }}
+                  disabled={isLoading}
+                  title={config.label}
+                >
+                  {config.emoji}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/reply-composer.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/reply-composer.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { useNotifications } from '@/components/ui/notifications';
+import { useCreateReply } from '../api/create-reply';
+
+type ReplyComposerProps = {
+  discussionId: string;
+  parentReplyId?: number | null;
+  onCancel?: () => void;
+  placeholder?: string;
+};
+
+export const ReplyComposer = ({
+  discussionId,
+  parentReplyId = null,
+  onCancel,
+  placeholder = 'Write a reply...',
+}: ReplyComposerProps) => {
+  const [body, setBody] = useState('');
+  const { addNotification } = useNotifications();
+
+  const createReplyMutation = useCreateReply({
+    discussionId,
+    mutationConfig: {
+      onSuccess: () => {
+        setBody('');
+        addNotification({ type: 'success', title: 'Reply posted' });
+        onCancel?.();
+      },
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    createReplyMutation.mutate({
+      data: { body: body.trim(), parent_reply_id: parentReplyId },
+      discussionId,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder={placeholder}
+        rows={3}
+        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="submit"
+          size="sm"
+          isLoading={createReplyMutation.isPending}
+          disabled={!body.trim()}
+        >
+          Post Reply
+        </Button>
+        {onCancel && (
+          <Button type="button" size="sm" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/reply-item.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/reply-item.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useState } from 'react';
+import { CheckCircle, MessageSquare, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmationDialog } from '@/components/ui/dialog';
+import { MDPreview } from '@/components/ui/md-preview';
+import { useNotifications } from '@/components/ui/notifications';
+import { useUser } from '@/lib/auth';
+import { Reply } from '@/types/api';
+import { cn } from '@/utils/cn';
+
+import { useAcceptReply } from '../api/accept-reply';
+import { useDeleteReply } from '../api/delete-reply';
+import { useReactToReply } from '../api/react-reply';
+import { useReportReply } from '../api/report-reply';
+import { useVoteReply } from '../api/vote-reply';
+import { ReactionPicker } from './reaction-picker';
+import { ReplyComposer } from './reply-composer';
+import { ReportDialog } from './report-dialog';
+import { UserBadge } from './user-badge';
+import { VoteButtons } from './vote-buttons';
+
+function timeAgo(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+type ReplyItemProps = {
+  reply: Reply & { children?: Reply[] };
+  discussionId: string;
+  discussionAuthorId?: number;
+  depth?: number;
+};
+
+export const ReplyItem = ({
+  reply,
+  discussionId,
+  discussionAuthorId,
+  depth = 0,
+}: ReplyItemProps) => {
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const user = useUser();
+  const { addNotification } = useNotifications();
+
+  const acceptMutation = useAcceptReply({
+    discussionId,
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({
+          type: 'success',
+          title: reply.is_accepted ? 'Solution unmarked' : 'Marked as solution',
+        });
+      },
+    },
+  });
+
+  const deleteMutation = useDeleteReply({
+    discussionId,
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({ type: 'success', title: 'Reply deleted' });
+      },
+    },
+  });
+
+  const voteMutation = useVoteReply({
+    discussionId,
+  });
+
+  const reactMutation = useReactToReply({
+    discussionId,
+  });
+
+  const reportMutation = useReportReply();
+
+  const canAccept =
+    user.data &&
+    (user.data.id === discussionAuthorId?.toString() ||
+      user.data.role?.toLowerCase() === 'admin');
+
+  const canDelete =
+    user.data &&
+    (user.data.id === reply.author_id?.toString() ||
+      user.data.role?.toLowerCase() === 'admin');
+
+  const maxNesting = 2;
+  const engagement = reply.engagement;
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-gray-100 bg-white p-3',
+        reply.is_accepted && 'border-green-300 bg-green-50',
+        depth > 0 && 'ml-6',
+      )}
+    >
+      {reply.is_accepted && (
+        <div className="mb-2 flex items-center gap-1 text-xs font-medium text-green-700">
+          <CheckCircle className="size-3.5" />
+          Accepted Solution
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        {/* Vote buttons */}
+        {engagement && (
+          <div className="flex flex-col items-center pt-0.5">
+            <VoteButtons
+              upvotes={engagement.upvotes}
+              downvotes={engagement.downvotes}
+              userVote={engagement.user_vote}
+              onVote={(value) =>
+                voteMutation.mutate({ replyId: reply.id, value })
+              }
+              isLoading={voteMutation.isPending}
+            />
+          </div>
+        )}
+
+        <div className="flex-1">
+          <div className="mb-2 flex items-center gap-2 text-xs text-gray-500">
+            <span className="font-medium text-gray-700">
+              {reply.author?.username || 'Unknown'}
+            </span>
+            <UserBadge user={reply.author} />
+            <span>{timeAgo(reply.createdAt)}</span>
+          </div>
+
+          <div className="prose prose-sm max-w-none text-sm text-gray-700">
+            <MDPreview value={reply.body} />
+          </div>
+
+          {/* Reactions */}
+          {engagement && (
+            <div className="mt-2">
+              <ReactionPicker
+                reactions={engagement.reactions}
+                userReactions={engagement.user_reactions}
+                onReact={(type) =>
+                  reactMutation.mutate({
+                    replyId: reply.id,
+                    reactionType: type,
+                  })
+                }
+                isLoading={reactMutation.isPending}
+              />
+            </div>
+          )}
+
+          <div className="mt-2 flex items-center gap-2">
+            {depth < maxNesting && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs text-gray-500"
+                onClick={() => setShowReplyForm(!showReplyForm)}
+              >
+                <MessageSquare className="mr-1 size-3" />
+                Reply
+              </Button>
+            )}
+
+            {canAccept && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-7 text-xs',
+                  reply.is_accepted ? 'text-green-600' : 'text-gray-500',
+                )}
+                onClick={() => acceptMutation.mutate({ replyId: reply.id })}
+                isLoading={acceptMutation.isPending}
+              >
+                <CheckCircle className="mr-1 size-3" />
+                {reply.is_accepted ? 'Unmark Solution' : 'Mark as Solution'}
+              </Button>
+            )}
+
+            {canDelete && (
+              <ConfirmationDialog
+                icon="danger"
+                title="Delete Reply"
+                body="Are you sure you want to delete this reply?"
+                triggerButton={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs text-red-500"
+                  >
+                    <Trash2 className="mr-1 size-3" />
+                    Delete
+                  </Button>
+                }
+                confirmButton={
+                  <Button
+                    variant="destructive"
+                    isLoading={deleteMutation.isPending}
+                    onClick={() =>
+                      deleteMutation.mutate({ replyId: reply.id })
+                    }
+                  >
+                    Delete
+                  </Button>
+                }
+              />
+            )}
+
+            <ReportDialog
+              targetLabel="reply"
+              onSubmit={({ reason, details }) =>
+                reportMutation.mutate({
+                  replyId: reply.id,
+                  reason,
+                  details,
+                })
+              }
+              isLoading={reportMutation.isPending}
+            />
+          </div>
+        </div>
+      </div>
+
+      {showReplyForm && (
+        <div className="mt-3">
+          <ReplyComposer
+            discussionId={discussionId}
+            parentReplyId={parseInt(reply.id)}
+            onCancel={() => setShowReplyForm(false)}
+            placeholder="Write a nested reply..."
+          />
+        </div>
+      )}
+
+      {reply.children && reply.children.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {reply.children.map((child) => (
+            <ReplyItem
+              key={child.id}
+              reply={child}
+              discussionId={discussionId}
+              discussionAuthorId={discussionAuthorId}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/reply-tree.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/reply-tree.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Reply } from '@/types/api';
+
+import { ReplyItem } from './reply-item';
+
+type ReplyTreeProps = {
+  replies: (Reply & { children?: Reply[] })[];
+  discussionId: string;
+  discussionAuthorId?: number;
+};
+
+export const ReplyTree = ({
+  replies,
+  discussionId,
+  discussionAuthorId,
+}: ReplyTreeProps) => {
+  if (!replies || replies.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-gray-400">
+        No replies yet. Be the first to respond!
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {replies.map((reply) => (
+        <ReplyItem
+          key={reply.id}
+          reply={reply}
+          discussionId={discussionId}
+          discussionAuthorId={discussionAuthorId}
+          depth={0}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/report-dialog.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/report-dialog.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { Flag } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useNotifications } from '@/components/ui/notifications';
+
+const REPORT_REASONS = [
+  { value: 'spam', label: 'Spam' },
+  { value: 'harassment', label: 'Harassment' },
+  { value: 'off_topic', label: 'Off Topic' },
+  { value: 'inappropriate', label: 'Inappropriate Content' },
+  { value: 'other', label: 'Other' },
+];
+
+type ReportDialogProps = {
+  onSubmit: (data: { reason: string; details: string }) => void;
+  isLoading?: boolean;
+  targetLabel?: string;
+};
+
+export const ReportDialog = ({
+  onSubmit,
+  isLoading,
+  targetLabel = 'content',
+}: ReportDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [details, setDetails] = useState('');
+  const { addNotification } = useNotifications();
+
+  const handleSubmit = () => {
+    if (!reason) return;
+    onSubmit({ reason, details });
+    addNotification({ type: 'success', title: 'Report submitted' });
+    setOpen(false);
+    setReason('');
+    setDetails('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-7 text-xs text-gray-500">
+          <Flag className="mr-1 size-3" />
+          Report
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Flag className="size-5 text-orange-500" />
+            Report {targetLabel}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              Reason
+            </label>
+            <select
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            >
+              <option value="">Select a reason...</option>
+              {REPORT_REASONS.map((r) => (
+                <option key={r.value} value={r.value}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              Additional details (optional)
+            </label>
+            <textarea
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              placeholder="Provide more context..."
+              rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!reason || isLoading}
+            isLoading={isLoading}
+          >
+            Submit Report
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/update-discussion.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/update-discussion.tsx
@@ -7,8 +7,7 @@ import {
   Form,
   FormDrawer,
   Input,
-  Label,
-  Switch,
+  Select,
   Textarea,
 } from '@/components/ui/form';
 import { useNotifications } from '@/components/ui/notifications';
@@ -20,6 +19,16 @@ import {
   updateDiscussionInputSchema,
   useUpdateDiscussion,
 } from '../api/update-discussion';
+
+const categoryOptions = [
+  { label: 'General', value: 'general' },
+  { label: 'Puzzle Help', value: 'puzzle_help' },
+  { label: 'Tips & Tricks', value: 'puzzle_tips' },
+  { label: 'Solutions', value: 'solutions' },
+  { label: 'Bug Report', value: 'bug_report' },
+  { label: 'Feature Request', value: 'feature_request' },
+  { label: 'Showcase', value: 'showcase' },
+];
 
 type UpdateDiscussionProps = {
   discussionId: string;
@@ -40,12 +49,11 @@ export const UpdateDiscussion = ({ discussionId }: UpdateDiscussionProps) => {
   });
 
   const user = useUser();
+  const discussion = discussionQuery.data;
 
-  if (!canUpdateDiscussion(user?.data)) {
+  if (!canUpdateDiscussion(user?.data, discussion ?? undefined)) {
     return null;
   }
-
-  const discussion = discussionQuery.data?.data;
 
   return (
     <FormDrawer
@@ -79,34 +87,29 @@ export const UpdateDiscussion = ({ discussionId }: UpdateDiscussionProps) => {
           defaultValues: {
             title: discussion?.title ?? '',
             body: discussion?.body ?? '',
-            public: discussion?.public ?? false,
+            category: discussion?.category ?? 'general',
           },
         }}
         schema={updateDiscussionInputSchema}
       >
-        {({ register, formState, setValue, watch }) => (
+        {({ register, formState }) => (
           <>
             <Input
               label="Title"
               error={formState.errors['title']}
               registration={register('title')}
             />
+            <Select
+              label="Category"
+              error={formState.errors['category']}
+              registration={register('category')}
+              options={categoryOptions}
+            />
             <Textarea
               label="Body"
               error={formState.errors['body']}
               registration={register('body')}
             />
-
-            <div className="flex items-center space-x-2">
-              <Switch
-                name="public"
-                onCheckedChange={(value) => setValue('public', value)}
-                checked={watch('public')}
-                className={` relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2`}
-                id="public"
-              />
-              <Label htmlFor="airplane-mode">Public</Label>
-            </div>
           </>
         )}
       </Form>

--- a/apps/nextjs-app/src/features/discussions/components/user-badge.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/user-badge.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { User } from '@/types/api';
+import { cn } from '@/utils/cn';
+
+function getLevelBadge(level: number): { label: string; color: string } | null {
+  if (level >= 20) return { label: 'Master', color: 'bg-purple-100 text-purple-700' };
+  if (level >= 10) return { label: 'Expert', color: 'bg-blue-100 text-blue-700' };
+  if (level >= 5) return { label: 'Regular', color: 'bg-green-100 text-green-700' };
+  return null;
+}
+
+function getRoleBadge(role: string): { label: string; color: string } | null {
+  const r = role?.toLowerCase();
+  if (r === 'admin') return { label: 'Admin', color: 'bg-red-100 text-red-700' };
+  if (r === 'creator') return { label: 'Creator', color: 'bg-amber-100 text-amber-700' };
+  return null;
+}
+
+type UserBadgeProps = {
+  user?: Pick<User, 'role' | 'level'> | null;
+};
+
+export const UserBadge = ({ user }: UserBadgeProps) => {
+  if (!user) return null;
+
+  const roleBadge = getRoleBadge(user.role);
+  const levelBadge = getLevelBadge(user.level ?? 0);
+
+  return (
+    <>
+      {roleBadge && (
+        <span
+          className={cn(
+            'inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold leading-none',
+            roleBadge.color,
+          )}
+        >
+          {roleBadge.label}
+        </span>
+      )}
+      {levelBadge && (
+        <span
+          className={cn(
+            'inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold leading-none',
+            levelBadge.color,
+          )}
+        >
+          {levelBadge.label}
+        </span>
+      )}
+    </>
+  );
+};

--- a/apps/nextjs-app/src/features/discussions/components/vote-buttons.tsx
+++ b/apps/nextjs-app/src/features/discussions/components/vote-buttons.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { ChevronUp, ChevronDown } from 'lucide-react';
+
+import { cn } from '@/utils/cn';
+
+type VoteButtonsProps = {
+  upvotes: number;
+  downvotes: number;
+  userVote: number | null;
+  onVote: (value: number) => void;
+  isLoading?: boolean;
+  size?: 'sm' | 'md';
+};
+
+export const VoteButtons = ({
+  upvotes,
+  downvotes,
+  userVote,
+  onVote,
+  isLoading,
+  size = 'sm',
+}: VoteButtonsProps) => {
+  const score = upvotes - downvotes;
+  const iconClass = size === 'md' ? 'size-5' : 'size-4';
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        className={cn(
+          'rounded p-0.5 transition-colors hover:bg-green-50',
+          userVote === 1
+            ? 'text-green-600'
+            : 'text-gray-400 hover:text-green-500',
+        )}
+        onClick={() => onVote(1)}
+        disabled={isLoading}
+        title="Upvote"
+      >
+        <ChevronUp className={iconClass} />
+      </button>
+      <span
+        className={cn(
+          'min-w-[1.5rem] text-center text-xs font-semibold',
+          score > 0 && 'text-green-600',
+          score < 0 && 'text-red-500',
+          score === 0 && 'text-gray-500',
+        )}
+      >
+        {score}
+      </span>
+      <button
+        className={cn(
+          'rounded p-0.5 transition-colors hover:bg-red-50',
+          userVote === -1
+            ? 'text-red-500'
+            : 'text-gray-400 hover:text-red-400',
+        )}
+        onClick={() => onVote(-1)}
+        disabled={isLoading}
+        title="Downvote"
+      >
+        <ChevronDown className={iconClass} />
+      </button>
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/notifications/api.ts
+++ b/apps/nextjs-app/src/features/notifications/api.ts
@@ -5,7 +5,7 @@ import { QueryConfig } from '@/lib/react-query';
 
 export type CreatorNotification = {
   id: number;
-  type: 'solve' | 'rating';
+  type: 'solve' | 'rating' | 'warning' | 'ban';
   message: string;
   xp_amount: number;
   puzzle_name: string;
@@ -14,7 +14,7 @@ export type CreatorNotification = {
 };
 
 export interface NotificationFilters {
-  notifType?: 'solve' | 'rating';
+  notifType?: 'solve' | 'rating' | 'warning' | 'ban';
   puzzleName?: string;
   actorUsername?: string;
   dateFrom?: string;

--- a/apps/nextjs-app/src/features/notifications/creator-notifications-popup.tsx
+++ b/apps/nextjs-app/src/features/notifications/creator-notifications-popup.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 
 import { useCreatorNotifications, useMarkNotificationsRead } from '@/features/notifications/api';
 import { useNotifications } from '@/components/ui/notifications';
 import { useUser } from '@/lib/auth';
-import { Button } from '@/components/ui/button';
 
 const SHOWN_NOTIFICATIONS_KEY = 'escapecircuit_shown_notifications';
 
@@ -22,7 +20,6 @@ const CreatorNotificationsPopup = () => {
   const markRead = useMarkNotificationsRead();
   const { addNotification } = useNotifications();
   const shownRef = useRef(false);
-  const [activeToastIds, setActiveToastIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     // Only fire once per mount, only when data is ready, only when we have a user
@@ -56,37 +53,32 @@ const CreatorNotificationsPopup = () => {
     const allNotificationIds = notifications.map((n) => n.id);
     localStorage.setItem(SHOWN_NOTIFICATIONS_KEY, JSON.stringify(allNotificationIds));
 
-    // Track which toasts are currently active
-    const toastIds = new Set<number>();
-
     // Show each notification as a toast (stagger slightly for UX)
     newNotifications.forEach((n, i) => {
       setTimeout(() => {
-        toastIds.add(n.id);
-        setActiveToastIds(new Set(toastIds));
+        let title = 'Notification';
+        let type: 'success' | 'info' | 'warning' | 'error' = 'info';
+        if (n.type === 'solve') {
+          title = 'Puzzle Solved!';
+          type = 'success';
+        } else if (n.type === 'rating') {
+          title = 'New Rating!';
+          type = 'info';
+        } else if (n.type === 'warning') {
+          title = 'Warning';
+          type = 'warning';
+        } else if (n.type === 'ban') {
+          title = 'Account Restriction';
+          type = 'error';
+        }
 
-        const title = n.type === 'solve' ? 'Puzzle Solved!' : 'New Rating!';
-        const type = n.type === 'solve' ? 'success' : 'info';
+        const persistent = n.type === 'warning' || n.type === 'ban';
 
         addNotification({
           type,
           title,
           message: n.message,
-          // For multiple notifications, add a close all action hint
-          ...(newNotifications.length > 1 && {
-            action: (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  // Clear all toasts
-                  setActiveToastIds(new Set());
-                }}
-              >
-                <X className="size-4" />
-              </Button>
-            ),
-          }),
+          persistent,
         });
       }, i * 600); // 600ms apart so they don't all pop at once
     });

--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-details-dialog.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-details-dialog.tsx
@@ -56,7 +56,7 @@ export const PuzzleDetailsDialog = ({
               </div>
               <div>
                 <span className="font-medium text-gray-900">Tight budget:</span>{' '}
-                {puzzle.tightBudgetLimit ?? '—'}
+                {(puzzle as any).tightBudgetLimit ?? '—'}
               </div>
             </div>
 
@@ -65,18 +65,18 @@ export const PuzzleDetailsDialog = ({
                 Additional constraints (optional)
               </div>
               <div className="mt-1 space-y-1">
-                {Array.isArray(puzzle.additionalConstraints) ? (
-                  puzzle.additionalConstraints.length > 0 ? (
+                {Array.isArray((puzzle as any).additionalConstraints) ? (
+                  (puzzle as any).additionalConstraints.length > 0 ? (
                     <ul className="list-disc space-y-1 pl-5">
-                      {puzzle.additionalConstraints.map((c) => (
+                      {(puzzle as any).additionalConstraints.map((c: string) => (
                         <li key={c}>{c}</li>
                       ))}
                     </ul>
                   ) : (
                     <div className="text-gray-500">None provided.</div>
                   )
-                ) : puzzle.additionalConstraints ? (
-                  <div>{puzzle.additionalConstraints}</div>
+                ) : (puzzle as any).additionalConstraints ? (
+                  <div>{(puzzle as any).additionalConstraints}</div>
                 ) : (
                   <div className="text-gray-500">None provided.</div>
                 )}

--- a/apps/nextjs-app/src/lib/authorization.ts
+++ b/apps/nextjs-app/src/lib/authorization.ts
@@ -1,14 +1,30 @@
-import { Comment, User } from '@/types/api';
+import { Comment, Discussion, User } from '@/types/api';
 
 const normalizeRole = (role: string | undefined) => (role || '').toLowerCase();
 
 export const canCreateDiscussion = (user: User | null | undefined) => {
+  return !!user;
+};
+export const canDeleteDiscussion = (
+  user: User | null | undefined,
+  discussion?: Discussion,
+) => {
+  if (!user) return false;
+  if (normalizeRole(user.role) === 'admin') return true;
+  return discussion?.author_id?.toString() === user.id;
+};
+export const canUpdateDiscussion = (
+  user: User | null | undefined,
+  discussion?: Discussion,
+) => {
+  if (!user) return false;
+  if (normalizeRole(user.role) === 'admin') return true;
+  return discussion?.author_id?.toString() === user.id;
+};
+export const canPinDiscussion = (user: User | null | undefined) => {
   return normalizeRole(user?.role) === 'admin';
 };
-export const canDeleteDiscussion = (user: User | null | undefined) => {
-  return normalizeRole(user?.role) === 'admin';
-};
-export const canUpdateDiscussion = (user: User | null | undefined) => {
+export const canLockDiscussion = (user: User | null | undefined) => {
   return normalizeRole(user?.role) === 'admin';
 };
 
@@ -37,7 +53,7 @@ export const canDeleteComment = (
     return true;
   }
 
-  if (userRole === 'user' && comment.author?.id === user.id) {
+  if (userRole === 'user' && comment.author?.id === user?.id) {
     return true;
   }
 

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -34,13 +34,75 @@ export type Team = Entity<{
   description: string;
 }>;
 
+export type ThreadCategory =
+  | 'general'
+  | 'puzzle_help'
+  | 'puzzle_tips'
+  | 'solutions'
+  | 'bug_report'
+  | 'feature_request'
+  | 'showcase';
+
 export type Discussion = Entity<{
   title: string;
   body: string;
-  teamId: string;
   author: User;
-  public: boolean;
+  author_id: number;
+  puzzle_id: number | null;
+  category: ThreadCategory;
+  is_pinned: boolean;
+  is_locked: boolean;
+  view_count: number;
+  reply_count: number;
+  upvotes: number;
+  accepted_reply_id: number | null;
+  updated_at: string;
+  engagement?: DiscussionEngagement;
 }>;
+
+export type Reply = Entity<{
+  discussion_id: number;
+  parent_reply_id: number | null;
+  author: User;
+  author_id: number;
+  body: string;
+  upvotes: number;
+  downvotes: number;
+  is_accepted: boolean;
+  updated_at: string;
+  children?: Reply[];
+  engagement?: ReplyEngagement;
+}>;
+
+export type ReactionType =
+  | 'insightful'
+  | 'helpful'
+  | 'genius'
+  | 'spot_on'
+  | 'thinking';
+
+export type ReactionCount = {
+  type: ReactionType;
+  count: number;
+};
+
+export type DiscussionEngagement = {
+  upvotes: number;
+  downvotes: number;
+  user_vote: number | null;
+  reactions: ReactionCount[];
+  user_reactions: ReactionType[];
+  is_following: boolean;
+  is_bookmarked: boolean;
+};
+
+export type ReplyEngagement = {
+  upvotes: number;
+  downvotes: number;
+  user_vote: number | null;
+  reactions: ReactionCount[];
+  user_reactions: ReactionType[];
+};
 
 export type Comment = Entity<{
   body: string;

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -228,6 +228,20 @@ export type AuditLogEntry = {
   created_at: string;
 };
 
+export type Report = {
+  id: number;
+  reporter_id: number;
+  reporter_username?: string;
+  target_type: 'discussion' | 'reply';
+  target_id: number;
+  target_author_id?: number;
+  target_author_username?: string;
+  reason: string;
+  details: string;
+  status: 'pending' | 'reviewed' | 'dismissed';
+  created_at: string;
+};
+
 export type AdminPuzzle = Puzzle & {
   flags: string[]; // 'low_fun', 'low_clearness', 'unrated'
   status: 'draft' | 'published' | 'unpublished';

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -236,6 +236,7 @@ export type Report = {
   target_id: number;
   target_author_id?: number;
   target_author_username?: string;
+  discussion_id?: number;
   reason: string;
   details: string;
   status: 'pending' | 'reviewed' | 'dismissed';

--- a/forum2ARD.txt
+++ b/forum2ARD.txt
@@ -1,0 +1,657 @@
+# Discussion Forum Feature — Summaries for ARD & ADD
+
+## Context
+
+This document provides two detailed summaries of **everything implemented** for the Discussion Forum feature across Phases 1–3 plus the Admin Reports enhancement. The first summary is written for the **Application Requirements Document (ARD)** and the second for the **Application Design Document (ADD)**.
+
+---
+
+# PART 1 — APPLICATION REQUIREMENTS DOCUMENT (ARD) SUMMARY
+
+## 1. Feature Overview
+
+The Discussion Forum is a community-driven feature within EscapeCircuit that allows users to create, browse, and engage with discussion threads related to circuit puzzles and the platform in general. It includes threaded replies, user engagement tools, content discovery, content reporting, and admin moderation capabilities.
+
+## 2. Functional Requirements
+
+### 2.1 Discussion Management (Phase 1 — Core Forum)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-D01 | Create Discussion | Authenticated users can create a discussion with a title (3–200 chars), body (10–10,000 chars), category, and optional linked puzzle. Awards 5 XP to the author. |
+| FR-D02 | View Discussion | Any authenticated user can view a discussion. Viewing increments the view counter by 1. Returns the discussion enriched with author info, engagement data, and nested replies (3 levels deep). |
+| FR-D03 | List Discussions | Paginated listing with support for filtering by category, puzzle, author, and search term. Results are sortable by newest, oldest, most replies, most upvotes, and trending. Pinned discussions always appear first. |
+| FR-D04 | Update Discussion | Only the discussion author or an admin can update the title, body, or category. |
+| FR-D05 | Delete Discussion | Only the discussion author or an admin can delete. Cascading deletes remove all associated replies, votes, reactions, follows, and bookmarks. |
+| FR-D06 | Discussion Categories | Seven predefined categories: General, Puzzle Help, Tips & Tricks, Solutions, Bug Report, Feature Request, Showcase. |
+| FR-D07 | Ban Enforcement | Users with `is_discussion_banned = true` are blocked from creating discussions. They receive an error: "you are banned from creating discussions". |
+
+### 2.2 Reply Management (Phase 1 — Core Forum)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-R01 | Create Reply | Authenticated users can reply to a discussion. Supports nested threading via optional `parent_reply_id`. Awards 2 XP to the author. Blocked if discussion is locked or user is banned. |
+| FR-R02 | Update Reply | Only the reply author or an admin can update the body. |
+| FR-R03 | Delete Reply | Only the reply author or an admin can delete. Decrements the discussion's reply counter. |
+| FR-R04 | Accept Reply (Mark as Solution) | Only the discussion author or an admin can accept a reply. Clears any previously accepted reply. Awards 25 XP to the reply author and 5 XP to the discussion author. |
+| FR-R05 | Nested Threading | Replies support a parent–child hierarchy via `parent_reply_id`. The UI renders up to 3 levels of nesting. |
+| FR-R06 | Ban Enforcement | Users with `is_discussion_banned = true` are blocked from creating replies. |
+
+### 2.3 User Engagement (Phase 2 — Engagement)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-E01 | Vote on Discussion | Users can upvote (+1) or downvote (−1) a discussion. Re-voting with the same value removes the vote (toggle). Awards 3 XP to the discussion author on upvote (not self-upvote). |
+| FR-E02 | Vote on Reply | Same behavior as discussion voting but for replies. Awards 3 XP to the reply author on upvote. |
+| FR-E03 | React to Discussion | Users can add reactions (insightful, helpful, genius, spot_on, thinking). Each reaction type is independently toggle-able. Awards 1 XP to the discussion author on add (not self-react). |
+| FR-E04 | React to Reply | Same behavior as discussion reactions but for replies. |
+| FR-E05 | Follow Discussion | Users can toggle following a discussion. Followers may receive notifications on new replies (future enhancement). |
+| FR-E06 | Bookmark Discussion | Users can toggle bookmarking a discussion for quick access. |
+| FR-E07 | User Badge | Discussions and replies display the author's username, level, and experience information. Experienced users (level ≥ 5) are visually distinguished. |
+
+### 2.4 Discovery & Search (Phase 3 — Discovery)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-S01 | Full-Text Search | Users can search discussions by title and body content. Search is applied as a filter on the list endpoint. |
+| FR-S02 | Category Filtering | Users can filter the discussion list by category using filter buttons. |
+| FR-S03 | Trending Sort | A "trending" sort algorithm prioritizes discussions with high engagement relative to recency: `score = upvotes + (reply_count × 2) + (view_count × 0.1) + recency_bonus`. Recency bonus is 50 points for posts < 1 day old, decaying to 0 over 7 days. |
+
+### 2.5 Content Reporting (Phase 3 — Moderation)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-M01 | Report Discussion | Authenticated users can report a discussion for: spam, harassment, off_topic, inappropriate, or other. Optional details text. A user cannot report the same content twice (unique constraint). |
+| FR-M02 | Report Reply | Same behavior as discussion reporting but for replies. |
+| FR-M03 | Report De-duplication | A unique constraint on (reporter_id, target_type, target_id) prevents the same user from reporting the same content multiple times. |
+
+### 2.6 Admin Moderation (Admin Reports Enhancement)
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-A01 | View Reports | Admins can view all content reports in the Admin Panel → Reports tab. Reports display: reason badge, status badge, date, target type with clickable link, target author username, reporter username, and details. |
+| FR-A02 | Filter Reports by Status | Admins can filter reports by: All, Pending, Reviewed, Dismissed. |
+| FR-A03 | Update Report Status | Admins can manually change a report's status to reviewed or dismissed. |
+| FR-A04 | Warn Author | Admins can warn the author of reported content. This creates a persistent "warning" notification for the author visible on their next login, and marks the report as reviewed. |
+| FR-A05 | Ban Author from Discussions | Admins can ban the author of reported content from the discussions forum. This sets `is_discussion_banned = true`, creates a persistent "ban" notification for the user, and marks the report as reviewed. The user can no longer create discussions or replies. |
+| FR-A06 | Delete Reported Content | Admins can permanently delete the reported discussion or reply. Requires a confirmation dialog. Marks the report as reviewed. |
+| FR-A07 | Lock Reported Discussion | Admins can lock a reported discussion (only available for discussion-type targets). Prevents new replies. Marks the report as reviewed. |
+| FR-A08 | Pin Discussion | Admins can toggle the pinned status of a discussion. Pinned discussions appear first in all list views. |
+| FR-A09 | Lock Discussion (Direct) | Admins can toggle the locked status of a discussion from the discussion detail view. Locked discussions block new replies. |
+
+### 2.7 Notification Requirements
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-N01 | Warning Notification | When an admin warns a user, a notification of type "warning" is created. The title shows "Warning" with a yellow icon. The notification is persistent — it does not auto-dismiss and requires the user to manually close it. |
+| FR-N02 | Ban Notification | When an admin bans a user, a notification of type "ban" is created. The title shows "Account Restriction" with a red error icon. The notification is persistent. |
+| FR-N03 | Offline Notification Delivery | Notifications are stored server-side and fetched when the user logs in. If a user was offline when warned/banned, they see the notification on next login. |
+| FR-N04 | Notification De-duplication | Shown notification IDs are tracked in localStorage to prevent re-showing on page refresh. |
+
+### 2.8 XP Reward Table
+
+| Action | XP Awarded | Recipient |
+|--------|-----------|-----------|
+| Create Discussion | +5 | Author |
+| Create Reply | +2 | Author |
+| Receive Upvote (Discussion) | +3 | Discussion Author |
+| Receive Upvote (Reply) | +3 | Reply Author |
+| Receive Reaction (Discussion) | +1 | Discussion Author |
+| Receive Reaction (Reply) | +1 | Reply Author |
+| Reply Accepted as Solution | +25 | Reply Author |
+| Accept a Solution | +5 | Discussion Author |
+
+### 2.9 Non-Functional Requirements
+
+- All discussion list queries support pagination (limit/offset)
+- Search is case-insensitive substring matching on title and body
+- Report creation validates reason against allowed enum values
+- Admin-only endpoints verify user role = admin before processing
+- Ban checks occur at discussion/reply creation time, not at login
+- Cascade deletes ensure no orphaned data when discussions are removed
+
+## 3. API Endpoints Summary
+
+### Discussion Endpoints
+- `GET /discussions` — List (with filters, search, sort, pagination)
+- `POST /discussions` — Create
+- `GET /discussions/{id}` — Get single (with nested replies + engagement)
+- `PATCH /discussions/{id}` — Update
+- `DELETE /discussions/{id}` — Delete
+- `POST /discussions/{id}/pin` — Toggle pin (admin)
+- `POST /discussions/{id}/lock` — Toggle lock (admin)
+
+### Discussion Engagement Endpoints
+- `POST /discussions/{id}/vote` — Vote (+1/−1)
+- `POST /discussions/{id}/react` — React (insightful, helpful, etc.)
+- `POST /discussions/{id}/follow` — Toggle follow
+- `POST /discussions/{id}/bookmark` — Toggle bookmark
+- `POST /discussions/{id}/report` — Report content
+
+### Reply Endpoints
+- `GET /discussions/{id}/replies` — List replies
+- `POST /discussions/{id}/replies` — Create reply
+- `PATCH /replies/{id}` — Update reply
+- `DELETE /replies/{id}` — Delete reply
+- `POST /replies/{id}/accept` — Accept as solution
+
+### Reply Engagement Endpoints
+- `POST /replies/{id}/vote` — Vote
+- `POST /replies/{id}/react` — React
+- `POST /replies/{id}/report` — Report reply
+
+### Admin Report Endpoints
+- `GET /reports` — List reports (with status filter)
+- `PATCH /reports/{id}` — Update report status
+- `POST /reports/{id}/warn` — Warn content author
+- `POST /reports/{id}/ban` — Ban content author from discussions
+- `POST /reports/{id}/delete-content` — Delete reported content
+- `POST /reports/{id}/lock` — Lock reported discussion
+
+## 4. User Roles & Permissions
+
+| Action | Solver | Creator | Admin |
+|--------|--------|---------|-------|
+| Create Discussion | ✅ | ✅ | ✅ |
+| Create Reply | ✅ | ✅ | ✅ |
+| Edit Own Discussion/Reply | ✅ | ✅ | ✅ |
+| Edit Others' Discussion/Reply | ❌ | ❌ | ✅ |
+| Delete Own Discussion/Reply | ✅ | ✅ | ✅ |
+| Delete Others' Discussion/Reply | ❌ | ❌ | ✅ |
+| Vote / React / Follow / Bookmark | ✅ | ✅ | ✅ |
+| Accept Solution (own thread) | ✅ | ✅ | ✅ |
+| Accept Solution (any thread) | ❌ | ❌ | ✅ |
+| Report Content | ✅ | ✅ | ✅ |
+| View Reports | ❌ | ❌ | ✅ |
+| Warn / Ban / Delete / Lock (moderation) | ❌ | ❌ | ✅ |
+| Pin / Lock Discussion (direct) | ❌ | ❌ | ✅ |
+
+## 5. Frontend Pages
+
+| Page | Route | Description |
+|------|-------|-------------|
+| Discussions List | `/app/discussions` | Browse, search, filter, sort discussions |
+| Discussion Detail | `/app/discussions/{id}` | View discussion with nested replies, engagement |
+| Create Discussion | `/app/discussions/new` | Form to create a new discussion |
+| Public Discussion | `/public/discussions/{id}` | Public-facing read-only discussion view |
+| Admin Panel → Reports | `/app/users` (Reports tab) | Admin reports management with moderation actions |
+
+---
+
+# PART 2 — APPLICATION DESIGN DOCUMENT (ADD) SUMMARY
+
+## 1. Architecture Overview
+
+The Discussion Forum follows the existing EscapeCircuit layered architecture:
+
+```
+Frontend (Next.js 14 App Router)
+    ↕ HTTP/JSON (REST API)
+Backend (Python FastAPI)
+    ├── API Layer (Controllers / Routers)
+    ├── Service Layer (Business Logic / Validation / Authorization)
+    ├── Persistence Layer (Repositories / SQLite)
+    └── Domain Layer (Dataclasses / Enums)
+```
+
+### Key Architectural Decisions
+- **4 separate FastAPI routers** returned from `build_discussion_router()`: `disc_router`, `reply_router`, `puzzle_router`, `report_router` — each mounted on different prefixes in `main.py`
+- **Feature-based frontend structure**: All discussion code lives under `src/features/discussions/` following the existing `import/no-restricted-paths` ESLint rule preventing cross-feature imports
+- **React Query (TanStack Query)** for server state management with optimistic updates on engagement actions
+- **Zustand** for the notification toast store
+
+## 2. Database Design
+
+### 2.1 Entity-Relationship Diagram (Textual)
+
+```
+users (existing)
+  ├── 1:N → discussions (author_id)
+  ├── 1:N → replies (author_id)
+  ├── 1:N → discussion_votes (user_id)
+  ├── 1:N → reply_votes (user_id)
+  ├── 1:N → discussion_reactions (user_id)
+  ├── 1:N → reply_reactions (user_id)
+  ├── 1:N → discussion_follows (user_id)
+  ├── 1:N → discussion_bookmarks (user_id)
+  ├── 1:N → content_reports (reporter_id)
+  └── 1:N → creator_notifications (user_id)
+
+discussions
+  ├── 1:N → replies (discussion_id, CASCADE)
+  ├── 1:N → discussion_votes (discussion_id, CASCADE)
+  ├── 1:N → discussion_reactions (discussion_id, CASCADE)
+  ├── 1:N → discussion_follows (discussion_id, CASCADE)
+  ├── 1:N → discussion_bookmarks (discussion_id, CASCADE)
+  └── 1:1 → replies (accepted_reply_id, optional)
+
+replies
+  ├── 1:N → replies (parent_reply_id, self-reference, CASCADE)
+  ├── 1:N → reply_votes (reply_id, CASCADE)
+  └── 1:N → reply_reactions (reply_id, CASCADE)
+```
+
+### 2.2 Table Schemas
+
+**discussions**
+```sql
+CREATE TABLE discussions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author_id INTEGER NOT NULL REFERENCES users(id),
+    puzzle_id INTEGER REFERENCES puzzles(id),
+    category TEXT NOT NULL DEFAULT 'general',
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    is_locked INTEGER NOT NULL DEFAULT 0,
+    view_count INTEGER NOT NULL DEFAULT 0,
+    reply_count INTEGER NOT NULL DEFAULT 0,
+    upvotes INTEGER NOT NULL DEFAULT 0,
+    accepted_reply_id INTEGER,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+**replies**
+```sql
+CREATE TABLE replies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+    parent_reply_id INTEGER REFERENCES replies(id) ON DELETE CASCADE,
+    author_id INTEGER NOT NULL REFERENCES users(id),
+    body TEXT NOT NULL,
+    upvotes INTEGER NOT NULL DEFAULT 0,
+    downvotes INTEGER NOT NULL DEFAULT 0,
+    is_accepted INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+**discussion_votes**
+```sql
+CREATE TABLE discussion_votes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    value INTEGER NOT NULL,  -- +1 or -1
+    created_at TEXT NOT NULL,
+    UNIQUE(discussion_id, user_id)
+);
+```
+
+**reply_votes**
+```sql
+CREATE TABLE reply_votes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reply_id INTEGER NOT NULL REFERENCES replies(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    value INTEGER NOT NULL,  -- +1 or -1
+    created_at TEXT NOT NULL,
+    UNIQUE(reply_id, user_id)
+);
+```
+
+**discussion_reactions**
+```sql
+CREATE TABLE discussion_reactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    reaction_type TEXT NOT NULL,  -- insightful, helpful, genius, spot_on, thinking
+    created_at TEXT NOT NULL,
+    UNIQUE(discussion_id, user_id, reaction_type)
+);
+```
+
+**reply_reactions**
+```sql
+CREATE TABLE reply_reactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reply_id INTEGER NOT NULL REFERENCES replies(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    reaction_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(reply_id, user_id, reaction_type)
+);
+```
+
+**discussion_follows**
+```sql
+CREATE TABLE discussion_follows (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(discussion_id, user_id)
+);
+```
+
+**discussion_bookmarks**
+```sql
+CREATE TABLE discussion_bookmarks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(discussion_id, user_id)
+);
+```
+
+**content_reports**
+```sql
+CREATE TABLE content_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reporter_id INTEGER NOT NULL REFERENCES users(id),
+    target_type TEXT NOT NULL,     -- 'discussion' or 'reply'
+    target_id INTEGER NOT NULL,
+    reason TEXT NOT NULL,          -- spam, harassment, off_topic, inappropriate, other
+    details TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',  -- pending, reviewed, dismissed
+    created_at TEXT NOT NULL,
+    UNIQUE(reporter_id, target_type, target_id)
+);
+```
+
+**Users table extension (ALTER TABLE migration)**
+```sql
+ALTER TABLE users ADD COLUMN is_discussion_banned INTEGER NOT NULL DEFAULT 0;
+```
+
+**creator_notifications (existing table, reused for warnings/bans)**
+```sql
+CREATE TABLE creator_notifications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    type TEXT NOT NULL,           -- solve, rating, creator_invite, role_change, warning, ban
+    message TEXT NOT NULL,
+    xp_amount INTEGER NOT NULL DEFAULT 0,
+    puzzle_name TEXT NOT NULL DEFAULT '',
+    actor_username TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    is_read INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_notif_user_unread ON creator_notifications(user_id, is_read);
+```
+
+## 3. Backend Design
+
+### 3.1 Domain Layer
+
+**Files:**
+- `src/Backend/DomainLayer/Discussion.py` — `Discussion` dataclass
+- `src/Backend/DomainLayer/Reply.py` — `Reply` dataclass
+- `src/Backend/DomainLayer/Enums.py` — `ThreadCategory`, `ReactionType` enums
+- `src/Backend/DomainLayer/User.py` — Extended with `is_discussion_banned: bool`
+
+### 3.2 Persistence Layer (Repositories)
+
+| Repository | File | Tables Managed | Key Methods |
+|------------|------|----------------|-------------|
+| DiscussionRepo | `PersistantLayer/DiscussionRepo.py` | discussions | CRUD, list with filters/sort/search, increment counters, set accepted reply |
+| ReplyRepo | `PersistantLayer/ReplyRepo.py` | replies | CRUD, list by discussion, list children, update votes, clear accepted |
+| EngagementRepo | `PersistantLayer/EngagementRepo.py` | discussion_votes, reply_votes, discussion_reactions, reply_reactions, discussion_follows, discussion_bookmarks | Vote toggling, reaction toggling, follow/bookmark toggling, bulk engagement queries |
+| ReportRepo | `PersistantLayer/ReportRepo.py` | content_reports | Create, list, count, update status, has_reported check |
+| UserRepo (extended) | `PersistantLayer/UserRepo.py` | users (is_discussion_banned column) | `ban_from_discussions()`, `unban_from_discussions()`, `_row_to_user()` helper |
+| NotificationRepo (reused) | `PersistantLayer/NotificationRepo.py` | creator_notifications | `create()` for warning/ban notifications |
+
+**Design patterns:**
+- Each repo calls `_ensure_schema()` in `__init__` to auto-create tables
+- UserRepo uses ALTER TABLE migration to add the `is_discussion_banned` column if missing
+- `_row_to_user()` static helper DRYs up row-to-model mapping across 5 query methods
+- All repos share the same SQLite connection passed in from `main.py`
+
+### 3.3 Service Layer (Business Logic)
+
+| Service | File | Responsibilities |
+|---------|------|-----------------|
+| DiscussionService | `ServiceLayer/DiscussionService.py` (~567 lines) | Discussion CRUD, engagement (vote/react/follow/bookmark), moderation (pin/lock), reporting, admin moderation actions (warn/ban/delete/lock) |
+| ReplyService | `ServiceLayer/ReplyService.py` (~261 lines) | Reply CRUD, accept solution, engagement (vote/react), ban check |
+
+**Key service dependencies:**
+- `DiscussionService` takes: `discussion_repo`, `reply_repo`, `engagement_repo`, `report_repo`, `user_repo`, `xp_service`, `notification_repo`
+- `ReplyService` takes: `reply_repo`, `discussion_repo`, `engagement_repo`, `user_repo`, `xp_service`
+
+**Admin moderation flow (DiscussionService):**
+1. `_require_admin(token)` — Validates JWT and checks role = admin
+2. `_get_report_target_author_id(report)` — Resolves the author of the reported content
+3. Action method (warn/ban/delete/lock) — Performs the action + marks report as reviewed
+
+**Enrichment pattern for `list_reports()`:**
+- Fetches reports from ReportRepo
+- For each report, fetches reporter user → adds `reporter_username`
+- For each report, resolves target author → adds `target_author_id`, `target_author_username`
+
+### 3.4 API Layer (Controllers)
+
+**File:** `src/Backend/APILayer/DiscussionController.py`
+
+**Router architecture:**
+- `build_discussion_router(discussion_service, reply_service)` returns 4 routers:
+  - `disc_router` — mounted at `/discussions`
+  - `reply_router` — mounted at `/replies`
+  - `puzzle_router` — mounted at `/puzzles/{id}/discussions`
+  - `report_router` — mounted at `/reports`
+
+**Request validation models (Pydantic):**
+- `CreateDiscussionReq`: title, body, category, puzzle_id
+- `UpdateDiscussionReq`: title (opt), body (opt), category (opt)
+- `CreateReplyReq`: body, parent_reply_id (opt)
+- `UpdateReplyReq`: body
+- `VoteReq`: value (+1 or −1)
+- `ReactionReq`: reaction_type
+- `ReportReq`: reason, details (opt)
+- `UpdateReportStatusReq`: status
+
+### 3.5 Wiring in main.py
+
+```python
+# Repos
+discussion_repo = DiscussionRepo(conn)
+reply_repo = ReplyRepo(conn)
+engagement_repo = EngagementRepo(conn)
+report_repo = ReportRepo(conn)
+
+# Services
+discussion_service = DiscussionService(
+    discussion_repo, reply_repo, engagement_repo,
+    report_repo, user_repo, xp_service,
+    notification_repo=notification_repo
+)
+reply_service = ReplyService(
+    reply_repo, discussion_repo, engagement_repo,
+    user_repo, xp_service
+)
+
+# Routers
+disc_router, reply_router, puzzle_router, report_router = build_discussion_router(
+    discussion_service, reply_service
+)
+app.include_router(disc_router)
+app.include_router(reply_router)
+app.include_router(puzzle_router)
+app.include_router(report_router)
+```
+
+## 4. Frontend Design
+
+### 4.1 Feature Structure
+
+```
+src/features/discussions/
+├── api/
+│   ├── get-discussions.ts       # useDiscussions() query hook
+│   ├── get-discussion.ts        # useDiscussion(id) query hook
+│   ├── create-discussion.ts     # useCreateDiscussion() mutation
+│   ├── update-discussion.ts     # useUpdateDiscussion() mutation
+│   ├── delete-discussion.ts     # useDeleteDiscussion() mutation
+│   ├── vote-discussion.ts       # useVoteDiscussion() mutation
+│   ├── react-discussion.ts      # useReactDiscussion() mutation
+│   ├── follow-discussion.ts     # useFollowDiscussion() mutation
+│   ├── bookmark-discussion.ts   # useBookmarkDiscussion() mutation
+│   ├── report-discussion.ts     # useReportDiscussion() mutation
+│   ├── create-reply.ts          # useCreateReply() mutation
+│   ├── delete-reply.ts          # useDeleteReply() mutation
+│   ├── accept-reply.ts          # useAcceptReply() mutation
+│   ├── vote-reply.ts            # useVoteReply() mutation
+│   ├── react-reply.ts           # useReactReply() mutation
+│   └── report-reply.ts          # useReportReply() mutation
+└── components/
+    ├── discussion-view.tsx       # Full discussion detail view
+    ├── discussions-list.tsx      # Paginated list with filters
+    ├── discussion-card.tsx       # Card in list view
+    ├── create-discussion.tsx     # Create form
+    ├── update-discussion.tsx     # Edit form
+    ├── delete-discussion.tsx     # Delete confirmation dialog
+    ├── reply-tree.tsx            # Nested reply rendering (3 levels)
+    ├── reply-item.tsx            # Single reply with engagement
+    ├── reply-composer.tsx        # Reply creation form
+    ├── vote-buttons.tsx          # Upvote/downvote UI
+    ├── reaction-picker.tsx       # Reaction emoji picker
+    ├── report-dialog.tsx         # Report form dialog
+    ├── category-badge.tsx        # Category label badge
+    └── user-badge.tsx            # Author info badge (username, level)
+```
+
+### 4.2 Admin Feature Structure
+
+```
+src/features/admin/
+├── api/
+│   ├── get-reports.ts            # useReports({ status }) query hook
+│   ├── update-report-status.ts   # useUpdateReportStatus() mutation
+│   └── report-actions.ts         # useWarnReportAuthor(), useBanReportAuthor(),
+│                                 # useDeleteReportedContent(), useLockReportedDiscussion()
+└── components/
+    └── reports-list.tsx           # Reports tab with status filters + action buttons
+```
+
+### 4.3 Page Routes
+
+```
+src/app/app/discussions/
+├── page.tsx                      # /app/discussions — List page
+├── new/page.tsx                  # /app/discussions/new — Create page
+└── [id]/page.tsx                 # /app/discussions/{id} — Detail page
+
+src/app/app/users/
+└── _components/admin-panel.tsx   # Admin panel with Reports tab (Tab type includes 'reports')
+
+src/app/public/discussions/
+└── [discussionId]/page.tsx       # Public discussion view
+```
+
+### 4.4 TypeScript Types
+
+**In `src/types/api.ts`:**
+```typescript
+type Discussion = Entity & {
+  title: string; body: string; author_id: number; puzzle_id?: number;
+  category: ThreadCategory; is_pinned: boolean; is_locked: boolean;
+  view_count: number; reply_count: number; upvotes: number;
+  accepted_reply_id?: number; author?: User; engagement?: DiscussionEngagement;
+  replies?: Reply[];
+};
+
+type Reply = Entity & {
+  discussion_id: number; author_id: number; body: string;
+  parent_reply_id?: number; upvotes: number; downvotes: number;
+  is_accepted: boolean; author?: User; engagement?: ReplyEngagement;
+  children?: Reply[];
+};
+
+type DiscussionEngagement = {
+  upvotes: number; downvotes: number; user_vote: number | null;
+  reactions: ReactionCount[]; user_reactions: string[];
+  is_following: boolean; is_bookmarked: boolean;
+};
+
+type ReplyEngagement = {
+  upvotes: number; downvotes: number; user_vote: number | null;
+  reactions: ReactionCount[]; user_reactions: string[];
+};
+
+type Report = {
+  id: number; reporter_id: number; reporter_username?: string;
+  target_type: 'discussion' | 'reply'; target_id: number;
+  target_author_id?: number; target_author_username?: string;
+  reason: string; details: string;
+  status: 'pending' | 'reviewed' | 'dismissed'; created_at: string;
+};
+
+type ThreadCategory = 'general' | 'puzzle_help' | 'puzzle_tips' | 'solutions' |
+  'bug_report' | 'feature_request' | 'showcase';
+
+type ReactionType = 'insightful' | 'helpful' | 'genius' | 'spot_on' | 'thinking';
+```
+
+### 4.5 Notification System Design
+
+**Store (`notifications-store.ts`):**
+- Zustand store with `Notification` type including optional `persistent?: boolean` flag
+- `addNotification()` — adds to array with nanoid
+- `dismissNotification()` — removes by id
+
+**Toast Component (`notification.tsx`):**
+- Auto-dismiss after 5 seconds by default
+- If `persistent: true` — skips the auto-dismiss timer; requires manual X button click
+
+**Creator Notifications Popup (`creator-notifications-popup.tsx`):**
+- Mounts via `AuthGate` on all authenticated pages
+- On mount: fetches `GET /users/me/notifications` (unread)
+- De-duplicates using `localStorage` key `escapecircuit_shown_notifications`
+- Maps notification types to toast styles:
+  - `'solve'` → "Puzzle Solved!" / success / auto-dismiss
+  - `'rating'` → "New Rating!" / info / auto-dismiss
+  - `'warning'` → "Warning" / warning (yellow icon) / **persistent**
+  - `'ban'` → "Account Restriction" / error (red icon) / **persistent**
+- Marks all as read after displaying via `PATCH /users/me/notifications/read`
+- Staggers multiple toasts by 600ms
+
+### 4.6 Admin Reports UI Design
+
+**Reports List Component (`reports-list.tsx`):**
+- Status filter tabs: All | Pending | Reviewed | Dismissed
+- Each report card shows:
+  - Reason badge (color-coded: spam=red, harassment=dark red, off_topic=yellow, inappropriate=orange, other=gray)
+  - Status badge (pending=yellow, reviewed=green, dismissed=gray)
+  - Timestamp
+  - Target type + clickable `<Link>` to `/app/discussions/{target_id}`
+  - Author username and Reporter username
+  - Details text
+- **For pending reports only**, action buttons:
+  - "Mark Reviewed" / "Dismiss" — status change buttons
+  - Separator line
+  - "Warn Author" — amber button with AlertTriangle icon, fires immediately
+  - "Lock" — blue button with Lock icon (only visible for discussion-type targets)
+  - "Delete Content" — red button with Trash2 icon, wrapped in `ConfirmationDialog`
+  - "Ban Author" — red button with Ban icon, wrapped in `ConfirmationDialog`
+- All action mutations invalidate `['admin-reports']` query key on success
+- Success notifications via Zustand toast store
+
+## 5. Test Coverage
+
+**107 tests across 7 test files:**
+
+| Test File | Layer | Coverage |
+|-----------|-------|----------|
+| `test_discussion_repo.py` | Persistence | CRUD, filtering, sorting, pagination, search |
+| `test_reply_repo.py` | Persistence | CRUD, threading, vote updates, accepted replies |
+| `test_engagement_repo.py` | Persistence | All engagement operations (votes, reactions, follows, bookmarks) |
+| `test_report_repo.py` | Persistence | Report creation, uniqueness constraint, status updates |
+| `test_discussion_search.py` | Persistence | Full-text search edge cases |
+| `test_discussion_service.py` | Service | Discussion CRUD + engagement + reporting + admin moderation |
+| `test_reply_service.py` | Service | Reply CRUD + solution acceptance + engagement |
+
+## 6. Integration Points with Existing System
+
+| Integration | How |
+|-------------|-----|
+| XP/Leveling System | `XPService.award_xp()` called on create, vote, react, accept solution |
+| User Authentication | JWT token validation via existing `UserService.get_current_user()` |
+| Admin Authorization | Role check via `user.role == UserRole.ADMIN` |
+| Notification System | Reuses existing `creator_notifications` table and `NotificationRepo` |
+| User Profiles | `user-badge.tsx` displays author info using User type from auth system |
+| Admin Panel | Reports tab added alongside existing Users, Puzzles, Audit Log tabs |
+| Navigation | Discussion link added to main app sidebar/navigation |

--- a/src/Backend/APILayer/DiscussionController.py
+++ b/src/Backend/APILayer/DiscussionController.py
@@ -1,0 +1,296 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from Backend.DomainLayer.Exceptions import ValidationError
+from Backend.ServiceLayer.DiscussionService import DiscussionService
+from Backend.ServiceLayer.ReplyService import ReplyService
+from Backend.APILayer.auth_utils import verify_token
+
+
+class CreateDiscussionReq(BaseModel):
+    title: str
+    body: str
+    category: str = "general"
+    puzzle_id: Optional[int] = None
+
+
+class UpdateDiscussionReq(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+    category: Optional[str] = None
+
+
+class CreateReplyReq(BaseModel):
+    body: str
+    parent_reply_id: Optional[int] = None
+
+
+class UpdateReplyReq(BaseModel):
+    body: str
+
+
+class VoteReq(BaseModel):
+    value: int  # +1 or -1
+
+
+class ReactionReq(BaseModel):
+    reaction_type: str
+
+
+class ReportReq(BaseModel):
+    reason: str
+    details: str = ""
+
+
+class UpdateReportStatusReq(BaseModel):
+    status: str
+
+
+def build_discussion_router(
+    discussion_service: DiscussionService,
+    reply_service: ReplyService,
+) -> APIRouter:
+    router = APIRouter(prefix="/discussions", tags=["discussions"])
+
+    # ---- Discussion CRUD ----
+
+    @router.get("")
+    def list_discussions(
+        limit: int = 20,
+        offset: int = 0,
+        category: Optional[str] = None,
+        puzzle_id: Optional[int] = None,
+        author_id: Optional[int] = None,
+        sort: str = "newest",
+        search: Optional[str] = None,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return discussion_service.list_discussions(
+                token,
+                limit=limit,
+                offset=offset,
+                category=category,
+                puzzle_id=puzzle_id,
+                author_id=author_id,
+                sort_by=sort,
+                search=search,
+            )
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.post("")
+    def create_discussion(req: CreateDiscussionReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.create_discussion(token, req.model_dump())
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.get("/{discussion_id}")
+    def get_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.get_discussion(token, discussion_id)
+        except ValidationError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+
+    @router.patch("/{discussion_id}")
+    def update_discussion(
+        discussion_id: int,
+        req: UpdateDiscussionReq,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            payload = {k: v for k, v in req.model_dump().items() if v is not None}
+            return discussion_service.update_discussion(token, discussion_id, payload)
+        except ValidationError as e:
+            code = 403 if "not allowed" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @router.delete("/{discussion_id}")
+    def delete_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.delete_discussion(token, discussion_id)
+        except ValidationError as e:
+            code = 403 if "not allowed" in str(e).lower() else 404
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @router.post("/{discussion_id}/pin")
+    def pin_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.pin_discussion(token, discussion_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 404
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @router.post("/{discussion_id}/lock")
+    def lock_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.lock_discussion(token, discussion_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 404
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # ---- Engagement: Discussion ----
+
+    @router.post("/{discussion_id}/vote")
+    def vote_discussion(discussion_id: int, req: VoteReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.vote_discussion(token, discussion_id, req.value)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.post("/{discussion_id}/react")
+    def react_to_discussion(discussion_id: int, req: ReactionReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.react_to_discussion(token, discussion_id, req.reaction_type)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.post("/{discussion_id}/follow")
+    def follow_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.follow_discussion(token, discussion_id)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.post("/{discussion_id}/bookmark")
+    def bookmark_discussion(discussion_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.bookmark_discussion(token, discussion_id)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    # ---- Reports: Discussion ----
+
+    @router.post("/{discussion_id}/report")
+    def report_discussion(discussion_id: int, req: ReportReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.report_discussion(token, discussion_id, req.reason, req.details)
+        except ValidationError as e:
+            code = 400
+            if "already reported" in str(e).lower():
+                code = 409
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # ---- Replies ----
+
+    @router.get("/{discussion_id}/replies")
+    def get_replies(
+        discussion_id: int,
+        limit: int = 100,
+        offset: int = 0,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return reply_service.get_replies(token, discussion_id, limit=limit, offset=offset)
+        except ValidationError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+
+    @router.post("/{discussion_id}/replies")
+    def create_reply(
+        discussion_id: int,
+        req: CreateReplyReq,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return reply_service.create_reply(token, discussion_id, req.model_dump())
+        except ValidationError as e:
+            code = 403 if "locked" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # Reply-level endpoints (outside /discussions prefix)
+    reply_router = APIRouter(prefix="/replies", tags=["replies"])
+
+    @reply_router.patch("/{reply_id}")
+    def update_reply(reply_id: int, req: UpdateReplyReq, token: str = Depends(verify_token)):
+        try:
+            return reply_service.update_reply(token, reply_id, req.model_dump())
+        except ValidationError as e:
+            code = 403 if "not allowed" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @reply_router.delete("/{reply_id}")
+    def delete_reply(reply_id: int, token: str = Depends(verify_token)):
+        try:
+            return reply_service.delete_reply(token, reply_id)
+        except ValidationError as e:
+            code = 403 if "not allowed" in str(e).lower() else 404
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @reply_router.post("/{reply_id}/accept")
+    def accept_reply(reply_id: int, token: str = Depends(verify_token)):
+        try:
+            return reply_service.accept_reply(token, reply_id)
+        except ValidationError as e:
+            code = 403 if "not allowed" in str(e).lower() or "only" in str(e).lower() else 404
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # ---- Engagement: Reply ----
+
+    @reply_router.post("/{reply_id}/vote")
+    def vote_reply(reply_id: int, req: VoteReq, token: str = Depends(verify_token)):
+        try:
+            return reply_service.vote_reply(token, reply_id, req.value)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @reply_router.post("/{reply_id}/react")
+    def react_to_reply(reply_id: int, req: ReactionReq, token: str = Depends(verify_token)):
+        try:
+            return reply_service.react_to_reply(token, reply_id, req.reaction_type)
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @reply_router.post("/{reply_id}/report")
+    def report_reply(reply_id: int, req: ReportReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.report_reply(token, reply_id, req.reason, req.details)
+        except ValidationError as e:
+            code = 409 if "already reported" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # ---- Reports: Admin ----
+    report_router = APIRouter(prefix="/reports", tags=["reports"])
+
+    @report_router.get("")
+    def list_reports(
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return discussion_service.list_reports(token, status=status, limit=limit, offset=offset)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @report_router.patch("/{report_id}")
+    def update_report(report_id: int, req: UpdateReportStatusReq, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.update_report_status(token, report_id, req.status)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    # Puzzle discussions endpoint
+    puzzle_router = APIRouter(prefix="/puzzles", tags=["puzzles"])
+
+    @puzzle_router.get("/{puzzle_id}/discussions")
+    def get_puzzle_discussions(
+        puzzle_id: int,
+        limit: int = 20,
+        offset: int = 0,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return discussion_service.list_discussions(
+                token, limit=limit, offset=offset, puzzle_id=puzzle_id
+            )
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    # Return all routers - they'll be included separately
+    return router, reply_router, puzzle_router, report_router

--- a/src/Backend/APILayer/DiscussionController.py
+++ b/src/Backend/APILayer/DiscussionController.py
@@ -275,6 +275,38 @@ def build_discussion_router(
             code = 403 if "admin" in str(e).lower() else 400
             raise HTTPException(status_code=code, detail=str(e))
 
+    @report_router.post("/{report_id}/warn")
+    def warn_report_author(report_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.warn_user_for_report(token, report_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @report_router.post("/{report_id}/ban")
+    def ban_report_author(report_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.ban_user_for_report(token, report_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @report_router.post("/{report_id}/delete-content")
+    def delete_reported_content(report_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.delete_reported_content(token, report_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
+    @report_router.post("/{report_id}/lock")
+    def lock_reported_discussion(report_id: int, token: str = Depends(verify_token)):
+        try:
+            return discussion_service.lock_reported_discussion(token, report_id)
+        except ValidationError as e:
+            code = 403 if "admin" in str(e).lower() else 400
+            raise HTTPException(status_code=code, detail=str(e))
+
     # Puzzle discussions endpoint
     puzzle_router = APIRouter(prefix="/puzzles", tags=["puzzles"])
 

--- a/src/Backend/DomainLayer/Discussion.py
+++ b/src/Backend/DomainLayer/Discussion.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from .Enums import ThreadCategory
+from .Exceptions import ValidationError
+from .Utils import utcnow, ensure_non_empty, ensure_non_negative_int
+
+
+@dataclass(slots=True)
+class Discussion:
+    id: int
+    title: str
+    body: str
+    author_id: int
+    puzzle_id: Optional[int] = None
+    category: ThreadCategory = ThreadCategory.GENERAL
+    is_pinned: bool = False
+    is_locked: bool = False
+    view_count: int = 0
+    reply_count: int = 0
+    upvotes: int = 0
+    accepted_reply_id: Optional[int] = None
+    created_at: datetime = field(default_factory=utcnow)
+    updated_at: datetime = field(default_factory=utcnow)
+
+    def __post_init__(self) -> None:
+        self.id = ensure_non_negative_int("Discussion.id", self.id)
+        self.author_id = ensure_non_negative_int("Discussion.author_id", self.author_id)
+        ensure_non_empty("Discussion.title", self.title)
+        ensure_non_empty("Discussion.body", self.body)
+        if self.puzzle_id is not None:
+            self.puzzle_id = ensure_non_negative_int("Discussion.puzzle_id", self.puzzle_id)
+        if not isinstance(self.category, ThreadCategory):
+            self.category = ThreadCategory(self.category)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "title": self.title,
+            "body": self.body,
+            "author_id": self.author_id,
+            "puzzle_id": self.puzzle_id,
+            "category": self.category.value,
+            "is_pinned": self.is_pinned,
+            "is_locked": self.is_locked,
+            "view_count": self.view_count,
+            "reply_count": self.reply_count,
+            "upvotes": self.upvotes,
+            "accepted_reply_id": self.accepted_reply_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "createdAt": int(self.created_at.timestamp() * 1000),
+        }
+
+    @staticmethod
+    def from_dict(d: dict) -> "Discussion":
+        from datetime import datetime as dt
+        return Discussion(
+            id=int(d.get("id", 0)),
+            title=d["title"],
+            body=d["body"],
+            author_id=int(d["author_id"]),
+            puzzle_id=int(d["puzzle_id"]) if d.get("puzzle_id") is not None else None,
+            category=ThreadCategory(d.get("category", "general")),
+            is_pinned=bool(d.get("is_pinned", False)),
+            is_locked=bool(d.get("is_locked", False)),
+            view_count=int(d.get("view_count", 0)),
+            reply_count=int(d.get("reply_count", 0)),
+            upvotes=int(d.get("upvotes", 0)),
+            accepted_reply_id=int(d["accepted_reply_id"]) if d.get("accepted_reply_id") is not None else None,
+            created_at=dt.fromisoformat(d["created_at"]) if "created_at" in d else utcnow(),
+            updated_at=dt.fromisoformat(d["updated_at"]) if "updated_at" in d else utcnow(),
+        )

--- a/src/Backend/DomainLayer/Enums.py
+++ b/src/Backend/DomainLayer/Enums.py
@@ -51,4 +51,21 @@ class GateType(str, Enum):
 
     # Special gate types - flip flop
     DFF = "DFF"
-    
+
+
+class ThreadCategory(str, Enum):
+    GENERAL = "general"
+    PUZZLE_HELP = "puzzle_help"
+    PUZZLE_TIPS = "puzzle_tips"
+    SOLUTIONS = "solutions"
+    BUG_REPORT = "bug_report"
+    FEATURE_REQUEST = "feature_request"
+    SHOWCASE = "showcase"
+
+
+class ReactionType(str, Enum):
+    INSIGHTFUL = "insightful"
+    HELPFUL = "helpful"
+    GENIUS = "genius"
+    SPOT_ON = "spot_on"
+    THINKING = "thinking"

--- a/src/Backend/DomainLayer/Reply.py
+++ b/src/Backend/DomainLayer/Reply.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from .Exceptions import ValidationError
+from .Utils import utcnow, ensure_non_empty, ensure_non_negative_int
+
+
+@dataclass(slots=True)
+class Reply:
+    id: int
+    discussion_id: int
+    author_id: int
+    body: str
+    parent_reply_id: Optional[int] = None
+    upvotes: int = 0
+    downvotes: int = 0
+    is_accepted: bool = False
+    created_at: datetime = field(default_factory=utcnow)
+    updated_at: datetime = field(default_factory=utcnow)
+
+    def __post_init__(self) -> None:
+        self.id = ensure_non_negative_int("Reply.id", self.id)
+        self.discussion_id = ensure_non_negative_int("Reply.discussion_id", self.discussion_id)
+        self.author_id = ensure_non_negative_int("Reply.author_id", self.author_id)
+        ensure_non_empty("Reply.body", self.body)
+        if self.parent_reply_id is not None:
+            self.parent_reply_id = ensure_non_negative_int("Reply.parent_reply_id", self.parent_reply_id)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "discussion_id": self.discussion_id,
+            "parent_reply_id": self.parent_reply_id,
+            "author_id": self.author_id,
+            "body": self.body,
+            "upvotes": self.upvotes,
+            "downvotes": self.downvotes,
+            "is_accepted": self.is_accepted,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "createdAt": int(self.created_at.timestamp() * 1000),
+        }
+
+    @staticmethod
+    def from_dict(d: dict) -> "Reply":
+        from datetime import datetime as dt
+        return Reply(
+            id=int(d.get("id", 0)),
+            discussion_id=int(d["discussion_id"]),
+            author_id=int(d["author_id"]),
+            body=d["body"],
+            parent_reply_id=int(d["parent_reply_id"]) if d.get("parent_reply_id") is not None else None,
+            upvotes=int(d.get("upvotes", 0)),
+            downvotes=int(d.get("downvotes", 0)),
+            is_accepted=bool(d.get("is_accepted", False)),
+            created_at=dt.fromisoformat(d["created_at"]) if "created_at" in d else utcnow(),
+            updated_at=dt.fromisoformat(d["updated_at"]) if "updated_at" in d else utcnow(),
+        )

--- a/src/Backend/DomainLayer/User.py
+++ b/src/Backend/DomainLayer/User.py
@@ -8,12 +8,13 @@ from .Utils import utcnow, ensure_non_empty, ensure_non_negative_int
 
 @dataclass(slots=True)
 class User:
-    id: int 
+    id: int
     username: str
     email: str = ""
     role: UserRole = UserRole.SOLVER
     bio: str = ""
     xp: int = 0
+    is_discussion_banned: bool = False
     created_at: datetime = field(default_factory=utcnow)
 
     def __post_init__(self) -> None:
@@ -46,6 +47,7 @@ class User:
             "bio": self.bio,
             "xp": self.xp,
             "level": self.level,
+            "is_discussion_banned": self.is_discussion_banned,
             "created_at": self.created_at.isoformat(),
             "createdAt": int(self.created_at.timestamp() * 1000),
         }
@@ -60,6 +62,7 @@ class User:
             role=UserRole(d.get("role", UserRole.SOLVER.value)),
             bio=d.get("bio", ""),
             xp=int(d.get("xp", 0)),
+            is_discussion_banned=bool(d.get("is_discussion_banned", False)),
             created_at=datetime.fromisoformat(d["created_at"]) if "created_at" in d else utcnow(),
         )
 

--- a/src/Backend/PersistantLayer/DiscussionRepo.py
+++ b/src/Backend/PersistantLayer/DiscussionRepo.py
@@ -1,0 +1,216 @@
+import sqlite3
+from typing import Optional, List
+
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Utils import utcnow
+
+
+class DiscussionRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute("""
+        CREATE TABLE IF NOT EXISTS discussions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author_id INTEGER NOT NULL REFERENCES users(id),
+            puzzle_id INTEGER REFERENCES puzzles(id),
+            category TEXT NOT NULL DEFAULT 'general',
+            is_pinned INTEGER NOT NULL DEFAULT 0,
+            is_locked INTEGER NOT NULL DEFAULT 0,
+            view_count INTEGER NOT NULL DEFAULT 0,
+            reply_count INTEGER NOT NULL DEFAULT 0,
+            upvotes INTEGER NOT NULL DEFAULT 0,
+            accepted_reply_id INTEGER,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        """)
+
+    def create(self, discussion: Discussion) -> Discussion:
+        cur = self.conn.execute("""
+            INSERT INTO discussions(title, body, author_id, puzzle_id, category,
+                is_pinned, is_locked, view_count, reply_count, upvotes,
+                accepted_reply_id, created_at, updated_at)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """, (
+            discussion.title,
+            discussion.body,
+            int(discussion.author_id),
+            int(discussion.puzzle_id) if discussion.puzzle_id is not None else None,
+            discussion.category.value,
+            1 if discussion.is_pinned else 0,
+            1 if discussion.is_locked else 0,
+            discussion.view_count,
+            discussion.reply_count,
+            discussion.upvotes,
+            int(discussion.accepted_reply_id) if discussion.accepted_reply_id is not None else None,
+            discussion.created_at.isoformat(),
+            discussion.updated_at.isoformat(),
+        ))
+        self.conn.commit()
+        discussion.id = int(cur.lastrowid)
+        return discussion
+
+    def get_by_id(self, discussion_id: int) -> Optional[Discussion]:
+        row = self.conn.execute(
+            "SELECT * FROM discussions WHERE id=?", (int(discussion_id),)
+        ).fetchone()
+        return self._row_to_discussion(row) if row else None
+
+    def list_all(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+        category: Optional[str] = None,
+        puzzle_id: Optional[int] = None,
+        author_id: Optional[int] = None,
+        sort_by: str = "newest",
+        search: Optional[str] = None,
+    ) -> List[Discussion]:
+        where_clauses = []
+        params: list = []
+
+        if category:
+            where_clauses.append("category = ?")
+            params.append(category)
+        if puzzle_id is not None:
+            where_clauses.append("puzzle_id = ?")
+            params.append(int(puzzle_id))
+        if author_id is not None:
+            where_clauses.append("author_id = ?")
+            params.append(int(author_id))
+        if search:
+            where_clauses.append("(title LIKE ? OR body LIKE ?)")
+            pattern = f"%{search}%"
+            params.extend([pattern, pattern])
+
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+        order_map = {
+            "newest": "created_at DESC",
+            "oldest": "created_at ASC",
+            "most_replies": "reply_count DESC, created_at DESC",
+            "most_upvotes": "upvotes DESC, created_at DESC",
+            "trending": "(upvotes * 3 + reply_count * 2 + view_count * 0.5) / MAX(1.0, (julianday('now') - julianday(created_at)) * 24) DESC",
+        }
+        order_clause = order_map.get(sort_by, "created_at DESC")
+
+        # Pinned first, then by sort order
+        query = f"""
+            SELECT * FROM discussions {where_sql}
+            ORDER BY is_pinned DESC, {order_clause}
+            LIMIT ? OFFSET ?
+        """
+        params.extend([limit, offset])
+        rows = self.conn.execute(query, params).fetchall()
+        return [self._row_to_discussion(r) for r in rows]
+
+    def count(
+        self,
+        category: Optional[str] = None,
+        puzzle_id: Optional[int] = None,
+        author_id: Optional[int] = None,
+        search: Optional[str] = None,
+    ) -> int:
+        where_clauses = []
+        params: list = []
+
+        if category:
+            where_clauses.append("category = ?")
+            params.append(category)
+        if puzzle_id is not None:
+            where_clauses.append("puzzle_id = ?")
+            params.append(int(puzzle_id))
+        if author_id is not None:
+            where_clauses.append("author_id = ?")
+            params.append(int(author_id))
+        if search:
+            where_clauses.append("(title LIKE ? OR body LIKE ?)")
+            pattern = f"%{search}%"
+            params.extend([pattern, pattern])
+
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        row = self.conn.execute(
+            f"SELECT COUNT(*) FROM discussions {where_sql}", params
+        ).fetchone()
+        return row[0] if row else 0
+
+    def update(self, discussion_id: int, fields: dict) -> Optional[Discussion]:
+        allowed = {"title", "body", "category", "is_pinned", "is_locked", "upvotes", "updated_at"}
+        set_clauses = []
+        params: list = []
+        for key, value in fields.items():
+            if key not in allowed:
+                continue
+            if key in ("is_pinned", "is_locked"):
+                value = 1 if value else 0
+            set_clauses.append(f"{key} = ?")
+            params.append(value)
+
+        if not set_clauses:
+            return self.get_by_id(discussion_id)
+
+        # Always update updated_at
+        if "updated_at" not in fields:
+            set_clauses.append("updated_at = ?")
+            params.append(utcnow().isoformat())
+
+        params.append(int(discussion_id))
+        self.conn.execute(
+            f"UPDATE discussions SET {', '.join(set_clauses)} WHERE id = ?", params
+        )
+        self.conn.commit()
+        return self.get_by_id(discussion_id)
+
+    def delete(self, discussion_id: int) -> bool:
+        cur = self.conn.execute(
+            "DELETE FROM discussions WHERE id=?", (int(discussion_id),)
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def increment_view_count(self, discussion_id: int) -> None:
+        self.conn.execute(
+            "UPDATE discussions SET view_count = view_count + 1 WHERE id = ?",
+            (int(discussion_id),),
+        )
+        self.conn.commit()
+
+    def increment_reply_count(self, discussion_id: int, delta: int = 1) -> None:
+        self.conn.execute(
+            "UPDATE discussions SET reply_count = reply_count + ? WHERE id = ?",
+            (delta, int(discussion_id)),
+        )
+        self.conn.commit()
+
+    def set_accepted_reply(self, discussion_id: int, reply_id: Optional[int]) -> None:
+        self.conn.execute(
+            "UPDATE discussions SET accepted_reply_id = ? WHERE id = ?",
+            (int(reply_id) if reply_id is not None else None, int(discussion_id)),
+        )
+        self.conn.commit()
+
+    @staticmethod
+    def _row_to_discussion(row: sqlite3.Row) -> Discussion:
+        return Discussion.from_dict({
+            "id": int(row["id"]),
+            "title": row["title"],
+            "body": row["body"],
+            "author_id": int(row["author_id"]),
+            "puzzle_id": int(row["puzzle_id"]) if row["puzzle_id"] is not None else None,
+            "category": row["category"],
+            "is_pinned": bool(int(row["is_pinned"])),
+            "is_locked": bool(int(row["is_locked"])),
+            "view_count": int(row["view_count"]),
+            "reply_count": int(row["reply_count"]),
+            "upvotes": int(row["upvotes"]),
+            "accepted_reply_id": int(row["accepted_reply_id"]) if row["accepted_reply_id"] is not None else None,
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        })

--- a/src/Backend/PersistantLayer/DiscussionRepo.py
+++ b/src/Backend/PersistantLayer/DiscussionRepo.py
@@ -86,8 +86,10 @@ class DiscussionRepo:
             where_clauses.append("author_id = ?")
             params.append(int(author_id))
         if search:
-            where_clauses.append("(title LIKE ? OR body LIKE ?)")
-            pattern = f"%{search}%"
+            # Escape SQL wildcard characters in the user's search term
+            escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            where_clauses.append("(title LIKE ? ESCAPE '\\' OR body LIKE ? ESCAPE '\\')")
+            pattern = f"%{escaped}%"
             params.extend([pattern, pattern])
 
         where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
@@ -131,8 +133,10 @@ class DiscussionRepo:
             where_clauses.append("author_id = ?")
             params.append(int(author_id))
         if search:
-            where_clauses.append("(title LIKE ? OR body LIKE ?)")
-            pattern = f"%{search}%"
+            # Escape SQL wildcard characters in the user's search term
+            escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            where_clauses.append("(title LIKE ? ESCAPE '\\' OR body LIKE ? ESCAPE '\\')")
+            pattern = f"%{escaped}%"
             params.extend([pattern, pattern])
 
         where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""

--- a/src/Backend/PersistantLayer/EngagementRepo.py
+++ b/src/Backend/PersistantLayer/EngagementRepo.py
@@ -1,0 +1,366 @@
+import sqlite3
+from typing import Optional, List, Dict
+
+from Backend.DomainLayer.Utils import utcnow
+
+
+class EngagementRepo:
+    """Handles votes, reactions, follows, and bookmarks for discussions and replies."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.executescript("""
+        CREATE TABLE IF NOT EXISTS discussion_votes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            value INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(discussion_id, user_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS reply_votes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            reply_id INTEGER NOT NULL REFERENCES replies(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            value INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(reply_id, user_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS discussion_reactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            reaction_type TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(discussion_id, user_id, reaction_type)
+        );
+
+        CREATE TABLE IF NOT EXISTS reply_reactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            reply_id INTEGER NOT NULL REFERENCES replies(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            reaction_type TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(reply_id, user_id, reaction_type)
+        );
+
+        CREATE TABLE IF NOT EXISTS discussion_follows (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            created_at TEXT NOT NULL,
+            UNIQUE(discussion_id, user_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS discussion_bookmarks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            created_at TEXT NOT NULL,
+            UNIQUE(discussion_id, user_id)
+        );
+        """)
+
+    # ---- Discussion Votes ----
+
+    def get_discussion_vote(self, discussion_id: int, user_id: int) -> Optional[int]:
+        row = self.conn.execute(
+            "SELECT value FROM discussion_votes WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchone()
+        return int(row["value"]) if row else None
+
+    def set_discussion_vote(self, discussion_id: int, user_id: int, value: int) -> Optional[int]:
+        """Set vote (+1 or -1). Returns the new value, or None if removed (toggle)."""
+        existing = self.get_discussion_vote(discussion_id, user_id)
+        now = utcnow().isoformat()
+
+        if existing == value:
+            # Same vote again -> remove it
+            self.conn.execute(
+                "DELETE FROM discussion_votes WHERE discussion_id=? AND user_id=?",
+                (int(discussion_id), int(user_id)),
+            )
+            self.conn.commit()
+            return None
+        elif existing is not None:
+            # Different vote -> update
+            self.conn.execute(
+                "UPDATE discussion_votes SET value=?, created_at=? WHERE discussion_id=? AND user_id=?",
+                (value, now, int(discussion_id), int(user_id)),
+            )
+        else:
+            # No existing vote -> insert
+            self.conn.execute(
+                "INSERT INTO discussion_votes(discussion_id, user_id, value, created_at) VALUES(?,?,?,?)",
+                (int(discussion_id), int(user_id), value, now),
+            )
+        self.conn.commit()
+        return value
+
+    def count_discussion_votes(self, discussion_id: int) -> Dict[str, int]:
+        row = self.conn.execute("""
+            SELECT
+                COALESCE(SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END), 0) as upvotes,
+                COALESCE(SUM(CASE WHEN value = -1 THEN 1 ELSE 0 END), 0) as downvotes
+            FROM discussion_votes WHERE discussion_id=?
+        """, (int(discussion_id),)).fetchone()
+        return {"upvotes": int(row["upvotes"]), "downvotes": int(row["downvotes"])}
+
+    # ---- Reply Votes ----
+
+    def get_reply_vote(self, reply_id: int, user_id: int) -> Optional[int]:
+        row = self.conn.execute(
+            "SELECT value FROM reply_votes WHERE reply_id=? AND user_id=?",
+            (int(reply_id), int(user_id)),
+        ).fetchone()
+        return int(row["value"]) if row else None
+
+    def set_reply_vote(self, reply_id: int, user_id: int, value: int) -> Optional[int]:
+        """Set vote (+1 or -1). Returns the new value, or None if removed (toggle)."""
+        existing = self.get_reply_vote(reply_id, user_id)
+        now = utcnow().isoformat()
+
+        if existing == value:
+            self.conn.execute(
+                "DELETE FROM reply_votes WHERE reply_id=? AND user_id=?",
+                (int(reply_id), int(user_id)),
+            )
+            self.conn.commit()
+            return None
+        elif existing is not None:
+            self.conn.execute(
+                "UPDATE reply_votes SET value=?, created_at=? WHERE reply_id=? AND user_id=?",
+                (value, now, int(reply_id), int(user_id)),
+            )
+        else:
+            self.conn.execute(
+                "INSERT INTO reply_votes(reply_id, user_id, value, created_at) VALUES(?,?,?,?)",
+                (int(reply_id), int(user_id), value, now),
+            )
+        self.conn.commit()
+        return value
+
+    def count_reply_votes(self, reply_id: int) -> Dict[str, int]:
+        row = self.conn.execute("""
+            SELECT
+                COALESCE(SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END), 0) as upvotes,
+                COALESCE(SUM(CASE WHEN value = -1 THEN 1 ELSE 0 END), 0) as downvotes
+            FROM reply_votes WHERE reply_id=?
+        """, (int(reply_id),)).fetchone()
+        return {"upvotes": int(row["upvotes"]), "downvotes": int(row["downvotes"])}
+
+    # ---- Discussion Reactions ----
+
+    def add_discussion_reaction(self, discussion_id: int, user_id: int, reaction_type: str) -> bool:
+        """Add a reaction. Returns True if added, False if already exists."""
+        now = utcnow().isoformat()
+        try:
+            self.conn.execute(
+                "INSERT INTO discussion_reactions(discussion_id, user_id, reaction_type, created_at) VALUES(?,?,?,?)",
+                (int(discussion_id), int(user_id), reaction_type, now),
+            )
+            self.conn.commit()
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+    def remove_discussion_reaction(self, discussion_id: int, user_id: int, reaction_type: str) -> bool:
+        """Remove a reaction. Returns True if removed."""
+        cur = self.conn.execute(
+            "DELETE FROM discussion_reactions WHERE discussion_id=? AND user_id=? AND reaction_type=?",
+            (int(discussion_id), int(user_id), reaction_type),
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def toggle_discussion_reaction(self, discussion_id: int, user_id: int, reaction_type: str) -> bool:
+        """Toggle a reaction. Returns True if now active, False if removed."""
+        exists = self.conn.execute(
+            "SELECT 1 FROM discussion_reactions WHERE discussion_id=? AND user_id=? AND reaction_type=?",
+            (int(discussion_id), int(user_id), reaction_type),
+        ).fetchone()
+        if exists:
+            self.remove_discussion_reaction(discussion_id, user_id, reaction_type)
+            return False
+        else:
+            self.add_discussion_reaction(discussion_id, user_id, reaction_type)
+            return True
+
+    def get_discussion_reactions(self, discussion_id: int) -> List[Dict]:
+        """Get reaction counts grouped by type."""
+        rows = self.conn.execute("""
+            SELECT reaction_type, COUNT(*) as count
+            FROM discussion_reactions WHERE discussion_id=?
+            GROUP BY reaction_type
+        """, (int(discussion_id),)).fetchall()
+        return [{"type": row["reaction_type"], "count": int(row["count"])} for row in rows]
+
+    def get_user_discussion_reactions(self, discussion_id: int, user_id: int) -> List[str]:
+        """Get the reaction types a specific user has on a discussion."""
+        rows = self.conn.execute(
+            "SELECT reaction_type FROM discussion_reactions WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchall()
+        return [row["reaction_type"] for row in rows]
+
+    # ---- Reply Reactions ----
+
+    def toggle_reply_reaction(self, reply_id: int, user_id: int, reaction_type: str) -> bool:
+        """Toggle a reaction on a reply. Returns True if now active, False if removed."""
+        exists = self.conn.execute(
+            "SELECT 1 FROM reply_reactions WHERE reply_id=? AND user_id=? AND reaction_type=?",
+            (int(reply_id), int(user_id), reaction_type),
+        ).fetchone()
+        now = utcnow().isoformat()
+        if exists:
+            self.conn.execute(
+                "DELETE FROM reply_reactions WHERE reply_id=? AND user_id=? AND reaction_type=?",
+                (int(reply_id), int(user_id), reaction_type),
+            )
+            self.conn.commit()
+            return False
+        else:
+            try:
+                self.conn.execute(
+                    "INSERT INTO reply_reactions(reply_id, user_id, reaction_type, created_at) VALUES(?,?,?,?)",
+                    (int(reply_id), int(user_id), reaction_type, now),
+                )
+                self.conn.commit()
+                return True
+            except sqlite3.IntegrityError:
+                return False
+
+    def get_reply_reactions(self, reply_id: int) -> List[Dict]:
+        rows = self.conn.execute("""
+            SELECT reaction_type, COUNT(*) as count
+            FROM reply_reactions WHERE reply_id=?
+            GROUP BY reaction_type
+        """, (int(reply_id),)).fetchall()
+        return [{"type": row["reaction_type"], "count": int(row["count"])} for row in rows]
+
+    def get_user_reply_reactions(self, reply_id: int, user_id: int) -> List[str]:
+        rows = self.conn.execute(
+            "SELECT reaction_type FROM reply_reactions WHERE reply_id=? AND user_id=?",
+            (int(reply_id), int(user_id)),
+        ).fetchall()
+        return [row["reaction_type"] for row in rows]
+
+    # ---- Discussion Follows ----
+
+    def toggle_follow(self, discussion_id: int, user_id: int) -> bool:
+        """Toggle follow. Returns True if now following, False if unfollowed."""
+        exists = self.conn.execute(
+            "SELECT 1 FROM discussion_follows WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchone()
+        if exists:
+            self.conn.execute(
+                "DELETE FROM discussion_follows WHERE discussion_id=? AND user_id=?",
+                (int(discussion_id), int(user_id)),
+            )
+            self.conn.commit()
+            return False
+        else:
+            now = utcnow().isoformat()
+            self.conn.execute(
+                "INSERT INTO discussion_follows(discussion_id, user_id, created_at) VALUES(?,?,?)",
+                (int(discussion_id), int(user_id), now),
+            )
+            self.conn.commit()
+            return True
+
+    def is_following(self, discussion_id: int, user_id: int) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM discussion_follows WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchone()
+        return row is not None
+
+    def get_follower_ids(self, discussion_id: int) -> List[int]:
+        rows = self.conn.execute(
+            "SELECT user_id FROM discussion_follows WHERE discussion_id=?",
+            (int(discussion_id),),
+        ).fetchall()
+        return [int(row["user_id"]) for row in rows]
+
+    # ---- Discussion Bookmarks ----
+
+    def toggle_bookmark(self, discussion_id: int, user_id: int) -> bool:
+        """Toggle bookmark. Returns True if now bookmarked, False if removed."""
+        exists = self.conn.execute(
+            "SELECT 1 FROM discussion_bookmarks WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchone()
+        if exists:
+            self.conn.execute(
+                "DELETE FROM discussion_bookmarks WHERE discussion_id=? AND user_id=?",
+                (int(discussion_id), int(user_id)),
+            )
+            self.conn.commit()
+            return False
+        else:
+            now = utcnow().isoformat()
+            self.conn.execute(
+                "INSERT INTO discussion_bookmarks(discussion_id, user_id, created_at) VALUES(?,?,?)",
+                (int(discussion_id), int(user_id), now),
+            )
+            self.conn.commit()
+            return True
+
+    def is_bookmarked(self, discussion_id: int, user_id: int) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM discussion_bookmarks WHERE discussion_id=? AND user_id=?",
+            (int(discussion_id), int(user_id)),
+        ).fetchone()
+        return row is not None
+
+    def get_user_bookmarked_ids(self, user_id: int) -> List[int]:
+        rows = self.conn.execute(
+            "SELECT discussion_id FROM discussion_bookmarks WHERE user_id=? ORDER BY created_at DESC",
+            (int(user_id),),
+        ).fetchall()
+        return [int(row["discussion_id"]) for row in rows]
+
+    # ---- Bulk engagement data for a discussion (for get_discussion enrichment) ----
+
+    def get_discussion_engagement(self, discussion_id: int, user_id: int) -> Dict:
+        """Get all engagement data for a discussion for a specific user."""
+        votes = self.count_discussion_votes(discussion_id)
+        user_vote = self.get_discussion_vote(discussion_id, user_id)
+        reactions = self.get_discussion_reactions(discussion_id)
+        user_reactions = self.get_user_discussion_reactions(discussion_id, user_id)
+        is_following = self.is_following(discussion_id, user_id)
+        is_bookmarked = self.is_bookmarked(discussion_id, user_id)
+
+        return {
+            "upvotes": votes["upvotes"],
+            "downvotes": votes["downvotes"],
+            "user_vote": user_vote,
+            "reactions": reactions,
+            "user_reactions": user_reactions,
+            "is_following": is_following,
+            "is_bookmarked": is_bookmarked,
+        }
+
+    def get_reply_engagement(self, reply_id: int, user_id: int) -> Dict:
+        """Get all engagement data for a reply for a specific user."""
+        votes = self.count_reply_votes(reply_id)
+        user_vote = self.get_reply_vote(reply_id, user_id)
+        reactions = self.get_reply_reactions(reply_id)
+        user_reactions = self.get_user_reply_reactions(reply_id, user_id)
+
+        return {
+            "upvotes": votes["upvotes"],
+            "downvotes": votes["downvotes"],
+            "user_vote": user_vote,
+            "reactions": reactions,
+            "user_reactions": user_reactions,
+        }

--- a/src/Backend/PersistantLayer/ReplyRepo.py
+++ b/src/Backend/PersistantLayer/ReplyRepo.py
@@ -1,0 +1,150 @@
+import sqlite3
+from typing import Optional, List
+
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.Utils import utcnow
+
+
+class ReplyRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute("""
+        CREATE TABLE IF NOT EXISTS replies (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discussion_id INTEGER NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+            parent_reply_id INTEGER REFERENCES replies(id) ON DELETE CASCADE,
+            author_id INTEGER NOT NULL REFERENCES users(id),
+            body TEXT NOT NULL,
+            upvotes INTEGER NOT NULL DEFAULT 0,
+            downvotes INTEGER NOT NULL DEFAULT 0,
+            is_accepted INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        """)
+
+    def create(self, reply: Reply) -> Reply:
+        cur = self.conn.execute("""
+            INSERT INTO replies(discussion_id, parent_reply_id, author_id, body,
+                upvotes, downvotes, is_accepted, created_at, updated_at)
+            VALUES(?,?,?,?,?,?,?,?,?)
+        """, (
+            int(reply.discussion_id),
+            int(reply.parent_reply_id) if reply.parent_reply_id is not None else None,
+            int(reply.author_id),
+            reply.body,
+            reply.upvotes,
+            reply.downvotes,
+            1 if reply.is_accepted else 0,
+            reply.created_at.isoformat(),
+            reply.updated_at.isoformat(),
+        ))
+        self.conn.commit()
+        reply.id = int(cur.lastrowid)
+        return reply
+
+    def get_by_id(self, reply_id: int) -> Optional[Reply]:
+        row = self.conn.execute(
+            "SELECT * FROM replies WHERE id=?", (int(reply_id),)
+        ).fetchone()
+        return self._row_to_reply(row) if row else None
+
+    def list_by_discussion(
+        self, discussion_id: int, limit: int = 100, offset: int = 0
+    ) -> List[Reply]:
+        rows = self.conn.execute("""
+            SELECT * FROM replies WHERE discussion_id=?
+            ORDER BY created_at ASC LIMIT ? OFFSET ?
+        """, (int(discussion_id), limit, offset)).fetchall()
+        return [self._row_to_reply(r) for r in rows]
+
+    def list_top_level(
+        self, discussion_id: int, limit: int = 100, offset: int = 0
+    ) -> List[Reply]:
+        rows = self.conn.execute("""
+            SELECT * FROM replies
+            WHERE discussion_id=? AND parent_reply_id IS NULL
+            ORDER BY created_at ASC LIMIT ? OFFSET ?
+        """, (int(discussion_id), limit, offset)).fetchall()
+        return [self._row_to_reply(r) for r in rows]
+
+    def list_children(self, parent_reply_id: int) -> List[Reply]:
+        rows = self.conn.execute("""
+            SELECT * FROM replies WHERE parent_reply_id=?
+            ORDER BY created_at ASC
+        """, (int(parent_reply_id),)).fetchall()
+        return [self._row_to_reply(r) for r in rows]
+
+    def count_by_discussion(self, discussion_id: int) -> int:
+        row = self.conn.execute(
+            "SELECT COUNT(*) FROM replies WHERE discussion_id=?",
+            (int(discussion_id),),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def update(self, reply_id: int, fields: dict) -> Optional[Reply]:
+        allowed = {"body", "is_accepted", "updated_at"}
+        set_clauses = []
+        params: list = []
+        for key, value in fields.items():
+            if key not in allowed:
+                continue
+            if key == "is_accepted":
+                value = 1 if value else 0
+            set_clauses.append(f"{key} = ?")
+            params.append(value)
+
+        if not set_clauses:
+            return self.get_by_id(reply_id)
+
+        if "updated_at" not in fields:
+            set_clauses.append("updated_at = ?")
+            params.append(utcnow().isoformat())
+
+        params.append(int(reply_id))
+        self.conn.execute(
+            f"UPDATE replies SET {', '.join(set_clauses)} WHERE id = ?", params
+        )
+        self.conn.commit()
+        return self.get_by_id(reply_id)
+
+    def delete(self, reply_id: int) -> bool:
+        cur = self.conn.execute(
+            "DELETE FROM replies WHERE id=?", (int(reply_id),)
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def update_votes(self, reply_id: int, upvotes: int, downvotes: int) -> None:
+        self.conn.execute(
+            "UPDATE replies SET upvotes=?, downvotes=? WHERE id=?",
+            (upvotes, downvotes, int(reply_id)),
+        )
+        self.conn.commit()
+
+    def clear_accepted_for_discussion(self, discussion_id: int) -> None:
+        self.conn.execute(
+            "UPDATE replies SET is_accepted=0 WHERE discussion_id=?",
+            (int(discussion_id),),
+        )
+        self.conn.commit()
+
+    @staticmethod
+    def _row_to_reply(row: sqlite3.Row) -> Reply:
+        return Reply.from_dict({
+            "id": int(row["id"]),
+            "discussion_id": int(row["discussion_id"]),
+            "parent_reply_id": int(row["parent_reply_id"]) if row["parent_reply_id"] is not None else None,
+            "author_id": int(row["author_id"]),
+            "body": row["body"],
+            "upvotes": int(row["upvotes"]),
+            "downvotes": int(row["downvotes"]),
+            "is_accepted": bool(int(row["is_accepted"])),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        })

--- a/src/Backend/PersistantLayer/ReportRepo.py
+++ b/src/Backend/PersistantLayer/ReportRepo.py
@@ -1,0 +1,104 @@
+import sqlite3
+from typing import Optional, List, Dict
+
+from Backend.DomainLayer.Utils import utcnow
+
+
+class ReportRepo:
+    """Handles content reports for discussions and replies."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute("""
+        CREATE TABLE IF NOT EXISTS content_reports (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            reporter_id INTEGER NOT NULL REFERENCES users(id),
+            target_type TEXT NOT NULL,
+            target_id INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            details TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at TEXT NOT NULL,
+            UNIQUE(reporter_id, target_type, target_id)
+        );
+        """)
+
+    def create(self, reporter_id: int, target_type: str, target_id: int, reason: str, details: str = "") -> Dict:
+        now = utcnow().isoformat()
+        cur = self.conn.execute("""
+            INSERT INTO content_reports(reporter_id, target_type, target_id, reason, details, status, created_at)
+            VALUES(?,?,?,?,?,?,?)
+        """, (int(reporter_id), target_type, int(target_id), reason, details, "pending", now))
+        self.conn.commit()
+        return {
+            "id": cur.lastrowid,
+            "reporter_id": reporter_id,
+            "target_type": target_type,
+            "target_id": target_id,
+            "reason": reason,
+            "details": details,
+            "status": "pending",
+            "created_at": now,
+        }
+
+    def get_by_id(self, report_id: int) -> Optional[Dict]:
+        row = self.conn.execute(
+            "SELECT * FROM content_reports WHERE id=?", (int(report_id),)
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def list_all(self, status: Optional[str] = None, limit: int = 50, offset: int = 0) -> List[Dict]:
+        where_clauses = []
+        params: list = []
+        if status:
+            where_clauses.append("status = ?")
+            params.append(status)
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        params.extend([limit, offset])
+        rows = self.conn.execute(
+            f"SELECT * FROM content_reports {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            params,
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def count(self, status: Optional[str] = None) -> int:
+        if status:
+            row = self.conn.execute(
+                "SELECT COUNT(*) FROM content_reports WHERE status=?", (status,)
+            ).fetchone()
+        else:
+            row = self.conn.execute("SELECT COUNT(*) FROM content_reports").fetchone()
+        return row[0] if row else 0
+
+    def update_status(self, report_id: int, status: str) -> Optional[Dict]:
+        self.conn.execute(
+            "UPDATE content_reports SET status=? WHERE id=?",
+            (status, int(report_id)),
+        )
+        self.conn.commit()
+        return self.get_by_id(report_id)
+
+    def has_reported(self, reporter_id: int, target_type: str, target_id: int) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM content_reports WHERE reporter_id=? AND target_type=? AND target_id=?",
+            (int(reporter_id), target_type, int(target_id)),
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row) -> Dict:
+        return {
+            "id": int(row["id"]),
+            "reporter_id": int(row["reporter_id"]),
+            "target_type": row["target_type"],
+            "target_id": int(row["target_id"]),
+            "reason": row["reason"],
+            "details": row["details"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+        }

--- a/src/Backend/PersistantLayer/UserRepo.py
+++ b/src/Backend/PersistantLayer/UserRepo.py
@@ -29,6 +29,23 @@ class UserRepo:
             pw_hash BLOB
         );
         """)
+        # Migration: add is_discussion_banned column if missing
+        cols = [row[1] for row in self.conn.execute("PRAGMA table_info(users)").fetchall()]
+        if "is_discussion_banned" not in cols:
+            self.conn.execute("ALTER TABLE users ADD COLUMN is_discussion_banned INTEGER NOT NULL DEFAULT 0")
+
+    @staticmethod
+    def _row_to_user(row) -> User:
+        return User.from_dict({
+            "id": int(row["id"]),
+            "username": row["username"],
+            "email": row["email"],
+            "role": row["role"],
+            "bio": row["bio"],
+            "xp": int(row["xp"]),
+            "is_discussion_banned": bool(row["is_discussion_banned"]) if "is_discussion_banned" in row.keys() else False,
+            "created_at": row["created_at"],
+        })
 
     @staticmethod
     def _hash_password(password: str, salt: bytes) -> bytes:
@@ -51,39 +68,15 @@ class UserRepo:
 
     def get_by_id(self, user_id: int) -> Optional[User]:
         row = self.conn.execute("SELECT * FROM users WHERE id=?", (user_id,)).fetchone()
-        return User.from_dict({
-            "id": int(row["id"]),
-            "username": row["username"],
-            "email": row["email"],
-            "role": row["role"],
-            "bio": row["bio"],
-            "xp": int(row["xp"]),
-            "created_at": row["created_at"],
-        }) if row else None
+        return self._row_to_user(row) if row else None
 
     def get_by_username(self, username: str) -> Optional[User]:
         row = self.conn.execute("SELECT * FROM users WHERE username=?", (username,)).fetchone()
-        return User.from_dict({
-            "id": int(row["id"]),
-            "username": row["username"],
-            "email": row["email"],
-            "role": row["role"],
-            "bio": row["bio"],
-            "xp": int(row["xp"]),
-            "created_at": row["created_at"],
-        }) if row else None
+        return self._row_to_user(row) if row else None
 
     def get_by_email(self, email: str) -> Optional[User]:
         row = self.conn.execute("SELECT * FROM users WHERE email=?", (email,)).fetchone()
-        return User.from_dict({
-            "id": int(row["id"]),
-            "username": row["username"],
-            "email": row["email"],
-            "role": row["role"],
-            "bio": row["bio"],
-            "xp": int(row["xp"]),
-            "created_at": row["created_at"],
-        }) if row else None
+        return self._row_to_user(row) if row else None
 
     def verify_login(self, username: str, password: str) -> Optional[User]:
         row = self.conn.execute("SELECT * FROM users WHERE username=?", (username,)).fetchone()
@@ -92,15 +85,7 @@ class UserRepo:
         got = self._hash_password(password, row["pw_salt"])
         if got != row["pw_hash"]:
             return None
-        return User.from_dict({
-            "id": int(row["id"]),
-            "username": row["username"],
-            "email": row["email"],
-            "role": row["role"],
-            "bio": row["bio"],
-            "xp": int(row["xp"]),
-            "created_at": row["created_at"],
-        })
+        return self._row_to_user(row)
 
     def update_xp(self, user_id: int, xp: int) -> None:
         if xp < 0:
@@ -197,18 +182,7 @@ class UserRepo:
         params.extend([limit, offset])
         
         rows = self.conn.execute(query, params).fetchall()
-        return [
-            User.from_dict({
-                "id": int(r["id"]),
-                "username": r["username"],
-                "email": r["email"],
-                "role": r["role"],
-                "bio": r["bio"],
-                "xp": int(r["xp"]),
-                "created_at": r["created_at"],
-            })
-            for r in rows
-        ]
+        return [self._row_to_user(r) for r in rows]
     
     def count_all(
         self,
@@ -264,3 +238,11 @@ class UserRepo:
         cur = self.conn.execute(f"SELECT COUNT(*) FROM users {where_sql}", params)
         row = cur.fetchone()
         return row[0] if row else 0
+
+    def ban_from_discussions(self, user_id: int) -> None:
+        self.conn.execute("UPDATE users SET is_discussion_banned=1 WHERE id=?", (int(user_id),))
+        self.conn.commit()
+
+    def unban_from_discussions(self, user_id: int) -> None:
+        self.conn.execute("UPDATE users SET is_discussion_banned=0 WHERE id=?", (int(user_id),))
+        self.conn.commit()

--- a/src/Backend/ServiceLayer/DiscussionService.py
+++ b/src/Backend/ServiceLayer/DiscussionService.py
@@ -1,0 +1,427 @@
+from typing import Optional, List
+
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Enums import ReactionType, ThreadCategory, UserRole
+from Backend.DomainLayer.Exceptions import ValidationError
+from Backend.DomainLayer.Utils import utcnow
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.EngagementRepo import EngagementRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.ReportRepo import ReportRepo
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.ServiceLayer.AuthService import AuthService
+from Backend.ServiceLayer.XPService import XPService
+
+VALID_REPORT_REASONS = {"spam", "harassment", "off_topic", "inappropriate", "other"}
+
+
+# XP constants for forum actions
+DISCUSSION_CREATE_XP = 5
+UPVOTE_XP = 3
+REACTION_XP = 1
+
+
+class DiscussionService:
+    def __init__(
+        self,
+        discussion_repo: DiscussionRepo,
+        reply_repo: ReplyRepo,
+        user_repo: UserRepo,
+        auth_service: AuthService,
+        xp_service: XPService,
+        engagement_repo: Optional[EngagementRepo] = None,
+        report_repo: Optional[ReportRepo] = None,
+    ):
+        self.discussion_repo = discussion_repo
+        self.reply_repo = reply_repo
+        self.user_repo = user_repo
+        self.auth = auth_service
+        self.xp = xp_service
+        self.engagement = engagement_repo
+        self.report_repo = report_repo
+
+    def create_discussion(self, token: str, payload: dict) -> dict:
+        user_id = self.auth.require_user_id(token)
+        title = (payload.get("title") or "").strip()
+        body = (payload.get("body") or "").strip()
+        category_str = payload.get("category", "general")
+        puzzle_id = payload.get("puzzle_id")
+
+        if not title:
+            raise ValidationError("title is required")
+        if not body:
+            raise ValidationError("body is required")
+
+        try:
+            category = ThreadCategory(category_str)
+        except ValueError:
+            raise ValidationError(f"invalid category: {category_str}")
+
+        discussion = Discussion(
+            id=0,
+            title=title,
+            body=body,
+            author_id=user_id,
+            puzzle_id=int(puzzle_id) if puzzle_id is not None else None,
+            category=category,
+        )
+        created = self.discussion_repo.create(discussion)
+
+        # Award XP for creating a discussion
+        self.xp._apply_xp(user_id, DISCUSSION_CREATE_XP)
+
+        result = created.to_dict()
+        author = self.user_repo.get_by_id(user_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    def _enrich_reply(self, reply, user_id: int) -> dict:
+        """Convert reply to dict with author and engagement data."""
+        reply_dict = reply.to_dict()
+        reply_author = self.user_repo.get_by_id(reply.author_id)
+        if reply_author:
+            reply_dict["author"] = reply_author.to_dict()
+        if self.engagement:
+            reply_dict["engagement"] = self.engagement.get_reply_engagement(reply.id, user_id)
+        return reply_dict
+
+    def get_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        # Increment view count
+        self.discussion_repo.increment_view_count(discussion_id)
+        discussion.view_count += 1
+
+        result = discussion.to_dict()
+
+        # Attach author info
+        author = self.user_repo.get_by_id(discussion.author_id)
+        if author:
+            result["author"] = author.to_dict()
+
+        # Attach engagement data for the current user
+        if self.engagement:
+            result["engagement"] = self.engagement.get_discussion_engagement(discussion_id, user_id)
+
+        # Attach replies (nested)
+        top_replies = self.reply_repo.list_top_level(discussion_id, limit=100)
+        replies_list = []
+        for reply in top_replies:
+            reply_dict = self._enrich_reply(reply, user_id)
+            children = self.reply_repo.list_children(reply.id)
+            children_list = []
+            for child in children:
+                child_dict = self._enrich_reply(child, user_id)
+                grandchildren = self.reply_repo.list_children(child.id)
+                gc_list = []
+                for gc in grandchildren:
+                    gc_dict = self._enrich_reply(gc, user_id)
+                    gc_dict["children"] = []
+                    gc_list.append(gc_dict)
+                child_dict["children"] = gc_list
+                children_list.append(child_dict)
+            reply_dict["children"] = children_list
+            replies_list.append(reply_dict)
+
+        result["replies"] = replies_list
+        return result
+
+    def list_discussions(
+        self,
+        token: str,
+        limit: int = 20,
+        offset: int = 0,
+        category: Optional[str] = None,
+        puzzle_id: Optional[int] = None,
+        author_id: Optional[int] = None,
+        sort_by: str = "newest",
+        search: Optional[str] = None,
+    ) -> dict:
+        self.auth.require_user_id(token)
+
+        discussions = self.discussion_repo.list_all(
+            limit=limit,
+            offset=offset,
+            category=category,
+            puzzle_id=puzzle_id,
+            author_id=author_id,
+            sort_by=sort_by,
+            search=search,
+        )
+        total = self.discussion_repo.count(
+            category=category,
+            puzzle_id=puzzle_id,
+            author_id=author_id,
+            search=search,
+        )
+
+        items = []
+        for d in discussions:
+            item = d.to_dict()
+            author = self.user_repo.get_by_id(d.author_id)
+            if author:
+                item["author"] = author.to_dict()
+            items.append(item)
+
+        return {
+            "discussions": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    def update_discussion(self, token: str, discussion_id: int, payload: dict) -> dict:
+        user_id = self.auth.require_user_id(token)
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        user = self.user_repo.get_by_id(user_id)
+        is_admin = user and user.role == UserRole.ADMIN
+        is_owner = discussion.author_id == user_id
+
+        if not is_admin and not is_owner:
+            raise ValidationError("not allowed to update this discussion")
+
+        fields = {}
+        if "title" in payload:
+            title = (payload["title"] or "").strip()
+            if not title:
+                raise ValidationError("title is required")
+            fields["title"] = title
+        if "body" in payload:
+            body = (payload["body"] or "").strip()
+            if not body:
+                raise ValidationError("body is required")
+            fields["body"] = body
+        if "category" in payload:
+            try:
+                ThreadCategory(payload["category"])
+            except ValueError:
+                raise ValidationError(f"invalid category: {payload['category']}")
+            fields["category"] = payload["category"]
+
+        if not fields:
+            raise ValidationError("nothing to update")
+
+        updated = self.discussion_repo.update(discussion_id, fields)
+        if not updated:
+            raise ValidationError("discussion not found")
+
+        result = updated.to_dict()
+        author = self.user_repo.get_by_id(updated.author_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    def delete_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        user = self.user_repo.get_by_id(user_id)
+        is_admin = user and user.role == UserRole.ADMIN
+        is_owner = discussion.author_id == user_id
+
+        if not is_admin and not is_owner:
+            raise ValidationError("not allowed to delete this discussion")
+
+        self.discussion_repo.delete(discussion_id)
+        return {"deleted": True, "id": discussion_id}
+
+    def pin_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        user = self.user_repo.get_by_id(user_id)
+        if not user or user.role != UserRole.ADMIN:
+            raise ValidationError("admin only")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        new_pinned = not discussion.is_pinned
+        updated = self.discussion_repo.update(discussion_id, {"is_pinned": new_pinned})
+        result = updated.to_dict()
+        author = self.user_repo.get_by_id(updated.author_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    def lock_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        user = self.user_repo.get_by_id(user_id)
+        if not user or user.role != UserRole.ADMIN:
+            raise ValidationError("admin only")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        new_locked = not discussion.is_locked
+        updated = self.discussion_repo.update(discussion_id, {"is_locked": new_locked})
+        result = updated.to_dict()
+        author = self.user_repo.get_by_id(updated.author_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    # ---- Engagement methods ----
+
+    def vote_discussion(self, token: str, discussion_id: int, value: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+        if value not in (1, -1):
+            raise ValidationError("value must be 1 or -1")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        old_vote = self.engagement.get_discussion_vote(discussion_id, user_id)
+        new_vote = self.engagement.set_discussion_vote(discussion_id, user_id, value)
+
+        # Award XP on upvote (only when newly upvoting, not when toggling off)
+        if value == 1 and old_vote != 1 and discussion.author_id != user_id:
+            self.xp._apply_xp(discussion.author_id, UPVOTE_XP)
+
+        votes = self.engagement.count_discussion_votes(discussion_id)
+        # Update the cached upvotes on the discussion
+        self.discussion_repo.update(discussion_id, {"upvotes": votes["upvotes"]})
+
+        return {
+            "discussion_id": discussion_id,
+            "user_vote": new_vote,
+            "upvotes": votes["upvotes"],
+            "downvotes": votes["downvotes"],
+        }
+
+    def react_to_discussion(self, token: str, discussion_id: int, reaction_type: str) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+
+        try:
+            ReactionType(reaction_type)
+        except ValueError:
+            raise ValidationError(f"invalid reaction type: {reaction_type}")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        is_active = self.engagement.toggle_discussion_reaction(discussion_id, user_id, reaction_type)
+
+        # Award XP when reaction added (not removed)
+        if is_active and discussion.author_id != user_id:
+            self.xp._apply_xp(discussion.author_id, REACTION_XP)
+
+        reactions = self.engagement.get_discussion_reactions(discussion_id)
+        user_reactions = self.engagement.get_user_discussion_reactions(discussion_id, user_id)
+
+        return {
+            "discussion_id": discussion_id,
+            "is_active": is_active,
+            "reactions": reactions,
+            "user_reactions": user_reactions,
+        }
+
+    def follow_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        is_following = self.engagement.toggle_follow(discussion_id, user_id)
+        return {
+            "discussion_id": discussion_id,
+            "is_following": is_following,
+        }
+
+    def bookmark_discussion(self, token: str, discussion_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        is_bookmarked = self.engagement.toggle_bookmark(discussion_id, user_id)
+        return {
+            "discussion_id": discussion_id,
+            "is_bookmarked": is_bookmarked,
+        }
+
+    # ---- Report methods ----
+
+    def report_discussion(self, token: str, discussion_id: int, reason: str, details: str = "") -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+        if reason not in VALID_REPORT_REASONS:
+            raise ValidationError(f"invalid reason: {reason}")
+
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        if self.report_repo.has_reported(user_id, "discussion", discussion_id):
+            raise ValidationError("you have already reported this discussion")
+
+        return self.report_repo.create(user_id, "discussion", discussion_id, reason, details)
+
+    def report_reply(self, token: str, reply_id: int, reason: str, details: str = "") -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+        if reason not in VALID_REPORT_REASONS:
+            raise ValidationError(f"invalid reason: {reason}")
+
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        if self.report_repo.has_reported(user_id, "reply", reply_id):
+            raise ValidationError("you have already reported this reply")
+
+        return self.report_repo.create(user_id, "reply", reply_id, reason, details)
+
+    def list_reports(self, token: str, status: Optional[str] = None, limit: int = 50, offset: int = 0) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        user = self.user_repo.get_by_id(user_id)
+        if not user or user.role != UserRole.ADMIN:
+            raise ValidationError("admin only")
+
+        reports = self.report_repo.list_all(status=status, limit=limit, offset=offset)
+        total = self.report_repo.count(status=status)
+        return {"reports": reports, "total": total, "limit": limit, "offset": offset}
+
+    def update_report_status(self, token: str, report_id: int, status: str) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        user = self.user_repo.get_by_id(user_id)
+        if not user or user.role != UserRole.ADMIN:
+            raise ValidationError("admin only")
+
+        if status not in ("pending", "reviewed", "dismissed"):
+            raise ValidationError(f"invalid status: {status}")
+
+        report = self.report_repo.get_by_id(report_id)
+        if not report:
+            raise ValidationError("report not found")
+
+        return self.report_repo.update_status(report_id, status)

--- a/src/Backend/ServiceLayer/DiscussionService.py
+++ b/src/Backend/ServiceLayer/DiscussionService.py
@@ -1,3 +1,4 @@
+import sqlite3
 from typing import Optional, List
 
 from Backend.DomainLayer.Discussion import Discussion
@@ -383,7 +384,10 @@ class DiscussionService:
         if self.report_repo.has_reported(user_id, "discussion", discussion_id):
             raise ValidationError("you have already reported this discussion")
 
-        return self.report_repo.create(user_id, "discussion", discussion_id, reason, details)
+        try:
+            return self.report_repo.create(user_id, "discussion", discussion_id, reason, details)
+        except sqlite3.IntegrityError:
+            raise ValidationError("you have already reported this discussion")
 
     def report_reply(self, token: str, reply_id: int, reason: str, details: str = "") -> dict:
         user_id = self.auth.require_user_id(token)
@@ -399,7 +403,10 @@ class DiscussionService:
         if self.report_repo.has_reported(user_id, "reply", reply_id):
             raise ValidationError("you have already reported this reply")
 
-        return self.report_repo.create(user_id, "reply", reply_id, reason, details)
+        try:
+            return self.report_repo.create(user_id, "reply", reply_id, reason, details)
+        except sqlite3.IntegrityError:
+            raise ValidationError("you have already reported this reply")
 
     def list_reports(self, token: str, status: Optional[str] = None, limit: int = 50, offset: int = 0) -> dict:
         user_id = self.auth.require_user_id(token)
@@ -430,6 +437,7 @@ class DiscussionService:
                     author = self.user_repo.get_by_id(reply.author_id)
                     report["target_author_id"] = reply.author_id
                     report["target_author_username"] = author.username if author else "Unknown"
+                    report["discussion_id"] = reply.discussion_id
 
         return {"reports": reports, "total": total, "limit": limit, "offset": offset}
 
@@ -532,12 +540,16 @@ class DiscussionService:
             raise ValidationError("report not found")
 
         if report["target_type"] == "discussion":
+            disc = self.discussion_repo.get_by_id(report["target_id"])
+            if not disc:
+                raise ValidationError("reported discussion has already been deleted")
             self.discussion_repo.delete(report["target_id"])
         elif report["target_type"] == "reply":
             reply = self.reply_repo.get_by_id(report["target_id"])
-            if reply:
-                self.reply_repo.delete(report["target_id"])
-                self.discussion_repo.increment_reply_count(reply.discussion_id, -1)
+            if not reply:
+                raise ValidationError("reported reply has already been deleted")
+            self.reply_repo.delete(report["target_id"])
+            self.discussion_repo.increment_reply_count(reply.discussion_id, -1)
 
         # Mark report as reviewed
         self.report_repo.update_status(report_id, "reviewed")

--- a/src/Backend/ServiceLayer/DiscussionService.py
+++ b/src/Backend/ServiceLayer/DiscussionService.py
@@ -7,6 +7,7 @@ from Backend.DomainLayer.Utils import utcnow
 from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
 from Backend.PersistantLayer.EngagementRepo import EngagementRepo
 from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.NotificationRepo import NotificationRepo
 from Backend.PersistantLayer.ReportRepo import ReportRepo
 from Backend.PersistantLayer.UserRepo import UserRepo
 from Backend.ServiceLayer.AuthService import AuthService
@@ -31,6 +32,7 @@ class DiscussionService:
         xp_service: XPService,
         engagement_repo: Optional[EngagementRepo] = None,
         report_repo: Optional[ReportRepo] = None,
+        notification_repo: Optional[NotificationRepo] = None,
     ):
         self.discussion_repo = discussion_repo
         self.reply_repo = reply_repo
@@ -39,9 +41,13 @@ class DiscussionService:
         self.xp = xp_service
         self.engagement = engagement_repo
         self.report_repo = report_repo
+        self.notification_repo = notification_repo
 
     def create_discussion(self, token: str, payload: dict) -> dict:
         user_id = self.auth.require_user_id(token)
+        user = self.user_repo.get_by_id(user_id)
+        if user and user.is_discussion_banned:
+            raise ValidationError("you are banned from creating discussions")
         title = (payload.get("title") or "").strip()
         body = (payload.get("body") or "").strip()
         category_str = payload.get("category", "general")
@@ -406,6 +412,25 @@ class DiscussionService:
 
         reports = self.report_repo.list_all(status=status, limit=limit, offset=offset)
         total = self.report_repo.count(status=status)
+
+        # Enrich with usernames
+        for report in reports:
+            reporter = self.user_repo.get_by_id(report["reporter_id"])
+            report["reporter_username"] = reporter.username if reporter else "Unknown"
+            # Get target author
+            if report["target_type"] == "discussion":
+                disc = self.discussion_repo.get_by_id(report["target_id"])
+                if disc:
+                    author = self.user_repo.get_by_id(disc.author_id)
+                    report["target_author_id"] = disc.author_id
+                    report["target_author_username"] = author.username if author else "Unknown"
+            elif report["target_type"] == "reply":
+                reply = self.reply_repo.get_by_id(report["target_id"])
+                if reply:
+                    author = self.user_repo.get_by_id(reply.author_id)
+                    report["target_author_id"] = reply.author_id
+                    report["target_author_username"] = author.username if author else "Unknown"
+
         return {"reports": reports, "total": total, "limit": limit, "offset": offset}
 
     def update_report_status(self, token: str, report_id: int, status: str) -> dict:
@@ -425,3 +450,117 @@ class DiscussionService:
             raise ValidationError("report not found")
 
         return self.report_repo.update_status(report_id, status)
+
+    def _require_admin(self, token: str) -> int:
+        user_id = self.auth.require_user_id(token)
+        user = self.user_repo.get_by_id(user_id)
+        if not user or user.role != UserRole.ADMIN:
+            raise ValidationError("admin only")
+        return user_id
+
+    def _get_report_target_author_id(self, report: dict) -> int:
+        if report["target_type"] == "discussion":
+            disc = self.discussion_repo.get_by_id(report["target_id"])
+            if not disc:
+                raise ValidationError("reported discussion not found")
+            return disc.author_id
+        elif report["target_type"] == "reply":
+            reply = self.reply_repo.get_by_id(report["target_id"])
+            if not reply:
+                raise ValidationError("reported reply not found")
+            return reply.author_id
+        raise ValidationError("unknown target type")
+
+    def warn_user_for_report(self, token: str, report_id: int) -> dict:
+        self._require_admin(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        report = self.report_repo.get_by_id(report_id)
+        if not report:
+            raise ValidationError("report not found")
+
+        target_author_id = self._get_report_target_author_id(report)
+
+        # Send warning notification
+        if self.notification_repo:
+            msg = f"You have received a warning for your {report['target_type']} (reason: {report['reason']}). Please follow the community guidelines."
+            self.notification_repo.create(
+                user_id=target_author_id,
+                notif_type="warning",
+                message=msg,
+            )
+
+        # Mark report as reviewed
+        self.report_repo.update_status(report_id, "reviewed")
+        return {"action": "warned", "report_id": report_id, "warned_user_id": target_author_id}
+
+    def ban_user_for_report(self, token: str, report_id: int) -> dict:
+        self._require_admin(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        report = self.report_repo.get_by_id(report_id)
+        if not report:
+            raise ValidationError("report not found")
+
+        target_author_id = self._get_report_target_author_id(report)
+
+        # Ban the user from discussions
+        self.user_repo.ban_from_discussions(target_author_id)
+
+        # Send ban notification
+        if self.notification_repo:
+            msg = f"You have been banned from the discussions forum due to a violation (reason: {report['reason']}). You can no longer create discussions or replies."
+            self.notification_repo.create(
+                user_id=target_author_id,
+                notif_type="ban",
+                message=msg,
+            )
+
+        # Mark report as reviewed
+        self.report_repo.update_status(report_id, "reviewed")
+        return {"action": "banned", "report_id": report_id, "banned_user_id": target_author_id}
+
+    def delete_reported_content(self, token: str, report_id: int) -> dict:
+        self._require_admin(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        report = self.report_repo.get_by_id(report_id)
+        if not report:
+            raise ValidationError("report not found")
+
+        if report["target_type"] == "discussion":
+            self.discussion_repo.delete(report["target_id"])
+        elif report["target_type"] == "reply":
+            reply = self.reply_repo.get_by_id(report["target_id"])
+            if reply:
+                self.reply_repo.delete(report["target_id"])
+                self.discussion_repo.increment_reply_count(reply.discussion_id, -1)
+
+        # Mark report as reviewed
+        self.report_repo.update_status(report_id, "reviewed")
+        return {"action": "deleted", "report_id": report_id, "target_type": report["target_type"], "target_id": report["target_id"]}
+
+    def lock_reported_discussion(self, token: str, report_id: int) -> dict:
+        self._require_admin(token)
+        if not self.report_repo:
+            raise ValidationError("reporting not available")
+
+        report = self.report_repo.get_by_id(report_id)
+        if not report:
+            raise ValidationError("report not found")
+
+        if report["target_type"] != "discussion":
+            raise ValidationError("can only lock discussions, not replies")
+
+        discussion = self.discussion_repo.get_by_id(report["target_id"])
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        self.discussion_repo.update(report["target_id"], {"is_locked": True})
+
+        # Mark report as reviewed
+        self.report_repo.update_status(report_id, "reviewed")
+        return {"action": "locked", "report_id": report_id, "discussion_id": report["target_id"]}

--- a/src/Backend/ServiceLayer/ReplyService.py
+++ b/src/Backend/ServiceLayer/ReplyService.py
@@ -38,6 +38,9 @@ class ReplyService:
 
     def create_reply(self, token: str, discussion_id: int, payload: dict) -> dict:
         user_id = self.auth.require_user_id(token)
+        user = self.user_repo.get_by_id(user_id)
+        if user and user.is_discussion_banned:
+            raise ValidationError("you are banned from creating replies")
         discussion = self.discussion_repo.get_by_id(discussion_id)
         if not discussion:
             raise ValidationError("discussion not found")

--- a/src/Backend/ServiceLayer/ReplyService.py
+++ b/src/Backend/ServiceLayer/ReplyService.py
@@ -1,0 +1,257 @@
+from typing import Optional
+
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.Enums import ReactionType, UserRole
+from Backend.DomainLayer.Exceptions import ValidationError
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.EngagementRepo import EngagementRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.ServiceLayer.AuthService import AuthService
+from Backend.ServiceLayer.XPService import XPService
+
+
+# XP constants for forum actions
+REPLY_CREATE_XP = 2
+REPLY_ACCEPTED_XP = 25
+ACCEPT_SOLUTION_XP = 5
+REPLY_UPVOTE_XP = 3
+REPLY_REACTION_XP = 1
+
+
+class ReplyService:
+    def __init__(
+        self,
+        reply_repo: ReplyRepo,
+        discussion_repo: DiscussionRepo,
+        user_repo: UserRepo,
+        auth_service: AuthService,
+        xp_service: XPService,
+        engagement_repo: Optional[EngagementRepo] = None,
+    ):
+        self.reply_repo = reply_repo
+        self.discussion_repo = discussion_repo
+        self.user_repo = user_repo
+        self.auth = auth_service
+        self.xp = xp_service
+        self.engagement = engagement_repo
+
+    def create_reply(self, token: str, discussion_id: int, payload: dict) -> dict:
+        user_id = self.auth.require_user_id(token)
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+        if discussion.is_locked:
+            raise ValidationError("discussion is locked")
+
+        body = (payload.get("body") or "").strip()
+        if not body:
+            raise ValidationError("body is required")
+
+        parent_reply_id = payload.get("parent_reply_id")
+        if parent_reply_id is not None:
+            parent_reply_id = int(parent_reply_id)
+            parent = self.reply_repo.get_by_id(parent_reply_id)
+            if not parent or parent.discussion_id != discussion_id:
+                raise ValidationError("invalid parent reply")
+
+        reply = Reply(
+            id=0,
+            discussion_id=discussion_id,
+            author_id=user_id,
+            body=body,
+            parent_reply_id=parent_reply_id,
+        )
+        created = self.reply_repo.create(reply)
+
+        # Update reply count on discussion
+        self.discussion_repo.increment_reply_count(discussion_id, 1)
+
+        # Award XP for creating a reply
+        self.xp._apply_xp(user_id, REPLY_CREATE_XP)
+
+        result = created.to_dict()
+        author = self.user_repo.get_by_id(user_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    def get_replies(self, token: str, discussion_id: int, limit: int = 100, offset: int = 0) -> dict:
+        self.auth.require_user_id(token)
+        discussion = self.discussion_repo.get_by_id(discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        replies = self.reply_repo.list_by_discussion(discussion_id, limit=limit, offset=offset)
+        total = self.reply_repo.count_by_discussion(discussion_id)
+
+        items = []
+        for r in replies:
+            item = r.to_dict()
+            author = self.user_repo.get_by_id(r.author_id)
+            if author:
+                item["author"] = author.to_dict()
+            items.append(item)
+
+        return {
+            "replies": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    def update_reply(self, token: str, reply_id: int, payload: dict) -> dict:
+        user_id = self.auth.require_user_id(token)
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        user = self.user_repo.get_by_id(user_id)
+        is_admin = user and user.role == UserRole.ADMIN
+        is_owner = reply.author_id == user_id
+
+        if not is_admin and not is_owner:
+            raise ValidationError("not allowed to update this reply")
+
+        body = (payload.get("body") or "").strip()
+        if not body:
+            raise ValidationError("body is required")
+
+        updated = self.reply_repo.update(reply_id, {"body": body})
+        if not updated:
+            raise ValidationError("reply not found")
+
+        result = updated.to_dict()
+        author = self.user_repo.get_by_id(updated.author_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    def delete_reply(self, token: str, reply_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        user = self.user_repo.get_by_id(user_id)
+        is_admin = user and user.role == UserRole.ADMIN
+        is_owner = reply.author_id == user_id
+
+        if not is_admin and not is_owner:
+            raise ValidationError("not allowed to delete this reply")
+
+        discussion_id = reply.discussion_id
+        self.reply_repo.delete(reply_id)
+
+        # Decrement reply count on discussion
+        self.discussion_repo.increment_reply_count(discussion_id, -1)
+
+        return {"deleted": True, "id": reply_id}
+
+    def accept_reply(self, token: str, reply_id: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        discussion = self.discussion_repo.get_by_id(reply.discussion_id)
+        if not discussion:
+            raise ValidationError("discussion not found")
+
+        user = self.user_repo.get_by_id(user_id)
+        is_admin = user and user.role == UserRole.ADMIN
+        is_owner = discussion.author_id == user_id
+
+        if not is_admin and not is_owner:
+            raise ValidationError("only the thread author or admin can accept a solution")
+
+        # If this reply is already accepted, unaccept it
+        if reply.is_accepted:
+            self.reply_repo.update(reply_id, {"is_accepted": False})
+            self.discussion_repo.set_accepted_reply(discussion.id, None)
+            updated = self.reply_repo.get_by_id(reply_id)
+            result = updated.to_dict()
+            author = self.user_repo.get_by_id(updated.author_id)
+            if author:
+                result["author"] = author.to_dict()
+            return result
+
+        # Clear any previously accepted reply
+        self.reply_repo.clear_accepted_for_discussion(discussion.id)
+
+        # Accept this reply
+        self.reply_repo.update(reply_id, {"is_accepted": True})
+        self.discussion_repo.set_accepted_reply(discussion.id, reply_id)
+
+        # Award XP: +25 to reply author, +5 to thread author for accepting
+        if reply.author_id != user_id:
+            self.xp._apply_xp(reply.author_id, REPLY_ACCEPTED_XP)
+        self.xp._apply_xp(user_id, ACCEPT_SOLUTION_XP)
+
+        updated = self.reply_repo.get_by_id(reply_id)
+        result = updated.to_dict()
+        author = self.user_repo.get_by_id(updated.author_id)
+        if author:
+            result["author"] = author.to_dict()
+        return result
+
+    # ---- Engagement methods ----
+
+    def vote_reply(self, token: str, reply_id: int, value: int) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+        if value not in (1, -1):
+            raise ValidationError("value must be 1 or -1")
+
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        old_vote = self.engagement.get_reply_vote(reply_id, user_id)
+        new_vote = self.engagement.set_reply_vote(reply_id, user_id, value)
+
+        # Award XP on upvote (only when newly upvoting)
+        if value == 1 and old_vote != 1 and reply.author_id != user_id:
+            self.xp._apply_xp(reply.author_id, REPLY_UPVOTE_XP)
+
+        votes = self.engagement.count_reply_votes(reply_id)
+        # Update cached vote counts on the reply
+        self.reply_repo.update_votes(reply_id, votes["upvotes"], votes["downvotes"])
+
+        return {
+            "reply_id": reply_id,
+            "user_vote": new_vote,
+            "upvotes": votes["upvotes"],
+            "downvotes": votes["downvotes"],
+        }
+
+    def react_to_reply(self, token: str, reply_id: int, reaction_type: str) -> dict:
+        user_id = self.auth.require_user_id(token)
+        if not self.engagement:
+            raise ValidationError("engagement not available")
+
+        try:
+            ReactionType(reaction_type)
+        except ValueError:
+            raise ValidationError(f"invalid reaction type: {reaction_type}")
+
+        reply = self.reply_repo.get_by_id(reply_id)
+        if not reply:
+            raise ValidationError("reply not found")
+
+        is_active = self.engagement.toggle_reply_reaction(reply_id, user_id, reaction_type)
+
+        # Award XP when reaction added (not removed)
+        if is_active and reply.author_id != user_id:
+            self.xp._apply_xp(reply.author_id, REPLY_REACTION_XP)
+
+        reactions = self.engagement.get_reply_reactions(reply_id)
+        user_reactions = self.engagement.get_user_reply_reactions(reply_id, user_id)
+
+        return {
+            "reply_id": reply_id,
+            "is_active": is_active,
+            "reactions": reactions,
+            "user_reactions": user_reactions,
+        }

--- a/src/Backend/main.py
+++ b/src/Backend/main.py
@@ -145,6 +145,7 @@ def create_app() -> FastAPI:
         xp_service=xp_service,
         engagement_repo=engagement_repo,
         report_repo=report_repo,
+        notification_repo=notification_repo,
     )
 
     # Reply Service

--- a/src/Backend/main.py
+++ b/src/Backend/main.py
@@ -12,6 +12,10 @@ from Backend.PersistantLayer.RatingRepo import RatingRepo
 from Backend.PersistantLayer.SolveRepo import SolveRepo
 from Backend.PersistantLayer.NotificationRepo import NotificationRepo
 from Backend.PersistantLayer.AuditLogRepo import AuditLogRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.EngagementRepo import EngagementRepo
+from Backend.PersistantLayer.ReportRepo import ReportRepo
 
 # Services
 from Backend.ServiceLayer.AuthService import AuthService
@@ -25,6 +29,8 @@ from Backend.ServiceLayer.RatingService import RatingService
 from Backend.ServiceLayer.logicEngineService import logicEngineService
 from Backend.ServiceLayer.NotificationService import NotificationService
 from Backend.ServiceLayer.AdminService import AdminService
+from Backend.ServiceLayer.DiscussionService import DiscussionService
+from Backend.ServiceLayer.ReplyService import ReplyService
 
 # Controllers
 from Backend.APILayer.UserController import build_user_router
@@ -33,6 +39,7 @@ from Backend.APILayer.ArsenalController import build_arsenal_router
 from Backend.APILayer.PuzzleController import build_puzzle_router
 from Backend.APILayer.RatingController import build_rating_router
 from Backend.APILayer.AdminController import build_admin_router
+from Backend.APILayer.DiscussionController import build_discussion_router
 
 
 def create_app() -> FastAPI:
@@ -56,6 +63,10 @@ def create_app() -> FastAPI:
     solve_repo = SolveRepo(conn)
     notification_repo = NotificationRepo(conn)
     audit_log_repo = AuditLogRepo(conn)
+    discussion_repo = DiscussionRepo(conn)
+    reply_repo = ReplyRepo(conn)
+    engagement_repo = EngagementRepo(conn)
+    report_repo = ReportRepo(conn)
 
     # 3. Services
     # logic engine (stateless)
@@ -125,6 +136,27 @@ def create_app() -> FastAPI:
         notification_service,
     )
 
+    # Discussion Service
+    discussion_service = DiscussionService(
+        discussion_repo=discussion_repo,
+        reply_repo=reply_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+        engagement_repo=engagement_repo,
+        report_repo=report_repo,
+    )
+
+    # Reply Service
+    reply_service = ReplyService(
+        reply_repo=reply_repo,
+        discussion_repo=discussion_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+        engagement_repo=engagement_repo,
+    )
+
     # Admin Service
     admin_service = AdminService(
         user_repo=user_repo,
@@ -160,6 +192,15 @@ def create_app() -> FastAPI:
     app.include_router(build_puzzle_router(puzzle_service, solving_service, rating_service))
     app.include_router(build_rating_router(rating_service))
     app.include_router(build_admin_router(admin_service))
+
+    # Discussion & Reply routers
+    disc_router, reply_router, puzzle_disc_router, report_router = build_discussion_router(
+        discussion_service, reply_service
+    )
+    app.include_router(disc_router)
+    app.include_router(reply_router)
+    app.include_router(puzzle_disc_router)
+    app.include_router(report_router)
 
     @app.get("/")
     def root():

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -12,6 +12,10 @@ from Backend.PersistantLayer.CircuitRepo import CircuitRepo
 from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
 from Backend.PersistantLayer.RatingRepo import RatingRepo
 from Backend.PersistantLayer.SolveRepo import SolveRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.EngagementRepo import EngagementRepo
+from Backend.PersistantLayer.ReportRepo import ReportRepo
 
 def init_db():
     # DB in project root (src/..)
@@ -28,7 +32,11 @@ def init_db():
     PuzzleRepo(conn)
     RatingRepo(conn)
     SolveRepo(conn)
-    
+    DiscussionRepo(conn)
+    ReplyRepo(conn)
+    EngagementRepo(conn)
+    ReportRepo(conn)
+
     conn.commit()
     conn.close()
     print("Database initialized successfully.")

--- a/src/tests/PersistantLayerTests/test_discussion_repo.py
+++ b/src/tests/PersistantLayerTests/test_discussion_repo.py
@@ -181,3 +181,26 @@ def test_list_sort_by_most_replies(repo):
     items = repo.list_all(sort_by="most_replies")
     # Pinned first (both unpinned), then by reply count
     assert items[0].title == "Many"
+
+
+def test_search_with_percent_wildcard(repo):
+    repo.create(make_discussion(title="100% Complete"))
+    repo.create(make_discussion(title="Normal Discussion"))
+    repo.create(make_discussion(title="50% Done"))
+
+    results = repo.list_all(search="100%")
+    assert len(results) == 1
+    assert results[0].title == "100% Complete"
+
+    assert repo.count(search="100%") == 1
+
+
+def test_search_with_underscore_wildcard(repo):
+    repo.create(make_discussion(title="test_case_one"))
+    repo.create(make_discussion(title="testing something"))
+    repo.create(make_discussion(title="test_case_two"))
+
+    results = repo.list_all(search="test_case")
+    assert len(results) == 2
+    titles = {r.title for r in results}
+    assert titles == {"test_case_one", "test_case_two"}

--- a/src/tests/PersistantLayerTests/test_discussion_repo.py
+++ b/src/tests/PersistantLayerTests/test_discussion_repo.py
@@ -1,0 +1,183 @@
+import sqlite3
+import pytest
+from datetime import datetime, timezone
+
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    c.execute("PRAGMA foreign_keys = ON;")
+    return c
+
+
+@pytest.fixture
+def user_repo(conn):
+    return UserRepo(conn)
+
+
+@pytest.fixture
+def puzzle_repo(conn):
+    """Create puzzles table (needed for FK references)."""
+    return PuzzleRepo(conn)
+
+
+@pytest.fixture
+def repo(conn, user_repo, puzzle_repo):
+    # Create a user first (discussions reference users)
+    user = User(id=0, username="testuser", role=UserRole.SOLVER, xp=0)
+    user_repo.create(user, password="pw")
+    return DiscussionRepo(conn)
+
+
+def make_discussion(author_id=1, title="Test Discussion", body="This is a test body", category="general", puzzle_id=None):
+    return Discussion(
+        id=0,
+        title=title,
+        body=body,
+        author_id=author_id,
+        puzzle_id=puzzle_id,
+        category=ThreadCategory(category),
+    )
+
+
+def test_schema_created(conn, repo):
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='discussions'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_create_and_get(repo):
+    d = make_discussion()
+    created = repo.create(d)
+    assert created.id > 0
+    assert created.title == "Test Discussion"
+
+    fetched = repo.get_by_id(created.id)
+    assert fetched is not None
+    assert fetched.title == "Test Discussion"
+    assert fetched.body == "This is a test body"
+    assert fetched.category == ThreadCategory.GENERAL
+
+
+def test_get_nonexistent(repo):
+    assert repo.get_by_id(999) is None
+
+
+def test_list_all_pagination(repo):
+    for i in range(5):
+        repo.create(make_discussion(title=f"Discussion {i}"))
+
+    all_items = repo.list_all(limit=100)
+    assert len(all_items) == 5
+
+    page = repo.list_all(limit=2, offset=0)
+    assert len(page) == 2
+
+    page2 = repo.list_all(limit=2, offset=2)
+    assert len(page2) == 2
+
+
+def test_list_filter_by_category(repo):
+    repo.create(make_discussion(title="General 1", category="general"))
+    repo.create(make_discussion(title="Help 1", category="puzzle_help"))
+    repo.create(make_discussion(title="General 2", category="general"))
+
+    general = repo.list_all(category="general")
+    assert len(general) == 2
+
+    help_items = repo.list_all(category="puzzle_help")
+    assert len(help_items) == 1
+
+
+def test_count(repo):
+    repo.create(make_discussion(title="D1"))
+    repo.create(make_discussion(title="D2"))
+    repo.create(make_discussion(title="D3", category="puzzle_help"))
+
+    assert repo.count() == 3
+    assert repo.count(category="general") == 2
+    assert repo.count(category="puzzle_help") == 1
+
+
+def test_update(repo):
+    d = repo.create(make_discussion())
+    updated = repo.update(d.id, {"title": "Updated Title", "body": "Updated body"})
+    assert updated.title == "Updated Title"
+    assert updated.body == "Updated body"
+
+
+def test_delete(repo):
+    d = repo.create(make_discussion())
+    assert repo.delete(d.id)
+    assert repo.get_by_id(d.id) is None
+
+
+def test_delete_nonexistent(repo):
+    assert not repo.delete(999)
+
+
+def test_increment_view_count(repo):
+    d = repo.create(make_discussion())
+    assert d.view_count == 0
+
+    repo.increment_view_count(d.id)
+    repo.increment_view_count(d.id)
+
+    fetched = repo.get_by_id(d.id)
+    assert fetched.view_count == 2
+
+
+def test_increment_reply_count(repo):
+    d = repo.create(make_discussion())
+    repo.increment_reply_count(d.id, 1)
+    repo.increment_reply_count(d.id, 1)
+
+    fetched = repo.get_by_id(d.id)
+    assert fetched.reply_count == 2
+
+    repo.increment_reply_count(d.id, -1)
+    fetched = repo.get_by_id(d.id)
+    assert fetched.reply_count == 1
+
+
+def test_set_accepted_reply(repo):
+    d = repo.create(make_discussion())
+    assert d.accepted_reply_id is None
+
+    repo.set_accepted_reply(d.id, 42)
+    fetched = repo.get_by_id(d.id)
+    assert fetched.accepted_reply_id == 42
+
+    repo.set_accepted_reply(d.id, None)
+    fetched = repo.get_by_id(d.id)
+    assert fetched.accepted_reply_id is None
+
+
+def test_pinned_first_ordering(repo):
+    d1 = repo.create(make_discussion(title="Normal"))
+    d2 = repo.create(make_discussion(title="Pinned"))
+    repo.update(d2.id, {"is_pinned": True})
+
+    items = repo.list_all()
+    assert items[0].title == "Pinned"
+    assert items[0].is_pinned is True
+
+
+def test_list_sort_by_most_replies(repo):
+    d1 = repo.create(make_discussion(title="Few"))
+    d2 = repo.create(make_discussion(title="Many"))
+    repo.increment_reply_count(d2.id, 10)
+
+    items = repo.list_all(sort_by="most_replies")
+    # Pinned first (both unpinned), then by reply count
+    assert items[0].title == "Many"

--- a/src/tests/PersistantLayerTests/test_discussion_search.py
+++ b/src/tests/PersistantLayerTests/test_discussion_search.py
@@ -1,0 +1,130 @@
+import sqlite3
+import pytest
+
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    c.execute("PRAGMA foreign_keys = ON;")
+    return c
+
+
+@pytest.fixture
+def setup(conn):
+    user_repo = UserRepo(conn)
+    PuzzleRepo(conn)  # needed for FK
+    discussion_repo = DiscussionRepo(conn)
+
+    # Create a test user
+    user = User(id=0, username="alice", role=UserRole.SOLVER, xp=0)
+    user_repo.create(user, password="pw")
+
+    # Create several discussions with varied titles and bodies
+    discussions = []
+    data = [
+        ("How to solve XOR puzzles", "I need help with XOR gate logic"),
+        ("Tips for beginners", "Start with simple AND gates before moving on"),
+        ("XOR gate tricks", "Advanced XOR techniques for competitive solving"),
+        ("Feature request: dark mode", "Please add dark mode to the UI"),
+        ("Bug in puzzle editor", "The editor crashes when saving large circuits"),
+    ]
+    for title, body in data:
+        d = Discussion(
+            id=0, title=title, body=body, author_id=1,
+            category=ThreadCategory.GENERAL,
+        )
+        discussions.append(discussion_repo.create(d))
+
+    return discussion_repo, discussions
+
+
+# ---- Search by title substring ----
+
+def test_search_by_title(setup):
+    repo, _ = setup
+    results = repo.list_all(search="XOR")
+    # "How to solve XOR puzzles" and "XOR gate tricks" match by title;
+    # "I need help with XOR gate logic" also matches via body on the first one.
+    # The third discussion body also has "XOR".
+    titles = [d.title for d in results]
+    assert "How to solve XOR puzzles" in titles
+    assert "XOR gate tricks" in titles
+
+
+def test_search_by_title_case_insensitive_like(setup):
+    repo, _ = setup
+    # SQLite LIKE is case-insensitive for ASCII by default
+    results = repo.list_all(search="xor")
+    assert len(results) >= 2
+
+
+# ---- Search by body substring ----
+
+def test_search_by_body(setup):
+    repo, _ = setup
+    results = repo.list_all(search="dark mode")
+    assert len(results) == 1
+    assert results[0].title == "Feature request: dark mode"
+
+
+def test_search_by_body_partial(setup):
+    repo, _ = setup
+    results = repo.list_all(search="circuits")
+    assert len(results) == 1
+    assert results[0].title == "Bug in puzzle editor"
+
+
+# ---- Search with no results ----
+
+def test_search_no_results(setup):
+    repo, _ = setup
+    results = repo.list_all(search="nonexistent_term_xyz")
+    assert results == []
+
+
+def test_search_empty_string_returns_all(setup):
+    repo, discussions = setup
+    # An empty search string should not filter anything
+    results = repo.list_all(search="")
+    assert len(results) == len(discussions)
+
+
+# ---- Trending sort (basic sanity check) ----
+
+def test_trending_sort_returns_discussions(setup):
+    repo, discussions = setup
+    # Give one discussion some engagement signals
+    repo.increment_view_count(discussions[0].id)
+    repo.increment_view_count(discussions[0].id)
+    repo.increment_reply_count(discussions[0].id, 3)
+
+    results = repo.list_all(sort_by="trending")
+    assert len(results) == len(discussions)
+    # All discussions should be returned
+    returned_ids = {d.id for d in results}
+    expected_ids = {d.id for d in discussions}
+    assert returned_ids == expected_ids
+
+
+def test_trending_sort_with_search(setup):
+    repo, _ = setup
+    results = repo.list_all(sort_by="trending", search="XOR")
+    assert len(results) >= 2
+    for d in results:
+        assert "XOR" in d.title or "XOR" in d.body
+
+
+def test_count_with_search(setup):
+    repo, _ = setup
+    assert repo.count(search="XOR") >= 2
+    assert repo.count(search="dark mode") == 1
+    assert repo.count(search="nonexistent_term_xyz") == 0

--- a/src/tests/PersistantLayerTests/test_engagement_repo.py
+++ b/src/tests/PersistantLayerTests/test_engagement_repo.py
@@ -1,0 +1,228 @@
+import sqlite3
+import pytest
+
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.EngagementRepo import EngagementRepo
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    c.execute("PRAGMA foreign_keys = ON;")
+    return c
+
+
+@pytest.fixture
+def setup(conn):
+    user_repo = UserRepo(conn)
+    PuzzleRepo(conn)  # needed for FK
+    discussion_repo = DiscussionRepo(conn)
+    reply_repo = ReplyRepo(conn)
+    engagement_repo = EngagementRepo(conn)
+
+    # Create test users
+    alice = User(id=0, username="alice", role=UserRole.SOLVER, xp=0)
+    user_repo.create(alice, password="pw")
+    bob = User(id=0, username="bob", role=UserRole.SOLVER, xp=0)
+    user_repo.create(bob, password="pw")
+
+    # Create a test discussion
+    discussion = Discussion(
+        id=0, title="Test", body="Test body", author_id=1,
+        category=ThreadCategory.GENERAL,
+    )
+    discussion = discussion_repo.create(discussion)
+
+    # Create a test reply
+    reply = Reply(id=0, discussion_id=discussion.id, author_id=2, body="Reply body")
+    reply = reply_repo.create(reply)
+
+    return engagement_repo, discussion, reply
+
+
+# ---- Discussion Votes ----
+
+def test_set_discussion_vote_upvote(setup):
+    repo, discussion, _ = setup
+    result = repo.set_discussion_vote(discussion.id, 1, 1)
+    assert result == 1
+    assert repo.get_discussion_vote(discussion.id, 1) == 1
+
+
+def test_set_discussion_vote_toggle_off(setup):
+    repo, discussion, _ = setup
+    repo.set_discussion_vote(discussion.id, 1, 1)
+    result = repo.set_discussion_vote(discussion.id, 1, 1)  # same vote again
+    assert result is None
+    assert repo.get_discussion_vote(discussion.id, 1) is None
+
+
+def test_set_discussion_vote_change(setup):
+    repo, discussion, _ = setup
+    repo.set_discussion_vote(discussion.id, 1, 1)
+    result = repo.set_discussion_vote(discussion.id, 1, -1)
+    assert result == -1
+    assert repo.get_discussion_vote(discussion.id, 1) == -1
+
+
+def test_count_discussion_votes(setup):
+    repo, discussion, _ = setup
+    repo.set_discussion_vote(discussion.id, 1, 1)  # alice upvotes
+    repo.set_discussion_vote(discussion.id, 2, -1)  # bob downvotes
+    counts = repo.count_discussion_votes(discussion.id)
+    assert counts == {"upvotes": 1, "downvotes": 1}
+
+
+# ---- Reply Votes ----
+
+def test_set_reply_vote(setup):
+    repo, _, reply = setup
+    result = repo.set_reply_vote(reply.id, 1, 1)
+    assert result == 1
+    counts = repo.count_reply_votes(reply.id)
+    assert counts["upvotes"] == 1
+
+
+def test_reply_vote_toggle(setup):
+    repo, _, reply = setup
+    repo.set_reply_vote(reply.id, 1, 1)
+    repo.set_reply_vote(reply.id, 1, 1)  # toggle off
+    counts = repo.count_reply_votes(reply.id)
+    assert counts["upvotes"] == 0
+
+
+# ---- Discussion Reactions ----
+
+def test_toggle_discussion_reaction_on(setup):
+    repo, discussion, _ = setup
+    result = repo.toggle_discussion_reaction(discussion.id, 1, "insightful")
+    assert result is True
+    reactions = repo.get_discussion_reactions(discussion.id)
+    assert len(reactions) == 1
+    assert reactions[0]["type"] == "insightful"
+    assert reactions[0]["count"] == 1
+
+
+def test_toggle_discussion_reaction_off(setup):
+    repo, discussion, _ = setup
+    repo.toggle_discussion_reaction(discussion.id, 1, "insightful")
+    result = repo.toggle_discussion_reaction(discussion.id, 1, "insightful")
+    assert result is False
+    reactions = repo.get_discussion_reactions(discussion.id)
+    assert len(reactions) == 0
+
+
+def test_get_user_discussion_reactions(setup):
+    repo, discussion, _ = setup
+    repo.toggle_discussion_reaction(discussion.id, 1, "insightful")
+    repo.toggle_discussion_reaction(discussion.id, 1, "helpful")
+    user_reactions = repo.get_user_discussion_reactions(discussion.id, 1)
+    assert set(user_reactions) == {"insightful", "helpful"}
+
+
+# ---- Reply Reactions ----
+
+def test_toggle_reply_reaction(setup):
+    repo, _, reply = setup
+    result = repo.toggle_reply_reaction(reply.id, 1, "genius")
+    assert result is True
+    reactions = repo.get_reply_reactions(reply.id)
+    assert len(reactions) == 1
+    assert reactions[0]["type"] == "genius"
+
+
+def test_get_user_reply_reactions(setup):
+    repo, _, reply = setup
+    repo.toggle_reply_reaction(reply.id, 1, "genius")
+    user_reactions = repo.get_user_reply_reactions(reply.id, 1)
+    assert user_reactions == ["genius"]
+
+
+# ---- Follows ----
+
+def test_toggle_follow_on(setup):
+    repo, discussion, _ = setup
+    result = repo.toggle_follow(discussion.id, 1)
+    assert result is True
+    assert repo.is_following(discussion.id, 1) is True
+
+
+def test_toggle_follow_off(setup):
+    repo, discussion, _ = setup
+    repo.toggle_follow(discussion.id, 1)
+    result = repo.toggle_follow(discussion.id, 1)
+    assert result is False
+    assert repo.is_following(discussion.id, 1) is False
+
+
+def test_get_follower_ids(setup):
+    repo, discussion, _ = setup
+    repo.toggle_follow(discussion.id, 1)
+    repo.toggle_follow(discussion.id, 2)
+    followers = repo.get_follower_ids(discussion.id)
+    assert set(followers) == {1, 2}
+
+
+# ---- Bookmarks ----
+
+def test_toggle_bookmark_on(setup):
+    repo, discussion, _ = setup
+    result = repo.toggle_bookmark(discussion.id, 1)
+    assert result is True
+    assert repo.is_bookmarked(discussion.id, 1) is True
+
+
+def test_toggle_bookmark_off(setup):
+    repo, discussion, _ = setup
+    repo.toggle_bookmark(discussion.id, 1)
+    result = repo.toggle_bookmark(discussion.id, 1)
+    assert result is False
+    assert repo.is_bookmarked(discussion.id, 1) is False
+
+
+def test_get_user_bookmarked_ids(setup):
+    repo, discussion, _ = setup
+    repo.toggle_bookmark(discussion.id, 1)
+    bookmarked = repo.get_user_bookmarked_ids(1)
+    assert bookmarked == [discussion.id]
+
+
+# ---- Bulk engagement data ----
+
+def test_get_discussion_engagement(setup):
+    repo, discussion, _ = setup
+    repo.set_discussion_vote(discussion.id, 1, 1)
+    repo.toggle_discussion_reaction(discussion.id, 1, "helpful")
+    repo.toggle_follow(discussion.id, 1)
+    repo.toggle_bookmark(discussion.id, 1)
+
+    engagement = repo.get_discussion_engagement(discussion.id, 1)
+    assert engagement["upvotes"] == 1
+    assert engagement["downvotes"] == 0
+    assert engagement["user_vote"] == 1
+    assert len(engagement["reactions"]) == 1
+    assert engagement["user_reactions"] == ["helpful"]
+    assert engagement["is_following"] is True
+    assert engagement["is_bookmarked"] is True
+
+
+def test_get_reply_engagement(setup):
+    repo, _, reply = setup
+    repo.set_reply_vote(reply.id, 1, -1)
+    repo.toggle_reply_reaction(reply.id, 1, "thinking")
+
+    engagement = repo.get_reply_engagement(reply.id, 1)
+    assert engagement["upvotes"] == 0
+    assert engagement["downvotes"] == 1
+    assert engagement["user_vote"] == -1
+    assert len(engagement["reactions"]) == 1
+    assert engagement["user_reactions"] == ["thinking"]

--- a/src/tests/PersistantLayerTests/test_reply_repo.py
+++ b/src/tests/PersistantLayerTests/test_reply_repo.py
@@ -1,0 +1,168 @@
+import sqlite3
+import pytest
+
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    c.execute("PRAGMA foreign_keys = ON;")
+    return c
+
+
+@pytest.fixture
+def user_repo(conn):
+    return UserRepo(conn)
+
+
+@pytest.fixture
+def puzzle_repo(conn):
+    """Create puzzles table (needed for FK references)."""
+    return PuzzleRepo(conn)
+
+
+@pytest.fixture
+def discussion_repo(conn, user_repo, puzzle_repo):
+    user = User(id=0, username="testuser", role=UserRole.SOLVER, xp=0)
+    user_repo.create(user, password="pw")
+    return DiscussionRepo(conn)
+
+
+@pytest.fixture
+def repo(conn, discussion_repo):
+    # Create a discussion to reference
+    d = Discussion(id=0, title="Test", body="body", author_id=1, category=ThreadCategory.GENERAL)
+    discussion_repo.create(d)
+    return ReplyRepo(conn)
+
+
+def make_reply(discussion_id=1, author_id=1, body="This is a reply", parent_reply_id=None):
+    return Reply(
+        id=0,
+        discussion_id=discussion_id,
+        author_id=author_id,
+        body=body,
+        parent_reply_id=parent_reply_id,
+    )
+
+
+def test_schema_created(conn, repo):
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='replies'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_create_and_get(repo):
+    r = make_reply()
+    created = repo.create(r)
+    assert created.id > 0
+
+    fetched = repo.get_by_id(created.id)
+    assert fetched is not None
+    assert fetched.body == "This is a reply"
+    assert fetched.discussion_id == 1
+
+
+def test_get_nonexistent(repo):
+    assert repo.get_by_id(999) is None
+
+
+def test_list_by_discussion(repo):
+    repo.create(make_reply(body="Reply 1"))
+    repo.create(make_reply(body="Reply 2"))
+    repo.create(make_reply(body="Reply 3"))
+
+    replies = repo.list_by_discussion(1)
+    assert len(replies) == 3
+
+
+def test_list_top_level(repo):
+    r1 = repo.create(make_reply(body="Top level 1"))
+    r2 = repo.create(make_reply(body="Top level 2"))
+    repo.create(make_reply(body="Child", parent_reply_id=r1.id))
+
+    top = repo.list_top_level(1)
+    assert len(top) == 2
+
+
+def test_list_children(repo):
+    parent = repo.create(make_reply(body="Parent"))
+    repo.create(make_reply(body="Child 1", parent_reply_id=parent.id))
+    repo.create(make_reply(body="Child 2", parent_reply_id=parent.id))
+
+    children = repo.list_children(parent.id)
+    assert len(children) == 2
+
+
+def test_count_by_discussion(repo):
+    repo.create(make_reply())
+    repo.create(make_reply())
+    assert repo.count_by_discussion(1) == 2
+
+
+def test_update(repo):
+    r = repo.create(make_reply())
+    updated = repo.update(r.id, {"body": "Updated body"})
+    assert updated.body == "Updated body"
+
+
+def test_delete(repo):
+    r = repo.create(make_reply())
+    assert repo.delete(r.id)
+    assert repo.get_by_id(r.id) is None
+
+
+def test_delete_nonexistent(repo):
+    assert not repo.delete(999)
+
+
+def test_update_votes(repo):
+    r = repo.create(make_reply())
+    repo.update_votes(r.id, 5, 2)
+
+    fetched = repo.get_by_id(r.id)
+    assert fetched.upvotes == 5
+    assert fetched.downvotes == 2
+
+
+def test_clear_accepted_for_discussion(repo):
+    r1 = repo.create(make_reply(body="Reply 1"))
+    r2 = repo.create(make_reply(body="Reply 2"))
+    repo.update(r1.id, {"is_accepted": True})
+
+    fetched = repo.get_by_id(r1.id)
+    assert fetched.is_accepted is True
+
+    repo.clear_accepted_for_discussion(1)
+
+    fetched1 = repo.get_by_id(r1.id)
+    fetched2 = repo.get_by_id(r2.id)
+    assert fetched1.is_accepted is False
+    assert fetched2.is_accepted is False
+
+
+def test_nested_replies(repo):
+    parent = repo.create(make_reply(body="Level 0"))
+    child = repo.create(make_reply(body="Level 1", parent_reply_id=parent.id))
+    grandchild = repo.create(make_reply(body="Level 2", parent_reply_id=child.id))
+
+    assert grandchild.parent_reply_id == child.id
+
+    children_of_parent = repo.list_children(parent.id)
+    assert len(children_of_parent) == 1
+    assert children_of_parent[0].id == child.id
+
+    children_of_child = repo.list_children(child.id)
+    assert len(children_of_child) == 1
+    assert children_of_child[0].id == grandchild.id

--- a/src/tests/PersistantLayerTests/test_report_repo.py
+++ b/src/tests/PersistantLayerTests/test_report_repo.py
@@ -1,0 +1,308 @@
+import sqlite3
+import pytest
+
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
+from Backend.PersistantLayer.ReplyRepo import ReplyRepo
+from Backend.PersistantLayer.ReportRepo import ReportRepo
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    c.execute("PRAGMA foreign_keys = ON;")
+    return c
+
+
+@pytest.fixture
+def setup(conn):
+    user_repo = UserRepo(conn)
+    PuzzleRepo(conn)  # needed for FK
+    discussion_repo = DiscussionRepo(conn)
+    reply_repo = ReplyRepo(conn)
+    report_repo = ReportRepo(conn)
+
+    # Create test users
+    alice = User(id=0, username="alice", role=UserRole.SOLVER, xp=0)
+    user_repo.create(alice, password="pw")
+    bob = User(id=0, username="bob", role=UserRole.SOLVER, xp=0)
+    user_repo.create(bob, password="pw")
+
+    # Create a test discussion
+    discussion = Discussion(
+        id=0, title="Test Discussion", body="Test body", author_id=1,
+        category=ThreadCategory.GENERAL,
+    )
+    discussion = discussion_repo.create(discussion)
+
+    # Create a test reply
+    reply = Reply(id=0, discussion_id=discussion.id, author_id=2, body="Reply body")
+    reply = reply_repo.create(reply)
+
+    return report_repo, discussion, reply
+
+
+# ---- Create ----
+
+def test_create_report(setup):
+    repo, discussion, _ = setup
+    report = repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+        details="This is spam content",
+    )
+    assert report["id"] > 0
+    assert report["reporter_id"] == 1
+    assert report["target_type"] == "discussion"
+    assert report["target_id"] == discussion.id
+    assert report["reason"] == "spam"
+    assert report["details"] == "This is spam content"
+    assert report["status"] == "pending"
+    assert "created_at" in report
+
+
+def test_create_report_default_details(setup):
+    repo, discussion, _ = setup
+    report = repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="offensive",
+    )
+    assert report["details"] == ""
+
+
+def test_create_report_on_reply(setup):
+    repo, _, reply = setup
+    report = repo.create(
+        reporter_id=1,
+        target_type="reply",
+        target_id=reply.id,
+        reason="harassment",
+        details="Harassing content",
+    )
+    assert report["target_type"] == "reply"
+    assert report["target_id"] == reply.id
+
+
+# ---- Get by ID ----
+
+def test_get_by_id(setup):
+    repo, discussion, _ = setup
+    created = repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    fetched = repo.get_by_id(created["id"])
+    assert fetched is not None
+    assert fetched["id"] == created["id"]
+    assert fetched["reporter_id"] == 1
+    assert fetched["target_type"] == "discussion"
+    assert fetched["target_id"] == discussion.id
+    assert fetched["reason"] == "spam"
+    assert fetched["status"] == "pending"
+
+
+def test_get_by_id_nonexistent(setup):
+    repo, _, _ = setup
+    assert repo.get_by_id(999) is None
+
+
+# ---- List all ----
+
+def test_list_all_default(setup):
+    repo, discussion, reply = setup
+    repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    repo.create(reporter_id=2, target_type="reply", target_id=reply.id, reason="offensive")
+
+    reports = repo.list_all()
+    assert len(reports) == 2
+
+
+def test_list_all_filtered_by_status(setup):
+    repo, discussion, reply = setup
+    r1 = repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    repo.create(reporter_id=2, target_type="reply", target_id=reply.id, reason="offensive")
+
+    # Update one report to "resolved"
+    repo.update_status(r1["id"], "resolved")
+
+    pending = repo.list_all(status="pending")
+    assert len(pending) == 1
+    assert pending[0]["status"] == "pending"
+
+    resolved = repo.list_all(status="resolved")
+    assert len(resolved) == 1
+    assert resolved[0]["status"] == "resolved"
+
+
+def test_list_all_with_limit_and_offset(setup):
+    repo, discussion, reply = setup
+    repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    repo.create(reporter_id=2, target_type="reply", target_id=reply.id, reason="offensive")
+
+    page1 = repo.list_all(limit=1, offset=0)
+    assert len(page1) == 1
+
+    page2 = repo.list_all(limit=1, offset=1)
+    assert len(page2) == 1
+
+    # The two pages should have different reports
+    assert page1[0]["id"] != page2[0]["id"]
+
+
+def test_list_all_empty(setup):
+    repo, _, _ = setup
+    reports = repo.list_all()
+    assert reports == []
+
+
+# ---- Count ----
+
+def test_count_all(setup):
+    repo, discussion, reply = setup
+    repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    repo.create(reporter_id=2, target_type="reply", target_id=reply.id, reason="offensive")
+
+    assert repo.count() == 2
+
+
+def test_count_filtered_by_status(setup):
+    repo, discussion, reply = setup
+    r1 = repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    repo.create(reporter_id=2, target_type="reply", target_id=reply.id, reason="offensive")
+
+    repo.update_status(r1["id"], "resolved")
+
+    assert repo.count(status="pending") == 1
+    assert repo.count(status="resolved") == 1
+    assert repo.count() == 2
+
+
+def test_count_empty(setup):
+    repo, _, _ = setup
+    assert repo.count() == 0
+
+
+# ---- Update status ----
+
+def test_update_status(setup):
+    repo, discussion, _ = setup
+    created = repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    assert created["status"] == "pending"
+
+    updated = repo.update_status(created["id"], "resolved")
+    assert updated is not None
+    assert updated["status"] == "resolved"
+    assert updated["id"] == created["id"]
+
+
+def test_update_status_to_dismissed(setup):
+    repo, discussion, _ = setup
+    created = repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    updated = repo.update_status(created["id"], "dismissed")
+    assert updated["status"] == "dismissed"
+
+
+def test_update_status_nonexistent(setup):
+    repo, _, _ = setup
+    result = repo.update_status(999, "resolved")
+    assert result is None
+
+
+# ---- has_reported ----
+
+def test_has_reported_true(setup):
+    repo, discussion, _ = setup
+    repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    assert repo.has_reported(1, "discussion", discussion.id) is True
+
+
+def test_has_reported_false(setup):
+    repo, discussion, _ = setup
+    assert repo.has_reported(1, "discussion", discussion.id) is False
+
+
+def test_has_reported_different_target_type(setup):
+    repo, discussion, reply = setup
+    repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    # Same reporter, but target_type is "reply" -- should be False
+    assert repo.has_reported(1, "reply", reply.id) is False
+
+
+def test_has_reported_different_user(setup):
+    repo, discussion, _ = setup
+    repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    # Different reporter -- should be False
+    assert repo.has_reported(2, "discussion", discussion.id) is False
+
+
+# ---- Duplicate report (UNIQUE constraint) ----
+
+def test_duplicate_report_raises_integrity_error(setup):
+    repo, discussion, _ = setup
+    repo.create(
+        reporter_id=1,
+        target_type="discussion",
+        target_id=discussion.id,
+        reason="spam",
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create(
+            reporter_id=1,
+            target_type="discussion",
+            target_id=discussion.id,
+            reason="offensive",
+        )
+
+
+def test_same_reporter_different_targets_allowed(setup):
+    repo, discussion, reply = setup
+    # Same reporter can report different targets
+    r1 = repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    r2 = repo.create(reporter_id=1, target_type="reply", target_id=reply.id, reason="harassment")
+    assert r1["id"] != r2["id"]
+
+
+def test_different_reporters_same_target_allowed(setup):
+    repo, discussion, _ = setup
+    # Different reporters can report the same target
+    r1 = repo.create(reporter_id=1, target_type="discussion", target_id=discussion.id, reason="spam")
+    r2 = repo.create(reporter_id=2, target_type="discussion", target_id=discussion.id, reason="offensive")
+    assert r1["id"] != r2["id"]

--- a/src/tests/ServiceLayerTests/test_discussion_service.py
+++ b/src/tests/ServiceLayerTests/test_discussion_service.py
@@ -51,18 +51,21 @@ class TestCreateDiscussion:
     def test_missing_title(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         with pytest.raises(ValidationError, match="title"):
             svc.create_discussion("token", {"title": "", "body": "Body"})
 
     def test_missing_body(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         with pytest.raises(ValidationError, match="body"):
             svc.create_discussion("token", {"title": "Title", "body": ""})
 
     def test_invalid_category(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         with pytest.raises(ValidationError, match="category"):
             svc.create_discussion("token", {"title": "T", "body": "B", "category": "invalid"})
 
@@ -208,3 +211,274 @@ class TestLockDiscussion:
 
         with pytest.raises(ValidationError, match="admin"):
             svc.lock_discussion("token", 1)
+
+
+# ---------------------------------------------------------------------------
+# Full-service factory (includes engagement, report, notification repos)
+# ---------------------------------------------------------------------------
+
+def make_full_service():
+    """Service with engagement, report, and notification repos."""
+    discussion_repo = Mock()
+    reply_repo = Mock()
+    user_repo = Mock()
+    auth_service = Mock()
+    xp_service = Mock()
+    engagement_repo = Mock()
+    report_repo = Mock()
+    notification_repo = Mock()
+    service = DiscussionService(
+        discussion_repo=discussion_repo,
+        reply_repo=reply_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+        engagement_repo=engagement_repo,
+        report_repo=report_repo,
+        notification_repo=notification_repo,
+    )
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Engagement tests
+# ---------------------------------------------------------------------------
+
+class TestVoteDiscussion:
+    def test_upvote_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.get_discussion_vote.return_value = None
+        svc.engagement.set_discussion_vote.return_value = 1
+        svc.engagement.count_discussion_votes.return_value = {"upvotes": 1, "downvotes": 0}
+
+        result = svc.vote_discussion("token", 1, 1)
+
+        assert result["upvotes"] == 1
+        assert result["user_vote"] == 1
+        svc.xp._apply_xp.assert_called_once_with(1, 3)
+
+    def test_downvote_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.get_discussion_vote.return_value = None
+        svc.engagement.set_discussion_vote.return_value = -1
+        svc.engagement.count_discussion_votes.return_value = {"upvotes": 0, "downvotes": 1}
+
+        result = svc.vote_discussion("token", 1, -1)
+
+        assert result["downvotes"] == 1
+        svc.xp._apply_xp.assert_not_called()
+
+    def test_toggle_removes_vote(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.get_discussion_vote.return_value = 1
+        svc.engagement.set_discussion_vote.return_value = None
+        svc.engagement.count_discussion_votes.return_value = {"upvotes": 0, "downvotes": 0}
+
+        result = svc.vote_discussion("token", 1, 1)
+
+        assert result["user_vote"] is None
+        svc.xp._apply_xp.assert_not_called()
+
+
+class TestReactToDiscussion:
+    def test_add_reaction_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_discussion_reaction.return_value = True
+        svc.engagement.get_discussion_reactions.return_value = [{"type": "insightful", "count": 1}]
+        svc.engagement.get_user_discussion_reactions.return_value = ["insightful"]
+
+        result = svc.react_to_discussion("token", 1, "insightful")
+
+        assert result["is_active"] is True
+        svc.xp._apply_xp.assert_called_once_with(1, 1)
+
+    def test_remove_reaction_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_discussion_reaction.return_value = False
+        svc.engagement.get_discussion_reactions.return_value = []
+        svc.engagement.get_user_discussion_reactions.return_value = []
+
+        result = svc.react_to_discussion("token", 1, "insightful")
+
+        assert result["is_active"] is False
+        svc.xp._apply_xp.assert_not_called()
+
+    def test_invalid_reaction_type(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+
+        with pytest.raises(ValidationError, match="invalid reaction"):
+            svc.react_to_discussion("token", 1, "invalid_type")
+
+
+class TestFollowDiscussion:
+    def test_follow_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_follow.return_value = True
+
+        result = svc.follow_discussion("token", 1)
+
+        assert result["is_following"] is True
+
+    def test_unfollow_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_follow.return_value = False
+
+        result = svc.follow_discussion("token", 1)
+
+        assert result["is_following"] is False
+
+
+class TestBookmarkDiscussion:
+    def test_bookmark_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_bookmark.return_value = True
+
+        result = svc.bookmark_discussion("token", 1)
+
+        assert result["is_bookmarked"] is True
+
+    def test_unbookmark_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.engagement.toggle_bookmark.return_value = False
+
+        result = svc.bookmark_discussion("token", 1)
+
+        assert result["is_bookmarked"] is False
+
+
+# ---------------------------------------------------------------------------
+# Report tests
+# ---------------------------------------------------------------------------
+
+class TestReportDiscussion:
+    def test_report_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.report_repo.has_reported.return_value = False
+        svc.report_repo.create.return_value = {"id": 1, "reporter_id": 2, "target_type": "discussion", "target_id": 1, "reason": "spam"}
+
+        result = svc.report_discussion("token", 1, "spam")
+
+        svc.report_repo.create.assert_called_once()
+
+    def test_duplicate_report_rejected(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=1)
+        svc.report_repo.has_reported.return_value = True
+
+        with pytest.raises(ValidationError, match="already reported"):
+            svc.report_discussion("token", 1, "spam")
+
+
+# ---------------------------------------------------------------------------
+# Admin moderation tests
+# ---------------------------------------------------------------------------
+
+class TestAdminModeration:
+    def test_warn_author_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 10
+        svc.user_repo.get_by_id.return_value = make_user(user_id=10, role=UserRole.ADMIN)
+        svc.report_repo.get_by_id.return_value = {
+            "id": 1, "target_type": "discussion", "target_id": 1, "reason": "spam",
+        }
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=5)
+
+        result = svc.warn_user_for_report("token", 1)
+
+        svc.notification_repo.create.assert_called_once()
+        call_kwargs = svc.notification_repo.create.call_args[1]
+        assert call_kwargs["user_id"] == 5
+        assert call_kwargs["notif_type"] == "warning"
+        svc.report_repo.update_status.assert_called_once_with(1, "reviewed")
+
+    def test_ban_author_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 10
+        svc.user_repo.get_by_id.return_value = make_user(user_id=10, role=UserRole.ADMIN)
+        svc.report_repo.get_by_id.return_value = {
+            "id": 1, "target_type": "discussion", "target_id": 1, "reason": "spam",
+        }
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=5)
+
+        result = svc.ban_user_for_report("token", 1)
+
+        svc.user_repo.ban_from_discussions.assert_called_once_with(5)
+        svc.notification_repo.create.assert_called_once()
+        call_kwargs = svc.notification_repo.create.call_args[1]
+        assert call_kwargs["notif_type"] == "ban"
+        svc.report_repo.update_status.assert_called_once_with(1, "reviewed")
+
+    def test_delete_content_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 10
+        svc.user_repo.get_by_id.return_value = make_user(user_id=10, role=UserRole.ADMIN)
+        svc.report_repo.get_by_id.return_value = {
+            "id": 1, "target_type": "discussion", "target_id": 1, "reason": "spam",
+        }
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=5)
+
+        result = svc.delete_reported_content("token", 1)
+
+        svc.discussion_repo.delete.assert_called_once_with(1)
+        svc.report_repo.update_status.assert_called_once_with(1, "reviewed")
+
+    def test_lock_discussion_from_report_success(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 10
+        svc.user_repo.get_by_id.return_value = make_user(user_id=10, role=UserRole.ADMIN)
+        svc.report_repo.get_by_id.return_value = {
+            "id": 1, "target_type": "discussion", "target_id": 1, "reason": "spam",
+        }
+        svc.discussion_repo.get_by_id.return_value = make_discussion(discussion_id=1, author_id=5)
+
+        result = svc.lock_reported_discussion("token", 1)
+
+        svc.discussion_repo.update.assert_called_once_with(1, {"is_locked": True})
+        svc.report_repo.update_status.assert_called_once_with(1, "reviewed")
+
+    def test_non_admin_cannot_moderate(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.user_repo.get_by_id.return_value = make_user(user_id=2, role=UserRole.SOLVER)
+
+        with pytest.raises(ValidationError, match="admin"):
+            svc.warn_user_for_report("token", 1)
+
+
+# ---------------------------------------------------------------------------
+# Ban enforcement tests
+# ---------------------------------------------------------------------------
+
+class TestBanEnforcement:
+    def test_banned_user_cannot_create_discussion(self):
+        svc = make_full_service()
+        svc.auth.require_user_id.return_value = 1
+        user = make_user(user_id=1, role=UserRole.SOLVER)
+        user.is_discussion_banned = True
+        svc.user_repo.get_by_id.return_value = user
+
+        with pytest.raises(ValidationError, match="banned"):
+            svc.create_discussion("token", {"title": "Test", "body": "Body"})

--- a/src/tests/ServiceLayerTests/test_discussion_service.py
+++ b/src/tests/ServiceLayerTests/test_discussion_service.py
@@ -1,0 +1,210 @@
+import pytest
+from unittest.mock import Mock
+
+from Backend.ServiceLayer.DiscussionService import DiscussionService, DISCUSSION_CREATE_XP
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+from Backend.DomainLayer.Exceptions import ValidationError
+
+
+def make_service():
+    discussion_repo = Mock()
+    reply_repo = Mock()
+    user_repo = Mock()
+    auth_service = Mock()
+    xp_service = Mock()
+    service = DiscussionService(
+        discussion_repo=discussion_repo,
+        reply_repo=reply_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+    )
+    return service
+
+
+def make_user(user_id=1, role=UserRole.SOLVER):
+    return User(id=user_id, username=f"user{user_id}", role=role, xp=100)
+
+
+def make_discussion(discussion_id=1, author_id=1, title="Test", body="Body", category=ThreadCategory.GENERAL):
+    return Discussion(
+        id=discussion_id, title=title, body=body, author_id=author_id, category=category
+    )
+
+
+class TestCreateDiscussion:
+    def test_success(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        created = make_discussion()
+        svc.discussion_repo.create.return_value = created
+        svc.user_repo.get_by_id.return_value = make_user()
+        svc.xp._apply_xp.return_value = DISCUSSION_CREATE_XP
+
+        result = svc.create_discussion("token", {"title": "Test", "body": "Body"})
+        assert result["title"] == "Test"
+        svc.discussion_repo.create.assert_called_once()
+        svc.xp._apply_xp.assert_called_once_with(1, DISCUSSION_CREATE_XP)
+
+    def test_missing_title(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        with pytest.raises(ValidationError, match="title"):
+            svc.create_discussion("token", {"title": "", "body": "Body"})
+
+    def test_missing_body(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        with pytest.raises(ValidationError, match="body"):
+            svc.create_discussion("token", {"title": "Title", "body": ""})
+
+    def test_invalid_category(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        with pytest.raises(ValidationError, match="category"):
+            svc.create_discussion("token", {"title": "T", "body": "B", "category": "invalid"})
+
+    def test_with_category_and_puzzle_id(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        created = make_discussion(title="Help!", body="Stuck", category=ThreadCategory.PUZZLE_HELP)
+        svc.discussion_repo.create.return_value = created
+        svc.user_repo.get_by_id.return_value = make_user()
+        svc.xp._apply_xp.return_value = DISCUSSION_CREATE_XP
+
+        result = svc.create_discussion("token", {
+            "title": "Help!", "body": "Stuck", "category": "puzzle_help", "puzzle_id": 5
+        })
+        assert result["title"] == "Help!"
+
+
+class TestGetDiscussion:
+    def test_success(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        svc.user_repo.get_by_id.return_value = make_user()
+        svc.reply_repo.list_top_level.return_value = []
+
+        result = svc.get_discussion("token", 1)
+        assert result["title"] == "Test"
+        svc.discussion_repo.increment_view_count.assert_called_once_with(1)
+
+    def test_not_found(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = None
+        with pytest.raises(ValidationError, match="not found"):
+            svc.get_discussion("token", 999)
+
+
+class TestListDiscussions:
+    def test_success(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.list_all.return_value = [make_discussion(), make_discussion(discussion_id=2, title="T2")]
+        svc.discussion_repo.count.return_value = 2
+        svc.user_repo.get_by_id.return_value = make_user()
+
+        result = svc.list_discussions("token")
+        assert len(result["discussions"]) == 2
+        assert result["total"] == 2
+
+
+class TestUpdateDiscussion:
+    def test_owner_can_update(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+        updated = make_discussion(title="Updated")
+        svc.discussion_repo.update.return_value = updated
+
+        result = svc.update_discussion("token", 1, {"title": "Updated"})
+        assert result["title"] == "Updated"
+
+    def test_admin_can_update(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(2, role=UserRole.ADMIN)
+        updated = make_discussion(title="Admin Updated")
+        svc.discussion_repo.update.return_value = updated
+
+        result = svc.update_discussion("token", 1, {"title": "Admin Updated"})
+        assert result["title"] == "Admin Updated"
+
+    def test_non_owner_cannot_update(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(2)
+
+        with pytest.raises(ValidationError, match="not allowed"):
+            svc.update_discussion("token", 1, {"title": "Nope"})
+
+
+class TestDeleteDiscussion:
+    def test_owner_can_delete(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        result = svc.delete_discussion("token", 1)
+        assert result["deleted"] is True
+
+    def test_non_owner_cannot_delete(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(2)
+
+        with pytest.raises(ValidationError, match="not allowed"):
+            svc.delete_discussion("token", 1)
+
+
+class TestPinDiscussion:
+    def test_admin_can_pin(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user(1, role=UserRole.ADMIN)
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        pinned = make_discussion()
+        pinned.is_pinned = True
+        svc.discussion_repo.update.return_value = pinned
+
+        result = svc.pin_discussion("token", 1)
+        assert result["is_pinned"] is True
+
+    def test_non_admin_cannot_pin(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        with pytest.raises(ValidationError, match="admin"):
+            svc.pin_discussion("token", 1)
+
+
+class TestLockDiscussion:
+    def test_admin_can_lock(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user(1, role=UserRole.ADMIN)
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        locked = make_discussion()
+        locked.is_locked = True
+        svc.discussion_repo.update.return_value = locked
+
+        result = svc.lock_discussion("token", 1)
+        assert result["is_locked"] is True
+
+    def test_non_admin_cannot_lock(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        with pytest.raises(ValidationError, match="admin"):
+            svc.lock_discussion("token", 1)

--- a/src/tests/ServiceLayerTests/test_reply_service.py
+++ b/src/tests/ServiceLayerTests/test_reply_service.py
@@ -1,0 +1,206 @@
+import pytest
+from unittest.mock import Mock
+
+from Backend.ServiceLayer.ReplyService import ReplyService, REPLY_CREATE_XP, REPLY_ACCEPTED_XP, ACCEPT_SOLUTION_XP
+from Backend.DomainLayer.Discussion import Discussion
+from Backend.DomainLayer.Reply import Reply
+from Backend.DomainLayer.User import User
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+from Backend.DomainLayer.Exceptions import ValidationError
+
+
+def make_service():
+    reply_repo = Mock()
+    discussion_repo = Mock()
+    user_repo = Mock()
+    auth_service = Mock()
+    xp_service = Mock()
+    return ReplyService(
+        reply_repo=reply_repo,
+        discussion_repo=discussion_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+    )
+
+
+def make_user(user_id=1, role=UserRole.SOLVER):
+    return User(id=user_id, username=f"user{user_id}", role=role, xp=100)
+
+
+def make_discussion(discussion_id=1, author_id=1, is_locked=False):
+    d = Discussion(id=discussion_id, title="Test", body="Body", author_id=author_id, category=ThreadCategory.GENERAL)
+    d.is_locked = is_locked
+    return d
+
+
+def make_reply(reply_id=1, discussion_id=1, author_id=1, is_accepted=False, parent_reply_id=None):
+    r = Reply(id=reply_id, discussion_id=discussion_id, author_id=author_id, body="Reply body", parent_reply_id=parent_reply_id)
+    r.is_accepted = is_accepted
+    return r
+
+
+class TestCreateReply:
+    def test_success(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        created = make_reply()
+        svc.reply_repo.create.return_value = created
+        svc.user_repo.get_by_id.return_value = make_user()
+        svc.xp._apply_xp.return_value = REPLY_CREATE_XP
+
+        result = svc.create_reply("token", 1, {"body": "My reply"})
+        assert result["body"] == "Reply body"
+        svc.reply_repo.create.assert_called_once()
+        svc.discussion_repo.increment_reply_count.assert_called_once_with(1, 1)
+        svc.xp._apply_xp.assert_called_once_with(1, REPLY_CREATE_XP)
+
+    def test_locked_discussion(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion(is_locked=True)
+
+        with pytest.raises(ValidationError, match="locked"):
+            svc.create_reply("token", 1, {"body": "Nope"})
+
+    def test_missing_body(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+
+        with pytest.raises(ValidationError, match="body"):
+            svc.create_reply("token", 1, {"body": ""})
+
+    def test_discussion_not_found(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = None
+
+        with pytest.raises(ValidationError, match="not found"):
+            svc.create_reply("token", 1, {"body": "Reply"})
+
+    def test_with_parent_reply(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        parent = make_reply(reply_id=5, discussion_id=1)
+        svc.reply_repo.get_by_id.return_value = parent
+        created = make_reply(parent_reply_id=5)
+        svc.reply_repo.create.return_value = created
+        svc.user_repo.get_by_id.return_value = make_user()
+        svc.xp._apply_xp.return_value = REPLY_CREATE_XP
+
+        result = svc.create_reply("token", 1, {"body": "Nested reply", "parent_reply_id": 5})
+        svc.reply_repo.create.assert_called_once()
+
+    def test_invalid_parent_reply(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.discussion_repo.get_by_id.return_value = make_discussion()
+        svc.reply_repo.get_by_id.return_value = None
+
+        with pytest.raises(ValidationError, match="invalid parent"):
+            svc.create_reply("token", 1, {"body": "Reply", "parent_reply_id": 999})
+
+
+class TestUpdateReply:
+    def test_owner_can_update(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.reply_repo.get_by_id.return_value = make_reply(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+        updated = make_reply()
+        svc.reply_repo.update.return_value = updated
+
+        result = svc.update_reply("token", 1, {"body": "Updated"})
+        assert result["body"] == "Reply body"
+
+    def test_non_owner_cannot_update(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(2)
+
+        with pytest.raises(ValidationError, match="not allowed"):
+            svc.update_reply("token", 1, {"body": "Nope"})
+
+
+class TestDeleteReply:
+    def test_owner_can_delete(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        svc.reply_repo.get_by_id.return_value = make_reply(author_id=1, discussion_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        result = svc.delete_reply("token", 1)
+        assert result["deleted"] is True
+        svc.discussion_repo.increment_reply_count.assert_called_once_with(1, -1)
+
+
+class TestAcceptReply:
+    def test_thread_author_can_accept(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1  # Thread author
+        reply = make_reply(reply_id=5, author_id=2)  # Reply by someone else
+        svc.reply_repo.get_by_id.return_value = reply
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        # After accept, return updated reply
+        accepted = make_reply(reply_id=5, author_id=2, is_accepted=True)
+        svc.reply_repo.update.return_value = None
+        # get_by_id called after update returns accepted version
+        svc.reply_repo.get_by_id.side_effect = [reply, accepted]
+        user2 = make_user(2)
+        svc.user_repo.get_by_id.side_effect = [make_user(1), user2]
+        svc.xp._apply_xp.return_value = 0
+
+        result = svc.accept_reply("token", 5)
+        assert result["is_accepted"] is True
+        # XP awarded: +25 to reply author (2), +5 to acceptor (1)
+        svc.xp._apply_xp.assert_any_call(2, REPLY_ACCEPTED_XP)
+        svc.xp._apply_xp.assert_any_call(1, ACCEPT_SOLUTION_XP)
+
+    def test_non_author_cannot_accept(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 3  # Not thread author
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=5, author_id=2)
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(3)
+
+        with pytest.raises(ValidationError, match="only"):
+            svc.accept_reply("token", 5)
+
+    def test_admin_can_accept(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 3  # Admin, not thread author
+        reply = make_reply(reply_id=5, author_id=2)
+        svc.reply_repo.get_by_id.return_value = reply
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(3, role=UserRole.ADMIN)
+
+        accepted = make_reply(reply_id=5, author_id=2, is_accepted=True)
+        svc.reply_repo.get_by_id.side_effect = [reply, accepted]
+        svc.user_repo.get_by_id.side_effect = [make_user(3, role=UserRole.ADMIN), make_user(2)]
+        svc.xp._apply_xp.return_value = 0
+
+        result = svc.accept_reply("token", 5)
+        assert result["is_accepted"] is True
+
+    def test_unaccept_already_accepted(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        reply = make_reply(reply_id=5, author_id=2, is_accepted=True)
+        svc.reply_repo.get_by_id.return_value = reply
+        svc.discussion_repo.get_by_id.return_value = make_discussion(author_id=1)
+        svc.user_repo.get_by_id.return_value = make_user(1)
+
+        unaccepted = make_reply(reply_id=5, author_id=2, is_accepted=False)
+        svc.reply_repo.get_by_id.side_effect = [reply, unaccepted]
+        svc.user_repo.get_by_id.side_effect = [make_user(1), make_user(2)]
+
+        result = svc.accept_reply("token", 5)
+        assert result["is_accepted"] is False
+        # No XP should be awarded for unaccepting
+        svc.xp._apply_xp.assert_not_called()

--- a/src/tests/ServiceLayerTests/test_reply_service.py
+++ b/src/tests/ServiceLayerTests/test_reply_service.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import Mock
 
-from Backend.ServiceLayer.ReplyService import ReplyService, REPLY_CREATE_XP, REPLY_ACCEPTED_XP, ACCEPT_SOLUTION_XP
+from Backend.ServiceLayer.ReplyService import ReplyService, REPLY_CREATE_XP, REPLY_ACCEPTED_XP, ACCEPT_SOLUTION_XP, REPLY_UPVOTE_XP, REPLY_REACTION_XP
 from Backend.DomainLayer.Discussion import Discussion
 from Backend.DomainLayer.Reply import Reply
 from Backend.DomainLayer.User import User
-from Backend.DomainLayer.Enums import UserRole, ThreadCategory
+from Backend.DomainLayer.Enums import UserRole, ThreadCategory, ReactionType
 from Backend.DomainLayer.Exceptions import ValidationError
 
 
@@ -59,6 +59,7 @@ class TestCreateReply:
     def test_locked_discussion(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         svc.discussion_repo.get_by_id.return_value = make_discussion(is_locked=True)
 
         with pytest.raises(ValidationError, match="locked"):
@@ -67,6 +68,7 @@ class TestCreateReply:
     def test_missing_body(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         svc.discussion_repo.get_by_id.return_value = make_discussion()
 
         with pytest.raises(ValidationError, match="body"):
@@ -75,6 +77,7 @@ class TestCreateReply:
     def test_discussion_not_found(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         svc.discussion_repo.get_by_id.return_value = None
 
         with pytest.raises(ValidationError, match="not found"):
@@ -97,6 +100,7 @@ class TestCreateReply:
     def test_invalid_parent_reply(self):
         svc = make_service()
         svc.auth.require_user_id.return_value = 1
+        svc.user_repo.get_by_id.return_value = make_user()
         svc.discussion_repo.get_by_id.return_value = make_discussion()
         svc.reply_repo.get_by_id.return_value = None
 
@@ -204,3 +208,105 @@ class TestAcceptReply:
         assert result["is_accepted"] is False
         # No XP should be awarded for unaccepting
         svc.xp._apply_xp.assert_not_called()
+
+
+def make_service_with_engagement():
+    """Service with engagement repo for vote/react tests."""
+    reply_repo = Mock()
+    discussion_repo = Mock()
+    user_repo = Mock()
+    auth_service = Mock()
+    xp_service = Mock()
+    engagement_repo = Mock()
+    return ReplyService(
+        reply_repo=reply_repo,
+        discussion_repo=discussion_repo,
+        user_repo=user_repo,
+        auth_service=auth_service,
+        xp_service=xp_service,
+        engagement_repo=engagement_repo,
+    )
+
+
+class TestVoteReply:
+    def test_upvote_success(self):
+        svc = make_service_with_engagement()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=1, author_id=1)
+        svc.engagement.get_reply_vote.return_value = None
+        svc.engagement.set_reply_vote.return_value = 1
+        svc.engagement.count_reply_votes.return_value = {"upvotes": 1, "downvotes": 0}
+
+        result = svc.vote_reply("token", 1, 1)
+
+        assert result["upvotes"] == 1
+        svc.xp._apply_xp.assert_called_once_with(1, REPLY_UPVOTE_XP)
+        svc.reply_repo.update_votes.assert_called_once_with(1, 1, 0)
+
+    def test_downvote_success(self):
+        svc = make_service_with_engagement()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=1, author_id=1)
+        svc.engagement.get_reply_vote.return_value = None
+        svc.engagement.set_reply_vote.return_value = -1
+        svc.engagement.count_reply_votes.return_value = {"upvotes": 0, "downvotes": 1}
+
+        result = svc.vote_reply("token", 1, -1)
+
+        assert result["downvotes"] == 1
+        svc.xp._apply_xp.assert_not_called()
+        svc.reply_repo.update_votes.assert_called_once_with(1, 0, 1)
+
+    def test_toggle_removes_vote(self):
+        svc = make_service_with_engagement()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=1, author_id=1)
+        svc.engagement.get_reply_vote.return_value = 1  # already upvoted
+        svc.engagement.set_reply_vote.return_value = None
+        svc.engagement.count_reply_votes.return_value = {"upvotes": 0, "downvotes": 0}
+
+        result = svc.vote_reply("token", 1, 1)
+
+        assert result["user_vote"] is None
+        svc.reply_repo.update_votes.assert_called_once_with(1, 0, 0)
+
+
+class TestReactToReply:
+    def test_add_reaction(self):
+        svc = make_service_with_engagement()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=1, author_id=1)
+        svc.engagement.toggle_reply_reaction.return_value = True
+        svc.engagement.get_reply_reactions.return_value = [{"type": "helpful", "count": 1}]
+        svc.engagement.get_user_reply_reactions.return_value = ["helpful"]
+
+        result = svc.react_to_reply("token", 1, "helpful")
+
+        assert result["is_active"] is True
+        svc.xp._apply_xp.assert_called_once_with(1, REPLY_REACTION_XP)
+
+    def test_remove_reaction(self):
+        svc = make_service_with_engagement()
+        svc.auth.require_user_id.return_value = 2
+        svc.reply_repo.get_by_id.return_value = make_reply(reply_id=1, author_id=1)
+        svc.engagement.toggle_reply_reaction.return_value = False
+        svc.engagement.get_reply_reactions.return_value = []
+        svc.engagement.get_user_reply_reactions.return_value = []
+
+        result = svc.react_to_reply("token", 1, "helpful")
+
+        assert result["is_active"] is False
+        svc.xp._apply_xp.assert_not_called()
+
+
+class TestBanEnforcementReply:
+    def test_banned_user_cannot_create_reply(self):
+        svc = make_service()
+        svc.auth.require_user_id.return_value = 1
+        user = make_user(user_id=1)
+        user.is_discussion_banned = True
+        svc.user_repo.get_by_id.return_value = user
+        svc.discussion_repo.get_by_id.return_value = make_discussion(is_locked=False)
+
+        with pytest.raises(ValidationError, match="banned"):
+            svc.create_reply("token", 1, {"body": "I am banned"})


### PR DESCRIPTION
📝 Description

This Pull Request delivers the complete **Discussion Forum** for the EscapeCircuit platform — from creation to moderation — giving users a place to share puzzle tips, ask for help, and connect with the community. Think of it as the break room between escape rooms ☕💬.

Also includes: a redesigned landing page so new visitors don't stare at a blank wall 🧱➡️🏠, a view-count fix that stops every button click from counting as a "view" 👁️‍🗨️ (no more inflated metrics), a simplified notifications page, and 7 surgical bug fixes across the stack.

🔗 Related Issues

Requirements for Forum/Discussions feature (Phases 1–3), Admin Moderation, Notifications integration.

---

🛠️ Key Changes

### 1. 💬 Discussion Forum (Full-Stack)
- **CRUD Operations**: Create, read, update, delete discussions with title, body, category, and optional puzzle linking.
- **Categories**: `general`, `puzzle_help`, `puzzle_tips`, `solutions`, `bug_report`, `feature_request`, `showcase` — with color-coded badges.
- **Nested Replies**: Three-level reply threading (top-level → child → grandchild) with compose, edit, delete, and "accept as solution" ✅.
- **Engagement System**: Upvote/downvote (discussions & replies), 5 reaction types (`insightful`, `helpful`, `genius`, `spot_on`, `thinking`), follow/unfollow, bookmark.
- **Search & Filters**: Full-text search (with SQL wildcard escaping 🛡️), category filter, sort by newest/oldest/trending/most replies/most upvotes.
- **Pagination**: Offset-based pagination with total count.
- **Public Discussion View**: Shareable links at `/public/discussions/{id}` for non-authenticated viewing.

### 2. 🛡️ Admin Moderation (Reports System)
- **Report Flow**: Users can report discussions and replies with reason + details. Duplicate reports are caught with `IntegrityError` handling (no more 500s from double-reports 🚫).
- **Admin Reports Panel**: Tabbed interface in the admin panel with filterable reports list — pending/reviewed/dismissed.
- **Moderation Actions**: Warn author 🟡, Ban author from discussions 🔴, Delete reported content 🗑️, Lock discussion 🔒 — all from the reports panel.
- **Ban Enforcement**: Banned users get blocked from creating discussions and replies, with persistent warning/ban toast notifications that don't auto-dismiss 👻.
- **Reply Report Links**: Fixed to correctly navigate to the parent discussion (not an empty URL).

### 3. 🏠 Landing Page Redesign
- **Before**: Bare white page, tiny Login button, "Welcome" text, no way to register.
- **After**: Proper hero section with logo, "Wire your way out" headline, **Get Started** + **Log in** + **Register** buttons, 3 feature highlight cards (Solve Puzzles, Earn XP, Discuss), footer. Users can now actually find the door 🚪.

### 4. 👁️ View Count Fix (Architecture Change)
- **Problem**: `get_discussion()` incremented views on every call — including 14 different mutation refetches (vote, react, bookmark, follow, pin, lock…). One user interacting once could generate dozens of "views."
- **Fix**: Created dedicated `POST /discussions/{id}/view` endpoint. View increments only once per visit via `useRef` guard on mount. Cache updated optimistically via `setQueryData` so the +1 shows immediately. Discussions list uses `staleTime: 0` for fresh counts on navigation.

### 5. 📣 Notification System Updates
- **Type Support**: Added `'warning'` and `'ban'` to `CreatorNotification` type — fixed TypeScript build error that was breaking production builds.
- **Simplified Page**: Removed all filters/search from Notifications page. Now shows a clean scrollable list of the 10 most recent notifications (newest first) with color-coded badges (🟢 solve, 🔵 rating, 🟡 warning, 🔴 ban).
- **Persistent Toasts**: Warning and ban notifications don't auto-dismiss — they stick until manually closed.

### 6. 🐛 Bug Fixes (7 Fixes)
1. **SQL Wildcard Escape** (`DiscussionRepo.py`): Search terms with `%` or `_` no longer break LIKE queries. Added `ESCAPE '\'` clause.
2. **Duplicate Report Race Condition** (`DiscussionService.py`): Wrapped `report_repo.create()` in `try/except IntegrityError` — returns friendly error instead of 500.
3. **Delete Reported Content** (`DiscussionService.py`): Added existence check before deletion — returns clear error if content was already deleted.
4. **Reply Report Enrichment** (`DiscussionService.py`): Added `discussion_id` to reply report data so admin panel links work correctly.
5. **Pin/Lock Buttons** (`discussion-view.tsx` + 2 new files): Admin Pin/Lock buttons were rendered but had empty `onClick` handlers. Created `usePinDiscussion` and `useLockDiscussion` mutation hooks and wired them in.
6. **Reply Report Link** (`reports-list.tsx`): Fixed href to use `report.discussion_id` for reply-type reports instead of empty string.
7. **Error State** (`discussion-view.tsx`): Added error fallback when discussion fails to load (deleted or no permission) — shows message + back link instead of blank screen.

### 7. ✅ Comprehensive Testing (28 New Tests + 7 Fixes)
- **18 new tests** in `test_discussion_service.py`: Voting, reactions, follow, bookmark, report, admin moderation (warn/ban/delete/lock), ban enforcement.
- **6 new tests** in `test_reply_service.py`: Voting, reactions, ban enforcement.
- **2 new tests** in `test_discussion_repo.py`: SQL wildcard search edge cases.
- **2 new tests** for `view_discussion()` method.
- **7 pre-existing test failures fixed**: Ban enforcement + Mock interaction issues in service tests.
- **All 135 discussion-related tests passing** ✅.

---

📂 Files Modified

**Backend (Python/FastAPI) — 12 files:**
- `DomainLayer/Discussion.py` — 🆕 Discussion domain model
- `DomainLayer/Reply.py` — 🆕 Reply domain model
- `DomainLayer/Enums.py` — Discussion ban-related enums
- `PersistantLayer/DiscussionRepo.py` — 🆕 Full CRUD + search + view tracking
- `PersistantLayer/ReplyRepo.py` — 🆕 Threaded replies with parent/child queries
- `PersistantLayer/EngagementRepo.py` — 🆕 Votes, reactions, follows, bookmarks
- `PersistantLayer/ReportRepo.py` — 🆕 Report CRUD with unique constraints
- `PersistantLayer/UserRepo.py` — Added discussion ban fields
- `ServiceLayer/DiscussionService.py` — 🆕 Full orchestration (CRUD, engagement, moderation, reports)
- `ServiceLayer/ReplyService.py` — 🆕 Reply orchestration with ban enforcement
- `APILayer/DiscussionController.py` — 🆕 4 routers (discussions, replies, puzzles, reports)
- `main.py` — Wired all new repos, services, and routers

**Frontend (Next.js/React) — 40+ files:**
- `features/discussions/api/` — 🆕 15 API hooks (CRUD, vote, react, follow, bookmark, report, pin, lock, view)
- `features/discussions/components/` — 🆕 12 components (discussion-view, discussions-list, discussion-card, category-badge, vote-buttons, reaction-picker, reply-tree, reply-item, reply-composer, report-dialog, user-badge, create/update-discussion)
- `features/admin/api/` — 🆕 3 report API hooks
- `features/admin/components/reports-list.tsx` — 🆕 Admin reports panel with moderation actions
- `features/notifications/` — Updated types + simplified page
- `app/page.tsx` — Redesigned landing page
- `app/app/discussions/` — 🆕 3 route pages (list, detail, new)
- `app/app/notifications/page.tsx` — Simplified to 10-item scrollable list
- `types/api.ts` — Discussion, Reply, Engagement, Report types
- `config/paths.ts` — Discussion routes
- `lib/authorization.ts` — Discussion permission helpers

**Tests — 5 files:**
- `test_discussion_service.py` — 🆕 37 tests
- `test_reply_service.py` — 🆕 16 tests
- `test_discussion_repo.py` — 🆕 Full repo tests + wildcard search
- `test_discussion_search.py` — 🆕 Search-specific tests
- `test_engagement_repo.py` — 🆕 + `test_reply_repo.py` + `test_report_repo.py`

---

✅ Checklist

- [x] Discussion CRUD: Create, edit, delete discussions with categories
- [x] Nested Replies: Three-level threading with accept-as-solution
- [x] Engagement: Votes, reactions, follow, bookmark all working
- [x] Search & Sort: Full-text search with wildcard escaping, 5 sort modes
- [x] Reporting: Users can report content, duplicates handled gracefully
- [x] Admin Moderation: Warn, ban, delete content, lock — all from reports panel
- [x] Ban Enforcement: Banned users blocked from creating content + persistent notifications
- [x] Pin/Lock: Admin buttons fully functional
- [x] View Counts: Increment once per visit, not on every refetch
- [x] Landing Page: Proper design with login + register + feature highlights
- [x] Notifications: Warning/ban types supported, simplified to 10-item list
- [x] TypeScript: Clean build (zero type errors)
- [x] Tests: 135/135 discussion tests passing
- [x] Run Scripts: `run_server.sh` and `run_server.bat` verified working
