### PR TITLE
V0.2/dishon me/122/bug/redefine budget

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Description
+[Provide a clear and concise description of the changes made in this PR]
+
+### Related Issues
+<!-- use #<number-of-issue> to link issues -->
+[Link to related issues or indicate "None"]
+
+### Checklist
+- [ ] I am confident this code can be pushed to deployment (if not provide mitigation plan)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+### Testing
+[Describe the tests that you ran to verify your changes.]
+
+### Screenshots (For UI/UX changes mandatory)
+[Attach screenshots to demonstrate the visual changes]
+
+### Additional Information
+<!-- Optional: -->
+[Any other information that might be useful]

--- a/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
@@ -38,6 +38,7 @@ interface BasicInfo {
   name: string;
   description: string;
   budget: number;
+  creator_budget: number | null;
   difficulty: "EASY" | "MEDIUM" | "HARD";
   timeLimit: number | null;
   minCycles: number | null;
@@ -344,6 +345,7 @@ export default function CreatePuzzleForm() {
       name: "",
       description: "",
       budget: 0,
+      creator_budget: null,
       difficulty: "EASY",
       timeLimit: null,
       minCycles: null,
@@ -894,7 +896,13 @@ export default function CreatePuzzleForm() {
     }
     
     // All tests passed - create solution
+    const totalCost = placed.reduce((sum, p) => {
+      const comp = uiCatalog[p.componentId];
+      return sum + (comp?.cost ?? 1);
+    }, 0);
+
     const solution = {
+      totalCost,
       eval_map: evalMap,
       circuit: {
         placed: placed.map(p => ({
@@ -916,6 +924,9 @@ export default function CreatePuzzleForm() {
     setData((prev) => ({
       ...prev,
       solutionJSON: JSON.stringify(solution, null, 2),
+      basic: prev.basic.creator_budget === null
+        ? { ...prev.basic, creator_budget: totalCost }
+        : prev.basic,
     }));
     
     alert('✓ Circuit validated! All test cases passed. Solution exported.');
@@ -1026,6 +1037,14 @@ export default function CreatePuzzleForm() {
       alert("Provide a sample solution");
       return;
     }
+    if (
+      data.basic.creator_budget !== null &&
+      data.basic.budget > 0 &&
+      data.basic.budget <= data.basic.creator_budget
+    ) {
+      alert("Budget must be greater than Creator Budget");
+      return;
+    }
 
     setIsSubmitting(true);
     try {
@@ -1075,6 +1094,7 @@ export default function CreatePuzzleForm() {
           name: data.basic.name,
           description: data.basic.description,
           budget: data.basic.budget,
+          creator_budget: data.basic.creator_budget,
           time_limit_seconds: data.basic.timeLimit,
           difficulty: data.basic.difficulty,
           default_gate_set: data.basic.gateSet,
@@ -1245,7 +1265,7 @@ export default function CreatePuzzleForm() {
                   <InfoPopup>
                     <p className="font-medium text-foreground mb-1">Budget</p>
                     <p>The max total gate cost solvers can use. Solvers who exceed this cannot submit.</p>
-                    <p className="mt-1"><span className="font-medium text-foreground">Tight Budget</span> (125% of budget) is auto-calculated — solvers within it earn better medals.</p>
+                    <p className="mt-1"><span className="font-medium text-foreground">Creator Budget</span> is your solution&apos;s gate cost. Set it below — solvers who match or beat it earn a better medal.</p>
                   </InfoPopup>
                 </label>
                 <input
@@ -1276,6 +1296,29 @@ export default function CreatePuzzleForm() {
                   <option value="HARD">Hard</option>
                 </select>
               </div>
+            </div>
+
+            <div>
+              <label className="flex items-center gap-1 text-[13px] font-medium text-foreground mb-2">
+                Creator Budget (optional)
+                <InfoPopup>
+                  <p className="font-medium text-foreground mb-1">Creator Budget</p>
+                  <p>Your solution&apos;s total gate cost. Must be less than the Budget.</p>
+                  <p className="mt-1">Solvers who match or beat this cost earn a better medal. Auto-filled when you export your solution.</p>
+                </InfoPopup>
+              </label>
+              <input
+                type="number"
+                value={data.basic.creator_budget ?? ""}
+                onChange={(e) =>
+                  handleBasicChange(
+                    "creator_budget",
+                    e.target.value ? parseInt(e.target.value) : null
+                  )
+                }
+                className="w-full rounded-lg border border-border bg-transparent p-3 text-[13px] focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="Auto-filled from your exported solution"
+              />
             </div>
 
             <div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -138,7 +138,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   const outputs = puzzle?.outputs ?? EMPTY_STRINGS;
 
   const budgetLimit = puzzle?.budgetLimit ?? 0;
-  const tightBudget = Math.ceil((puzzle?.budgetLimit ?? 0) * 1.25);
+  const creatorBudget = puzzle?.creatorBudget ?? null;
 
   const allowedGates = useMemo(() => {
     // Whitelist approach: if defaultGateSet is provided, use it.
@@ -864,13 +864,17 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
         <div className="flex flex-wrap items-center gap-4 rounded-xl border border-border/60 bg-card/80 px-4 py-2.5 text-[13px] text-foreground shadow-subtle backdrop-blur-sm">
           <div className="flex items-center gap-1">
             <span className="text-muted-foreground">Budget:</span> {budgetLimit}
-            <span className="text-muted-foreground">Tight:</span> {tightBudget}
-            <span className="text-muted-foreground">Cost:</span> {currentCost}
+            {creatorBudget !== null && (
+              <><span className="text-muted-foreground ml-2">Creator Cost:</span> {creatorBudget}</>
+            )}
+            <span className="text-muted-foreground ml-2">Cost:</span> {currentCost}
             <InfoPopup>
               <p className="font-medium text-foreground mb-1">Circuit Cost Limits</p>
               <p><span className="font-medium text-foreground">Budget</span> — Max gate cost allowed. Your circuit must stay within this limit.</p>
-              <p className="mt-1"><span className="font-medium text-foreground">Tight</span> — 125% of budget. Stay within for a better medal.</p>
-              <p className="mt-1"><span className="font-medium text-foreground">Cost</span> — Your current circuit's total gate cost.</p>
+              {creatorBudget !== null && (
+                <p className="mt-1"><span className="font-medium text-foreground">Creator Cost</span> — The creator&apos;s solution cost. Match or beat it to earn a better medal.</p>
+              )}
+              <p className="mt-1"><span className="font-medium text-foreground">Cost</span> — Your current circuit&apos;s total gate cost.</p>
             </InfoPopup>
           </div>
           <div className="ml-auto flex flex-wrap items-center gap-3">

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -119,6 +119,7 @@ export type Puzzle = Entity<{
   difficulty: 'EASY' | 'MEDIUM' | 'HARD';
   timeLimit: number; // in seconds
   budgetLimit: number;
+  creatorBudget?: number | null;  // Creator's solution cost (for medal bonus condition)
   budget?: number; // Backend compat
   inputs: string[];
   outputs: string[];

--- a/riddles/riddle_01_binary_adder_config.json
+++ b/riddles/riddle_01_binary_adder_config.json
@@ -3,6 +3,7 @@
     "name": "Binary Adder Quiz",
     "description": "Design a full adder circuit using AND, NAND, and DFF gates. Implement the sum and carry-out logic for two input bits and a carry-in bit.",
     "budget": 200,
+    "creator_budget": 5,
     "time_limit_seconds": 30,
     "difficulty": "EASY",
     "default_gate_set": ["XOR", "AND", "OR"],

--- a/riddles/riddle_02_half_adder_config.json
+++ b/riddles/riddle_02_half_adder_config.json
@@ -3,6 +3,7 @@
     "name": "Half Adder Quiz",
     "description": "Design a half adder circuit using AND, NAND, and DFF gates. Implement the sum and carry-out logic for two input bits.",
     "budget": 10,
+    "creator_budget": 2,
     "time_limit_seconds": null,
     "difficulty": "EASY",
     "default_gate_set": ["AND", "NAND", "DFF"],

--- a/riddles/riddle_03_sequential_adder_config.json
+++ b/riddles/riddle_03_sequential_adder_config.json
@@ -3,6 +3,7 @@
     "name": "Sequential Binary Adder Quiz",
     "description": "Design a sequential circuit that adds binary numbers bit by bit over multiple clock cycles using DFF gates for state. Each cycle receives one input bit X, and produces sum (OUT) and carry (C_out) outputs.",
     "budget": 15,
+    "creator_budget": 7,
     "time_limit_seconds": null,
     "difficulty": "MEDIUM",
     "default_gate_set": [

--- a/riddles/riddle_04_palindrome_config.json
+++ b/riddles/riddle_04_palindrome_config.json
@@ -3,6 +3,7 @@
     "name": "Palindrome Detector",
     "description": "Design a circuit that detects if a 4-bit input sequence is a palindrome (reads the same forwards and backwards).",
     "budget": 200,
+    "creator_budget": 10,
     "time_limit_seconds": 60,
     "difficulty": "HARD",
     "default_gate_set": ["AND", "OR", "NOT", "XOR"],

--- a/riddles/riddle_05_comparison_config.json
+++ b/riddles/riddle_05_comparison_config.json
@@ -3,6 +3,7 @@
     "name": "2-Bit Comparator",
     "description": "Design a circuit that compares two 2-bit binary numbers A and B. Output 1 on the corresponding line if A > B (GT), A = B (EQ), or A < B (LT).",
     "budget": 250,
+    "creator_budget": 15,
     "time_limit_seconds": 90,
     "difficulty": "HARD",
     "default_gate_set": ["AND", "OR", "NOT", "XOR", "NAND", "NOR"],

--- a/riddles/riddle_06_binary_adder_config.json
+++ b/riddles/riddle_06_binary_adder_config.json
@@ -3,6 +3,7 @@
     "name": "Full Adder Circuit1",
     "description": "Design a full adder circuit using AND, NAND, and DFF gates. Implement the sum and carry-out logic for two input bits and a carry-in bit.",
     "budget": 200,
+    "creator_budget": 5,
     "time_limit_seconds": 30,
     "difficulty": "EASY",
     "default_gate_set": [

--- a/riddles/riddle_07_12_config.json
+++ b/riddles/riddle_07_12_config.json
@@ -3,6 +3,7 @@
     "name": "12",
     "description": "12",
     "budget": 123,
+    "creator_budget": 1,
     "time_limit_seconds": 123,
     "difficulty": "EASY",
     "default_gate_set": [

--- a/riddles/riddle_08_123_config.json
+++ b/riddles/riddle_08_123_config.json
@@ -3,6 +3,7 @@
     "name": "123",
     "description": "123",
     "budget": 123,
+    "creator_budget": 2,
     "time_limit_seconds": 122,
     "difficulty": "EASY",
     "default_gate_set": [

--- a/src/Backend/APILayer/PuzzleController.py
+++ b/src/Backend/APILayer/PuzzleController.py
@@ -25,6 +25,7 @@ class CreatePuzzleReq(BaseModel):
     title: str = "" # also accept title directly
     description: str = ""
     budget: int = 0
+    creator_budget: Optional[int] = None  # Creator's solution cost; must be < budget when both set
     time_limit_seconds: Optional[int] = None
     timeLimit: Optional[int] = None # alias
     default_gate_set: list[str] = []
@@ -35,6 +36,7 @@ class CreatePuzzleReq(BaseModel):
             "name": self.title if self.title else self.name,
             "description": self.description,
             "budget": self.budget,
+            "creator_budget": self.creator_budget,
             "time_limit_seconds": self.timeLimit if self.timeLimit is not None else self.time_limit_seconds,
             "default_gate_set": self.default_gate_set,
             "difficulty": self.difficulty
@@ -146,6 +148,16 @@ def _validate_uploaded_puzzle_payload(conn, config_data: dict, instructions_text
         raise ValidationError("Puzzle must have 'outputs' list")
     if not puzzle_config.get('default_gate_set'):
         raise ValidationError("Puzzle must have 'default_gate_set'")
+
+    budget = puzzle_config.get('budget', 0) or 0
+    creator_budget = puzzle_config.get('creator_budget')
+    if creator_budget is not None:
+        if creator_budget < 0:
+            raise ValidationError("creator_budget cannot be negative")
+        if budget > 0 and budget <= creator_budget:
+            raise ValidationError(
+                f"budget ({budget}) must be greater than creator_budget ({creator_budget})"
+            )
 
     test_cases = config_data.get('test_cases', [])
     if not test_cases:
@@ -541,6 +553,24 @@ def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingS
                 
                 if not isinstance(solution_data.get('eval_map'), dict):
                     raise ValidationError("Sample solution must have 'eval_map' field")
+
+                # Extract creator_budget from solution totalCost if not already set in config
+                solution_total_cost = solution_data.get('totalCost')
+                if solution_total_cost is not None:
+                    config_creator_budget = puzzle_config.get('creator_budget')
+                    if config_creator_budget is None:
+                        # Auto-set creator_budget from solution cost
+                        puzzle_config['creator_budget'] = int(solution_total_cost)
+                        config_data.setdefault('puzzle', {})['creator_budget'] = int(solution_total_cost)
+                    # Validate budget > creator_budget now that we have the solution cost
+                    effective_creator_budget = puzzle_config.get('creator_budget')
+                    if effective_creator_budget is not None:
+                        puzzle_budget = puzzle_config.get('budget', 0) or 0
+                        if puzzle_budget > 0 and puzzle_budget <= effective_creator_budget:
+                            raise ValidationError(
+                                f"budget ({puzzle_budget}) must be greater than creator_budget "
+                                f"({effective_creator_budget}). Raise the budget or lower the creator's solution cost."
+                            )
                 
                 # Check if solution has circuit structure for actual simulation
                 solution_circuit_data = solution_data.get('circuit')

--- a/src/Backend/DomainLayer/Puzzle.py
+++ b/src/Backend/DomainLayer/Puzzle.py
@@ -17,6 +17,7 @@ class Puzzle:
     status: PuzzleStatus = PuzzleStatus.DRAFT
 
     budget: int = 0
+    creator_budget: Optional[int] = None  # Creator's solution cost (must be < budget when set)
     time_limit_seconds: Optional[int] = None
     difficulty: PuzzleDifficulty = PuzzleDifficulty.EASY
     default_gate_set: Set[GateType] = field(default_factory=set)
@@ -58,6 +59,13 @@ class Puzzle:
         self.creator_user_id = ensure_non_negative_int("Puzzle.creator_user_id", self.creator_user_id)
         if self.budget < 0:
             raise ValidationError("Puzzle.budget cannot be negative")
+        if self.creator_budget is not None:
+            if self.creator_budget < 1:
+                raise ValidationError("Puzzle.creator_budget must be >= 1 when set")
+            if self.budget > 0 and self.budget <= self.creator_budget:
+                raise ValidationError(
+                    f"Puzzle.budget ({self.budget}) must be greater than creator_budget ({self.creator_budget})"
+                )
         if self.time_limit_seconds is not None and self.time_limit_seconds <= 0:
             raise ValidationError("Puzzle.time_limit_seconds must be > 0 when set")
 
@@ -86,6 +94,8 @@ class Puzzle:
             "isPublic": self.status == PuzzleStatus.PUBLISHED,
             "budget": self.budget,
             "budgetLimit": self.budget,
+            "creator_budget": self.creator_budget,
+            "creatorBudget": self.creator_budget,
             "time_limit_seconds": self.time_limit_seconds,
             "timeLimit": self.time_limit_seconds, # Alias for frontend
             "difficulty": self.difficulty.value, # Creator-set difficulty
@@ -124,6 +134,9 @@ class Puzzle:
             creator_comment=d.get("creator_comment"),
             status=PuzzleStatus(d.get("status", PuzzleStatus.DRAFT.value)),
             budget=int(d.get("budget", 0)),
+            creator_budget=int(d["creator_budget"]) if d.get("creator_budget") is not None else (
+                int(d["creatorBudget"]) if d.get("creatorBudget") is not None else None
+            ),
             time_limit_seconds=d.get("time_limit_seconds", None),
             difficulty=PuzzleDifficulty(d["difficulty"]) if "difficulty" in d else PuzzleDifficulty.EASY,
             default_gate_set={GateType(x) for x in d.get("default_gate_set", [])},
@@ -149,6 +162,7 @@ class Puzzle:
     def get_description(self) -> str: return self.description
     def get_status(self) -> PuzzleStatus: return self.status
     def get_budget(self) -> int: return self.budget
+    def get_creator_budget(self) -> Optional[int]: return self.creator_budget
     def get_time_limit_seconds(self): return self.time_limit_seconds
     def get_default_gate_set(self): return self.default_gate_set
     def get_rating_count(self) -> int: return self.rating_count
@@ -174,6 +188,19 @@ class Puzzle:
 
     def set_budget(self, value: int) -> None:
         self.budget = ensure_non_negative_int("Puzzle.budget", value)
+
+    def set_creator_budget(self, value: Optional[int]) -> None:
+        if value is None:
+            self.creator_budget = None
+        else:
+            v = int(value)
+            if v < 1:
+                raise ValidationError("Puzzle.creator_budget must be >= 1 when set")
+            if self.budget > 0 and self.budget <= v:
+                raise ValidationError(
+                    f"Puzzle.budget ({self.budget}) must be greater than creator_budget ({v})"
+                )
+            self.creator_budget = v
 
     def set_time_limit_seconds(self, value) -> None:
         self.time_limit_seconds = ensure_optional_positive_int("Puzzle.time_limit_seconds", value)

--- a/src/Backend/PersistantLayer/PuzzleRepo.py
+++ b/src/Backend/PersistantLayer/PuzzleRepo.py
@@ -63,6 +63,8 @@ class PuzzleRepo:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN board_cols INTEGER;")
             if "is_hall_of_fame" not in cols:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN is_hall_of_fame INTEGER NOT NULL DEFAULT 0;")
+            if "creator_budget" not in cols:
+                self.conn.execute("ALTER TABLE puzzles ADD COLUMN creator_budget INTEGER;")
         except Exception:
             pass
         self.conn.execute("""
@@ -138,18 +140,19 @@ class PuzzleRepo:
         cur = self.conn.execute("""
             INSERT INTO puzzles(
                 name, creator_user_id, description, status,
-                budget, time_limit_seconds, difficulty, default_gate_set,
+                budget, creator_budget, time_limit_seconds, difficulty, default_gate_set,
                 rating_count, is_hall_of_fame, avg_difficulty, avg_fun, avg_clearness,
                 total_gate_count, min_cycles, max_cycles,
                 creator_comment, allow_arsenal,
                 created_at
-            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """, (
             puzzle.name,
             puzzle.creator_user_id,
             puzzle.description,
             puzzle.status.value,
             puzzle.budget,
+            puzzle.creator_budget,
             puzzle.time_limit_seconds,
             puzzle.difficulty.value if hasattr(puzzle.difficulty, 'value') else str(puzzle.difficulty),
             json.dumps([g.value for g in puzzle.default_gate_set]),
@@ -182,6 +185,7 @@ class PuzzleRepo:
                 creator_comment=?,
                 status=?,
                 budget=?,
+                creator_budget=?,
                 time_limit_seconds=?,
                 difficulty=?,
                 default_gate_set=?,
@@ -203,6 +207,7 @@ class PuzzleRepo:
             puzzle.creator_comment,
             puzzle.status.value,
             puzzle.budget,
+            puzzle.creator_budget,
             puzzle.time_limit_seconds,
             puzzle.difficulty.value if hasattr(puzzle.difficulty, 'value') else str(puzzle.difficulty),
             json.dumps([g.value for g in puzzle.default_gate_set]),
@@ -907,6 +912,11 @@ class PuzzleRepo:
             is_hall_of_fame = bool(int(row["is_hall_of_fame"]))
         except (IndexError, KeyError, TypeError, ValueError):
             is_hall_of_fame = False
+        try:
+            creator_budget = row["creator_budget"]
+            creator_budget = int(creator_budget) if creator_budget is not None else None
+        except (IndexError, KeyError, TypeError, ValueError):
+            creator_budget = None
         return Puzzle.from_dict({
             "id": int(row["id"]),
             "name": row["name"],
@@ -916,6 +926,7 @@ class PuzzleRepo:
             "creator_comment": creator_comment_val,
             "status": row["status"],
             "budget": int(row["budget"]),
+            "creator_budget": creator_budget,
             "time_limit_seconds": row["time_limit_seconds"],
             "difficulty": diff_val or "EASY",
             "default_gate_set": gate_values,

--- a/src/Backend/ServiceLayer/PuzzleService.py
+++ b/src/Backend/ServiceLayer/PuzzleService.py
@@ -420,6 +420,8 @@ class PuzzleService:
         except (ValueError, KeyError):
             difficulty = PuzzleDifficulty.EASY
 
+        raw_creator_budget = payload.get("creator_budget")
+        creator_budget = int(raw_creator_budget) if raw_creator_budget is not None else None
         p = Puzzle(
             id=0,
             name=name,
@@ -427,6 +429,7 @@ class PuzzleService:
             description=description,
             status=PuzzleStatus.DRAFT,
             budget=int(payload.get("budget", 0)),
+            creator_budget=creator_budget,
             time_limit_seconds=payload.get("time_limit_seconds", None),
             default_gate_set=gate_set,
             difficulty=difficulty,

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -317,6 +317,7 @@ class SolvingService:
                     time_limit=getattr(p, 'time_limit_seconds', None),
                     cost_used=cost_used,
                     budget=getattr(p, 'budget', 0),
+                    creator_budget=getattr(p, 'creator_budget', None),
                 )
 
             # --- Compute raw XP for this solve (base + medal bonus, no delta) ---
@@ -373,7 +374,8 @@ class SolvingService:
                     tight_upgraded = getattr(old_progress, 'tight_upgraded', False)
                     if p.time_limit_seconds and time_taken_s <= p.time_limit_seconds:
                         timer_upgraded = True
-                    if p.budget > 0 and cost_used <= p.budget:
+                    p_creator_budget = getattr(p, 'creator_budget', None)
+                    if isinstance(p_creator_budget, int) and p_creator_budget > 0 and cost_used <= p_creator_budget:
                         tight_upgraded = True
                     self.solve_repo.upsert_progress(PuzzleProgress(
                         user_id=user_id,

--- a/src/Backend/ServiceLayer/XPService.py
+++ b/src/Backend/ServiceLayer/XPService.py
@@ -76,11 +76,15 @@ class XPService:
         time_limit: Optional[int],
         cost_used: int,
         budget: int,
+        creator_budget: Optional[int] = None,
     ) -> Medal:
         """
         Bronze = solved the puzzle.
-        Silver = solved + 1 bonus condition (beats timer OR tight budget).
+        Silver = solved + 1 bonus condition (beats timer OR matches/beats creator cost).
         Gold   = solved + both bonus conditions.
+
+        creator_budget: the creator's solution cost. If set, the solver earns a bonus
+                        by achieving cost <= creator_budget (beating the creator's cost).
         """
         if not passed:
             return Medal.NONE
@@ -91,8 +95,8 @@ class XPService:
         if time_limit is not None and time_limit > 0 and time_taken <= time_limit:
             bonus_count += 1
 
-        # Condition 2: Tight budget (cost <= budget)
-        if budget > 0 and cost_used <= budget:
+        # Condition 2: Creator Budget (cost <= creator's solution cost)
+        if creator_budget is not None and creator_budget > 0 and cost_used <= creator_budget:
             bonus_count += 1
 
         if bonus_count >= 2:

--- a/src/insert_riddles.py
+++ b/src/insert_riddles.py
@@ -237,10 +237,10 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
     
     if existing:
         puzzle_id = existing[0]
-        # Update description/budget/instructions/config but keep the same ID
+        # Update description/budget/creator_budget/instructions/config but keep the same ID
         c.execute("""
             UPDATE puzzles SET
-                description=?, instructions=?, budget=?, time_limit_seconds=?,
+                description=?, instructions=?, budget=?, creator_budget=?, time_limit_seconds=?,
                 default_gate_set=?, difficulty=?,
                 total_gate_count=?, min_cycles=?, max_cycles=?,
                 board_rows=?, board_cols=?
@@ -249,6 +249,7 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             description,
             instructions_text,
             puzzle_data.get('budget', 0),
+            puzzle_data.get('creator_budget'),
             puzzle_data.get('time_limit_seconds'),
             gates_json,
             difficulty,
@@ -265,13 +266,13 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
         # INSERT new puzzle
         c.execute("""
             INSERT INTO puzzles (
-                name, creator_user_id, description, instructions, status, budget, 
+                name, creator_user_id, description, instructions, status, budget, creator_budget,
                 time_limit_seconds, difficulty, default_gate_set, rating_count, 
                 avg_difficulty, avg_fun, avg_clearness,
                 total_gate_count, min_cycles, max_cycles,
                 allow_arsenal, board_rows, board_cols,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             puzzle_data['name'],
             creator_id,
@@ -279,6 +280,7 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             instructions_text,
             status,
             puzzle_data.get('budget', 0),
+            puzzle_data.get('creator_budget'),
             puzzle_data.get('time_limit_seconds'),
             difficulty,
             gates_json,

--- a/src/tests/DomainUnitTests/test_puzzle.py
+++ b/src/tests/DomainUnitTests/test_puzzle.py
@@ -478,3 +478,86 @@ class TestPuzzleSetters:
         puzzle = Puzzle(id=1, name="Test", creator_user_id=1)
         puzzle.set_avg_clearness(4.2)
         assert puzzle.avg_clearness == 4.2
+
+
+class TestPuzzleCreatorBudget:
+    """Tests for creator_budget field validation and behaviour."""
+
+    def test_creator_budget_none_by_default(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=100)
+        assert puzzle.creator_budget is None
+
+    def test_create_puzzle_with_valid_creator_budget(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=100, creator_budget=5)
+        assert puzzle.creator_budget == 5
+
+    def test_creator_budget_must_be_less_than_budget(self):
+        with pytest.raises(ValidationError) as exc_info:
+            Puzzle(id=1, name="Test", creator_user_id=1, budget=10, creator_budget=10)
+        assert "creator_budget" in str(exc_info.value).lower() or "budget" in str(exc_info.value).lower()
+
+    def test_creator_budget_greater_than_budget_raises(self):
+        with pytest.raises(ValidationError):
+            Puzzle(id=1, name="Test", creator_user_id=1, budget=10, creator_budget=15)
+
+    def test_creator_budget_negative_raises(self):
+        with pytest.raises(ValidationError):
+            Puzzle(id=1, name="Test", creator_user_id=1, budget=100, creator_budget=-1)
+
+    def test_creator_budget_zero_is_invalid(self):
+        # Zero makes no sense as creator cost — must be positive when set
+        with pytest.raises(ValidationError):
+            Puzzle(id=1, name="Test", creator_user_id=1, budget=100, creator_budget=0)
+
+    def test_creator_budget_one_valid(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=5, creator_budget=1)
+        assert puzzle.creator_budget == 1
+
+    def test_get_creator_budget(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50, creator_budget=8)
+        assert puzzle.get_creator_budget() == 8
+
+    def test_get_creator_budget_none(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50)
+        assert puzzle.get_creator_budget() is None
+
+    def test_set_creator_budget_valid(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50)
+        puzzle.set_creator_budget(10)
+        assert puzzle.creator_budget == 10
+
+    def test_set_creator_budget_none_clears_it(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50, creator_budget=10)
+        puzzle.set_creator_budget(None)
+        assert puzzle.creator_budget is None
+
+    def test_set_creator_budget_exceeds_budget_raises(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=10)
+        with pytest.raises(ValidationError):
+            puzzle.set_creator_budget(10)  # must be strictly less than budget
+
+    def test_to_dict_includes_creator_budget(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50, creator_budget=8)
+        d = puzzle.to_dict()
+        assert d.get("creator_budget") == 8 or d.get("creatorBudget") == 8
+
+    def test_to_dict_creator_budget_none(self):
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, budget=50)
+        d = puzzle.to_dict()
+        assert d.get("creator_budget") is None or d.get("creatorBudget") is None
+
+    def test_from_dict_reads_creator_budget(self):
+        d = {"id": 1, "name": "Test", "creator_user_id": 1, "budget": 50, "creator_budget": 8}
+        puzzle = Puzzle.from_dict(d)
+        assert puzzle.creator_budget == 8
+
+    def test_from_dict_reads_camel_case_creator_budget(self):
+        d = {"id": 1, "name": "Test", "creator_user_id": 1, "budget": 50, "creatorBudget": 8}
+        puzzle = Puzzle.from_dict(d)
+        assert puzzle.creator_budget == 8
+
+    def test_roundtrip_with_creator_budget(self):
+        original = Puzzle(id=1, name="Roundtrip", creator_user_id=1, budget=100, creator_budget=7)
+        d = original.to_dict()
+        restored = Puzzle.from_dict(d)
+        assert restored.creator_budget == original.creator_budget

--- a/src/tests/ServiceLayerTests/test_xp_service.py
+++ b/src/tests/ServiceLayerTests/test_xp_service.py
@@ -255,14 +255,14 @@ class TestXPServiceMedalCalculation:
         medal = self.service.calculate_medal(passed=True, time_taken=30, time_limit=60, cost_used=15, budget=10)
         assert medal == Medal.SILVER
 
-    def test_medal_silver_budget_only(self):
-        # Under budget but over timer
-        medal = self.service.calculate_medal(passed=True, time_taken=100, time_limit=60, cost_used=5, budget=10)
+    def test_medal_silver_creator_budget_only(self):
+        # Beats creator budget but over timer — needs creator_budget param
+        medal = self.service.calculate_medal(passed=True, time_taken=100, time_limit=60, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.SILVER
 
     def test_medal_gold_both_conditions(self):
-        # Both conditions met
-        medal = self.service.calculate_medal(passed=True, time_taken=30, time_limit=60, cost_used=5, budget=10)
+        # Both conditions met: beats timer AND beats creator budget
+        medal = self.service.calculate_medal(passed=True, time_taken=30, time_limit=60, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.GOLD
 
     def test_medal_bronze_no_time_limit(self):
@@ -270,10 +270,35 @@ class TestXPServiceMedalCalculation:
         medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=15, budget=10)
         assert medal == Medal.BRONZE
 
-    def test_medal_silver_no_time_limit_but_under_budget(self):
-        # No time limit, under budget -> 1 condition
-        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10)
+    def test_medal_silver_no_time_limit_but_beats_creator_budget(self):
+        # No time limit, beats creator budget -> 1 condition
+        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.SILVER
+
+    def test_medal_bronze_no_creator_budget_set(self):
+        # No creator_budget and no time limit -> no bonuses -> BRONZE
+        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10)
+        assert medal == Medal.BRONZE
+
+    def test_medal_bronze_creator_budget_not_met(self):
+        # cost exceeds creator_budget -> no budget bonus
+        medal = self.service.calculate_medal(passed=True, time_taken=100, time_limit=60, cost_used=12, budget=20, creator_budget=10)
+        assert medal == Medal.BRONZE
+
+    def test_medal_silver_creator_budget_exact_match(self):
+        # cost == creator_budget -> earns bonus ("match or beat")
+        medal = self.service.calculate_medal(passed=True, time_taken=100, time_limit=60, cost_used=10, budget=20, creator_budget=10)
+        assert medal == Medal.SILVER
+
+    def test_medal_creator_budget_zero_not_counted(self):
+        # creator_budget=0 should not award a bonus (guard against division/zero logic)
+        medal = self.service.calculate_medal(passed=True, time_taken=100, time_limit=60, cost_used=0, budget=20, creator_budget=0)
+        assert medal == Medal.BRONZE
+
+    def test_medal_gold_timer_and_creator_budget(self):
+        # Beats both timer and creator_budget -> GOLD
+        medal = self.service.calculate_medal(passed=True, time_taken=20, time_limit=60, cost_used=3, budget=20, creator_budget=5)
+        assert medal == Medal.GOLD
 
 class TestXPServiceArsenalCapacity:
     def setup_method(self):


### PR DESCRIPTION
### Description
Redefined puzzle cost semantics across backend + frontend:

- `budget` is now the hard solver cost limit.
- Added explicit `creator_budget` (creator solution cost), replacing the old "tight budget" concept.
- Enforced validation that `budget > creator_budget` wherever puzzle data is created/validated.
- Updated medal logic so the second bonus condition uses `creator_budget` (match/beat creator cost), not `budget`.

Implemented across domain model, persistence, API, services, riddle seed data, and Next.js UI:

- Backend: `Puzzle`, `PuzzleRepo`, `PuzzleController`, `PuzzleService`, `XPService`, `SolvingService`, `insert_riddles.py`.
- Frontend: puzzle type model, puzzle workstation display (shows "Creator Cost"), and create-puzzle form (creator budget input + validation + auto-fill from exported solution).
- Data: all riddle configs updated with `creator_budget`.
- Tests: added/updated unit tests for new `creator_budget` and medal behavior.

### Related Issues
<!-- use #<number-of-issue> to link issues -->
Fixes #122

### Checklist
- [x] I am confident this code can be pushed to deployment (if not provide mitigation plan)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Testing
Results summary:

- New/updated tests for this feature pass (domain + XP tests).
- `test_solving_service` passes for the changed medal/creator-budget flow.
- Repository has pre-existing unrelated failures in persistence/service suites; this branch reduced failures significantly during verification compared to baseline, but did not bring full suite to green.

### Screenshots (For UI/UX changes mandatory)
[Attach screenshots to demonstrate the visual changes]
<img width="478" height="267" alt="image" src="https://github.com/user-attachments/assets/a76766fa-15fd-4a9c-b0c3-d4b271b80a79" />

### Additional Information
<!-- Optional: -->
- Backward compatibility handled in serialization (`creator_budget` and `creatorBudget`) and repo migration (`creator_budget` DB column added when missing).
- UI copy updated to remove "Tight Budget (125%)" wording and replace with explicit Creator Cost semantics.
