### PR TITLE
V0.2/dishon me/124/feature/creator puzzle limit

### DIFF
--- a/apps/nextjs-app/src/app/app/admin/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/admin/create-puzzle/page.tsx
@@ -268,6 +268,14 @@ export default function CreatePuzzleForm() {
 
   const handleAddTestCase = () => {
     const initializedForm = { ...testCaseForm };
+
+    if (
+      (initializedForm.kind === 'blackbox' || !initializedForm.kind) &&
+      (data.basic.inputs.length === 0 || data.basic.outputs.length === 0)
+    ) {
+      alert('Please add at least one input and one output before creating a blackbox test case.');
+      return;
+    }
     
     // Only initialize inputs/outputs if this is a blackbox test case
     if (initializedForm.kind === 'blackbox' || !initializedForm.kind) {
@@ -1170,6 +1178,47 @@ export default function CreatePuzzleForm() {
           <div className="space-y-6">
             <div className="rounded-xl border border-border bg-secondary/50 p-4">
               <h3 className="font-semibold mb-4">Add Test Case</h3>
+
+              {(data.basic.inputs.length === 0 || data.basic.outputs.length === 0) && (
+                <div className="mb-4 rounded-lg border border-amber-300/50 bg-amber-50/40 p-3">
+                  <p className="text-[13px] text-amber-800 mb-2">
+                    Add at least one input and one output to define test data.
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleBasicChange('inputs', [
+                          ...data.basic.inputs,
+                          `input_${data.basic.inputs.length}`,
+                        ])
+                      }
+                      className="rounded-lg bg-emerald-50/70 px-3 py-1.5 text-[12px] text-emerald-700 hover:bg-emerald-100 transition-colors"
+                    >
+                      + Add Input
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleBasicChange('outputs', [
+                          ...data.basic.outputs,
+                          `output_${data.basic.outputs.length}`,
+                        ])
+                      }
+                      className="rounded-lg bg-emerald-50/70 px-3 py-1.5 text-[12px] text-emerald-700 hover:bg-emerald-100 transition-colors"
+                    >
+                      + Add Output
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setActiveTab('basic')}
+                      className="rounded-lg border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-secondary transition-colors"
+                    >
+                      Open Basic Info
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div className="mb-4">
                 <label className="block text-[13px] font-medium text-foreground mb-2">Test Case Type</label>

--- a/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
@@ -434,6 +434,14 @@ export default function CreatePuzzleForm() {
 
   const handleAddTestCase = () => {
     const initializedForm = { ...testCaseForm };
+
+    if (
+      (initializedForm.kind === 'blackbox' || !initializedForm.kind) &&
+      (data.basic.inputs.length === 0 || data.basic.outputs.length === 0)
+    ) {
+      alert('Please add at least one input and one output before creating a blackbox test case.');
+      return;
+    }
     
     // Only initialize inputs/outputs if this is a blackbox test case
     if (initializedForm.kind === 'blackbox' || !initializedForm.kind) {
@@ -1265,7 +1273,7 @@ export default function CreatePuzzleForm() {
                   <InfoPopup>
                     <p className="font-medium text-foreground mb-1">Budget</p>
                     <p>The max total gate cost solvers can use. Solvers who exceed this cannot submit.</p>
-                    <p className="mt-1"><span className="font-medium text-foreground">Creator Budget</span> is your solution&apos;s gate cost. Set it below — solvers who match or beat it earn a better medal.</p>
+                    <p className="mt-1"><span className="font-medium text-foreground">Creator Budget</span> is your solution&apos;s gate cost and is auto-filled when you export your solution. Solvers who match or beat it earn a better medal.</p>
                   </InfoPopup>
                 </label>
                 <input
@@ -1296,29 +1304,6 @@ export default function CreatePuzzleForm() {
                   <option value="HARD">Hard</option>
                 </select>
               </div>
-            </div>
-
-            <div>
-              <label className="flex items-center gap-1 text-[13px] font-medium text-foreground mb-2">
-                Creator Budget (optional)
-                <InfoPopup>
-                  <p className="font-medium text-foreground mb-1">Creator Budget</p>
-                  <p>Your solution&apos;s total gate cost. Must be less than the Budget.</p>
-                  <p className="mt-1">Solvers who match or beat this cost earn a better medal. Auto-filled when you export your solution.</p>
-                </InfoPopup>
-              </label>
-              <input
-                type="number"
-                value={data.basic.creator_budget ?? ""}
-                onChange={(e) =>
-                  handleBasicChange(
-                    "creator_budget",
-                    e.target.value ? parseInt(e.target.value) : null
-                  )
-                }
-                className="w-full rounded-lg border border-border bg-transparent p-3 text-[13px] focus:outline-none focus:ring-1 focus:ring-ring"
-                placeholder="Auto-filled from your exported solution"
-              />
             </div>
 
             <div>
@@ -1609,6 +1594,47 @@ export default function CreatePuzzleForm() {
           <div className="space-y-6">
             <div className="rounded-xl border border-border bg-secondary/50 p-4">
               <h3 className="font-semibold mb-4">Add Test Case</h3>
+
+              {(data.basic.inputs.length === 0 || data.basic.outputs.length === 0) && (
+                <div className="mb-4 rounded-lg border border-amber-300/50 bg-amber-50/40 p-3">
+                  <p className="text-[13px] text-amber-800 mb-2">
+                    Add at least one input and one output to define test data.
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleBasicChange('inputs', [
+                          ...data.basic.inputs,
+                          `input_${data.basic.inputs.length}`,
+                        ])
+                      }
+                      className="rounded-lg bg-emerald-50/70 px-3 py-1.5 text-[12px] text-emerald-700 hover:bg-emerald-100 transition-colors"
+                    >
+                      + Add Input
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleBasicChange('outputs', [
+                          ...data.basic.outputs,
+                          `output_${data.basic.outputs.length}`,
+                        ])
+                      }
+                      className="rounded-lg bg-emerald-50/70 px-3 py-1.5 text-[12px] text-emerald-700 hover:bg-emerald-100 transition-colors"
+                    >
+                      + Add Output
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setActiveTab('basic')}
+                      className="rounded-lg border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-secondary transition-colors"
+                    >
+                      Open Basic Info
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div className="mb-4">
                 <label className="block text-[13px] font-medium text-foreground mb-2">Test Case Type</label>

--- a/apps/nextjs-app/src/app/app/my-puzzles/_components/my-puzzles.tsx
+++ b/apps/nextjs-app/src/app/app/my-puzzles/_components/my-puzzles.tsx
@@ -23,8 +23,6 @@ import { paths } from '@/config/paths';
 import type { Puzzle } from '@/types/api';
 import { PuzzleViewDialog } from './puzzle-view-dialog';
 
-const PUZZLE_MAX_PUBLISHED_PER_USER = 10;
-
 export const MyPuzzles = () => {
   const user = useUser();
   const [page, setPage] = useState(1);
@@ -52,6 +50,8 @@ export const MyPuzzles = () => {
   const meta = puzzlesQuery.data?.meta;
   const isLoading = puzzlesQuery.isLoading;
   const isAdmin = String(user.data?.role || '').toLowerCase() === 'admin';
+  const effectiveMaxPublished = Number(user.data?.effective_max_published ?? 5);
+  const effectiveMaxUnpublished = Number(user.data?.effective_max_unpublished ?? 5);
   const isPublishedPuzzle = (p: Puzzle) =>
     (p as any).status === 'published' || (p as any).isPublished === true;
 
@@ -68,6 +68,18 @@ export const MyPuzzles = () => {
     (p) => isPublishedPuzzle(p) && !isPopularPublishedPuzzle(p),
   ).length;
   const popularPublishedCount = Math.max(0, publishedCount - effectivePublishedCount);
+  const unpublishedCount = allPuzzles.filter((p) => !isPublishedPuzzle(p)).length;
+  const unpublishedLimitReached = !isAdmin && unpublishedCount >= effectiveMaxUnpublished;
+
+  const handleCreatePuzzleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (unpublishedLimitReached) {
+      e.preventDefault();
+      alert(
+        `You have reached the unpublished puzzles limit (${unpublishedCount}/${effectiveMaxUnpublished}). ` +
+          'Delete or publish existing puzzles to create room.'
+      );
+    }
+  };
 
   // Filter by published status
   const filteredPuzzles = allPuzzles.filter((p) => {
@@ -145,9 +157,13 @@ export const MyPuzzles = () => {
             Create, manage, and publish your circuit puzzles
           </p>
           <p className="text-[12px] text-muted-foreground mt-1">
-            {isAdmin
-              ? `Publishing capacity: ${publishedCount}/Unlimited (Admin)`
-              : `Publishing capacity: ${effectivePublishedCount}/${PUZZLE_MAX_PUBLISHED_PER_USER}`}
+            {showPublished
+              ? isAdmin
+                ? `Published capacity: ${publishedCount}/Unlimited (Admin)`
+                : `Published capacity: ${effectivePublishedCount}/${effectiveMaxPublished}`
+              : isAdmin
+                ? `Unpublished capacity: ${unpublishedCount}/Unlimited (Admin)`
+                : `Unpublished capacity: ${unpublishedCount}/${effectiveMaxUnpublished}`}
           </p>
           {!isAdmin && popularPublishedCount > 0 && (
             <p className="text-[11px] text-muted-foreground mt-1">
@@ -160,6 +176,7 @@ export const MyPuzzles = () => {
         <div className="mb-6 flex gap-3">
           <Link
             href={paths.app.createPuzzle.getHref()}
+            onClick={handleCreatePuzzleClick}
             className="rounded-lg bg-foreground px-6 py-2 text-[13px] font-medium text-background hover:bg-foreground/90 transition-colors"
           >
             Create New Puzzle
@@ -219,6 +236,7 @@ export const MyPuzzles = () => {
             </p>
             <Link
               href={paths.app.createPuzzle.getHref()}
+              onClick={handleCreatePuzzleClick}
               className="rounded-lg bg-foreground px-4 py-2 text-[13px] font-medium text-background hover:bg-foreground/90 transition-colors"
             >
               Create Your First Puzzle

--- a/apps/nextjs-app/src/features/admin/api/admin-unpublish-puzzle.ts
+++ b/apps/nextjs-app/src/features/admin/api/admin-unpublish-puzzle.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export type AdminUnpublishPuzzleDTO = {
+  puzzleId: number;
+};
+
+export const adminUnpublishPuzzle = ({
+  puzzleId,
+}: AdminUnpublishPuzzleDTO): Promise<{ ok: boolean }> => {
+  return api.post(`/admin/puzzles/${puzzleId}/unpublish`, {});
+};
+
+type UseAdminUnpublishPuzzleOptions = {
+  mutationConfig?: MutationConfig<typeof adminUnpublishPuzzle>;
+};
+
+export const useAdminUnpublishPuzzle = ({
+  mutationConfig,
+}: UseAdminUnpublishPuzzleOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: ['admin-puzzles'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['puzzles'],
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: adminUnpublishPuzzle,
+  });
+};

--- a/apps/nextjs-app/src/features/admin/api/update-puzzle-limits.ts
+++ b/apps/nextjs-app/src/features/admin/api/update-puzzle-limits.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+import { getUsersQueryOptions } from '@/features/users/api/get-users';
+
+export type UpdatePuzzleLimitsDTO = {
+  userId: number;
+  maxPublished: number | null;
+  maxUnpublished: number | null;
+};
+
+export type UpdatePuzzleLimitsResponse = {
+  ok: boolean;
+  user_id: number;
+  max_published_override: number | null;
+  max_unpublished_override: number | null;
+  effective_max_published: number;
+  effective_max_unpublished: number;
+};
+
+export const updatePuzzleLimits = ({
+  userId,
+  maxPublished,
+  maxUnpublished,
+}: UpdatePuzzleLimitsDTO): Promise<UpdatePuzzleLimitsResponse> => {
+  return api.patch(`/admin/users/${userId}/puzzle-limits`, {
+    max_published: maxPublished,
+    max_unpublished: maxUnpublished,
+  });
+};
+
+type UseUpdatePuzzleLimitsOptions = {
+  mutationConfig?: MutationConfig<typeof updatePuzzleLimits>;
+};
+
+export const useUpdatePuzzleLimits = ({
+  mutationConfig,
+}: UseUpdatePuzzleLimitsOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getUsersQueryOptions().queryKey,
+      });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: updatePuzzleLimits,
+  });
+};

--- a/apps/nextjs-app/src/features/admin/components/admin-puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/admin/components/admin-puzzles-list.tsx
@@ -13,6 +13,7 @@ import {
   AdminPuzzleFilters,
 } from '../api/get-admin-puzzles';
 import { AdminDeletePuzzle } from './admin-delete-puzzle';
+import { AdminUnpublishPuzzle } from './admin-unpublish-puzzle';
 
 // Debounce hook — delays value updates until user stops typing
 function useDebouncedValue<T>(value: T, delay: number = 400): T {
@@ -161,10 +162,19 @@ export const AdminPuzzlesList = () => {
             field: 'id',
             Cell({ entry }: { entry: any }) {
               return (
-                <AdminDeletePuzzle
-                  puzzleId={Number(entry.id)}
-                  puzzleName={entry.name || entry.title || 'Unknown'}
-                />
+                <div className="flex gap-2 items-center">
+                  {entry.status === 'published' ? (
+                    <AdminUnpublishPuzzle
+                      puzzleId={Number(entry.id)}
+                      puzzleName={entry.name || entry.title || 'Unknown'}
+                    />
+                  ) : (
+                    <AdminDeletePuzzle
+                      puzzleId={Number(entry.id)}
+                      puzzleName={entry.name || entry.title || 'Unknown'}
+                    />
+                  )}
+                </div>
               );
             },
           },

--- a/apps/nextjs-app/src/features/admin/components/admin-unpublish-puzzle.tsx
+++ b/apps/nextjs-app/src/features/admin/components/admin-unpublish-puzzle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmationDialog } from '@/components/ui/dialog';
+import { useNotifications } from '@/components/ui/notifications';
+
+import { useAdminUnpublishPuzzle } from '../api/admin-unpublish-puzzle';
+
+type AdminUnpublishPuzzleProps = {
+  puzzleId: number;
+  puzzleName: string;
+};
+
+export const AdminUnpublishPuzzle = ({
+  puzzleId,
+  puzzleName,
+}: AdminUnpublishPuzzleProps) => {
+  const { addNotification } = useNotifications();
+  const mutation = useAdminUnpublishPuzzle({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({
+          type: 'success',
+          title: `Puzzle "${puzzleName}" unpublished`,
+        });
+      },
+    },
+  });
+
+  return (
+    <ConfirmationDialog
+      icon="info"
+      title="Unpublish Puzzle"
+      body={`Unpublish puzzle "${puzzleName}"? The creator will be notified. If the creator is over their unpublished limit they will be temporarily blocked from editing or creating puzzles until they remove enough.`}
+      triggerButton={
+        <Button variant="outline" size="sm">
+          Unpublish
+        </Button>
+      }
+      confirmButton={
+        <Button
+          isLoading={mutation.isPending}
+          type="button"
+          onClick={() => mutation.mutate({ puzzleId })}
+        >
+          Unpublish Puzzle
+        </Button>
+      }
+    />
+  );
+};

--- a/apps/nextjs-app/src/features/admin/components/creator-puzzle-limits.tsx
+++ b/apps/nextjs-app/src/features/admin/components/creator-puzzle-limits.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { Settings } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useNotifications } from '@/components/ui/notifications';
+
+import { useUpdatePuzzleLimits } from '../api/update-puzzle-limits';
+
+type CreatorPuzzleLimitsProps = {
+  userId: number;
+  username: string;
+  /** Current effective max published (admin override or level-based default). */
+  effectiveMaxPublished: number;
+  /** Current effective max unpublished (admin override or level-based default). */
+  effectiveMaxUnpublished: number;
+  /** Admin-set override (null = using level default). */
+  maxPublishedOverride: number | null;
+  maxUnpublishedOverride: number | null;
+};
+
+export const CreatorPuzzleLimits = ({
+  userId,
+  username,
+  effectiveMaxPublished,
+  effectiveMaxUnpublished,
+  maxPublishedOverride,
+  maxUnpublishedOverride,
+}: CreatorPuzzleLimitsProps) => {
+  const [open, setOpen] = useState(false);
+  const [maxPublished, setMaxPublished] = useState(effectiveMaxPublished);
+  const [maxUnpublished, setMaxUnpublished] = useState(effectiveMaxUnpublished);
+  const { addNotification } = useNotifications();
+
+  const mutation = useUpdatePuzzleLimits({
+    mutationConfig: {
+      onSuccess: (data) => {
+        addNotification({
+          type: 'success',
+          title: `Puzzle limits for ${username} updated`,
+        });
+        setOpen(false);
+      },
+      onError: (error: any) => {
+        addNotification({
+          type: 'error',
+          title: 'Failed to update puzzle limits',
+        });
+      },
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate({
+      userId,
+      maxPublished,
+      maxUnpublished,
+    });
+  };
+
+  const handleReset = () => {
+    setMaxPublished(effectiveMaxPublished);
+    setMaxUnpublished(effectiveMaxUnpublished);
+  };
+
+  if (!open) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="gap-1"
+        title="Edit puzzle limits"
+      >
+        <Settings className="size-3.5" />
+        Limits
+      </Button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 space-y-4 min-w-[260px]">
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] font-semibold text-foreground">
+          Puzzle Limits for {username}
+        </span>
+        <button
+          onClick={() => { handleReset(); setOpen(false); }}
+          className="text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {/* Published limit row */}
+      <div className="space-y-1">
+        <label className="text-[12px] font-medium text-foreground">
+          Max Published
+          {maxPublishedOverride === null && (
+            <span className="ml-1 text-[11px] text-muted-foreground">(level default)</span>
+          )}
+        </label>
+        <div className="flex items-center gap-2">
+          <button
+            className="rounded-md border border-border px-2 py-1 text-[13px] hover:bg-secondary disabled:opacity-50"
+            onClick={() => setMaxPublished((v) => Math.max(0, v - 1))}
+            disabled={maxPublished <= 0}
+          >
+            −
+          </button>
+          <span className="min-w-[32px] text-center text-[14px] font-medium">
+            {maxPublished}
+          </span>
+          <button
+            className="rounded-md border border-border px-2 py-1 text-[13px] hover:bg-secondary"
+            onClick={() => setMaxPublished((v) => v + 1)}
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* Unpublished limit row */}
+      <div className="space-y-1">
+        <label className="text-[12px] font-medium text-foreground">
+          Max Unpublished
+          {maxUnpublishedOverride === null && (
+            <span className="ml-1 text-[11px] text-muted-foreground">(level default)</span>
+          )}
+        </label>
+        <div className="flex items-center gap-2">
+          <button
+            className="rounded-md border border-border px-2 py-1 text-[13px] hover:bg-secondary disabled:opacity-50"
+            onClick={() => setMaxUnpublished((v) => Math.max(0, v - 1))}
+            disabled={maxUnpublished <= 0}
+          >
+            −
+          </button>
+          <span className="min-w-[32px] text-center text-[14px] font-medium">
+            {maxUnpublished}
+          </span>
+          <button
+            className="rounded-md border border-border px-2 py-1 text-[13px] hover:bg-secondary"
+            onClick={() => setMaxUnpublished((v) => v + 1)}
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      <Button
+        size="sm"
+        className="w-full"
+        isLoading={mutation.isPending}
+        onClick={handleSave}
+      >
+        Save
+      </Button>
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/features/users/components/users-list.tsx
+++ b/apps/nextjs-app/src/features/users/components/users-list.tsx
@@ -13,6 +13,7 @@ import { useUsers, UserFilters } from '../api/get-users';
 import { DeleteUser } from './delete-user';
 import { AssignCreatorButton } from '@/features/admin/components/assign-creator-button';
 import { RemoveCreatorButton } from '@/features/admin/components/remove-creator-button';
+import { CreatorPuzzleLimits } from '@/features/admin/components/creator-puzzle-limits';
 
 // Debounce hook — delays value updates until user stops typing
 function useDebouncedValue<T>(value: T, delay: number = 400): T {
@@ -123,11 +124,23 @@ export const UsersList = () => {
                     />
                   )}
                   {(entry.role === 'creator' || entry.role === 'pending_creator') && (
-                    <RemoveCreatorButton
-                      userId={Number(entry.id)}
-                      username={entry.username}
-                      currentRole={entry.role}
-                    />
+                    <>
+                      <RemoveCreatorButton
+                        userId={Number(entry.id)}
+                        username={entry.username}
+                        currentRole={entry.role}
+                      />
+                      {entry.role === 'creator' && (
+                        <CreatorPuzzleLimits
+                          userId={Number(entry.id)}
+                          username={entry.username}
+                          effectiveMaxPublished={entry.effective_max_published ?? 5}
+                          effectiveMaxUnpublished={entry.effective_max_unpublished ?? 5}
+                          maxPublishedOverride={entry.max_published_override ?? null}
+                          maxUnpublishedOverride={entry.max_unpublished_override ?? null}
+                        />
+                      )}
+                    </>
                   )}
                   <DeleteUser id={entry.id} />
                 </div>

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -22,6 +22,10 @@ export type User = Entity<{
   bio: string;
   xp: number;
   level: number;
+  max_published_override?: number | null;
+  max_unpublished_override?: number | null;
+  effective_max_published?: number;
+  effective_max_unpublished?: number;
 }>;
 
 export type AuthResponse = {

--- a/src/Backend/APILayer/AdminController.py
+++ b/src/Backend/APILayer/AdminController.py
@@ -30,6 +30,11 @@ class ConfirmRemoveCreatorReq(BaseModel):
     action: str  # "unpublish", "delete", or "leave"
 
 
+class UpdatePuzzleLimitsReq(BaseModel):
+    max_published: Optional[int] = None
+    max_unpublished: Optional[int] = None
+
+
 def get_db_conn():
     """Helper to get a fresh connection for the upload-puzzle script."""
     current_file = pathlib.Path(__file__).resolve()
@@ -149,12 +154,44 @@ def build_admin_router(admin_service: AdminService) -> APIRouter:
             raise HTTPException(status_code=400, detail=msg)
 
     # ------------------------------------------------------------------ #
-    #  REQ 7.4  —  Delete any puzzle
+    #  REQ 7.4  —  Delete any puzzle (only non-published)
     # ------------------------------------------------------------------ #
     @router.delete("/puzzles/{puzzle_id}")
     def delete_puzzle(puzzle_id: int, token: str = Depends(verify_token)):
         try:
             return admin_service.delete_puzzle(token, puzzle_id)
+        except ValidationError as e:
+            msg = str(e)
+            if "admin required" in msg:
+                raise HTTPException(status_code=403, detail=msg)
+            raise HTTPException(status_code=400, detail=msg)
+
+    # ------------------------------------------------------------------ #
+    #  Admin unpublish a published puzzle
+    # ------------------------------------------------------------------ #
+    @router.post("/puzzles/{puzzle_id}/unpublish")
+    def unpublish_puzzle(puzzle_id: int, token: str = Depends(verify_token)):
+        try:
+            return admin_service.admin_unpublish_puzzle(token, puzzle_id)
+        except ValidationError as e:
+            msg = str(e)
+            if "admin required" in msg:
+                raise HTTPException(status_code=403, detail=msg)
+            raise HTTPException(status_code=400, detail=msg)
+
+    # ------------------------------------------------------------------ #
+    #  Admin: update creator puzzle capacity overrides
+    # ------------------------------------------------------------------ #
+    @router.patch("/users/{user_id}/puzzle-limits")
+    def update_puzzle_limits(
+        user_id: int,
+        req: UpdatePuzzleLimitsReq,
+        token: str = Depends(verify_token),
+    ):
+        try:
+            return admin_service.update_creator_puzzle_limits(
+                token, user_id, req.max_published, req.max_unpublished
+            )
         except ValidationError as e:
             msg = str(e)
             if "admin required" in msg:

--- a/src/Backend/APILayer/PuzzleController.py
+++ b/src/Backend/APILayer/PuzzleController.py
@@ -492,6 +492,24 @@ def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingS
         except ValidationError as e:
             raise HTTPException(status_code=403, detail=str(e))
 
+        # Enforce unpublished puzzle capacity for non-admin creators.
+        # This endpoint bypasses PuzzleService.create_puzzle, so the check must
+        # be applied here as well.
+        user = puzzle_service.user_repo.get_by_id(user_id)
+        if not user:
+            raise HTTPException(status_code=400, detail="user not found")
+        if not puzzle_service._is_admin(user.role):
+            _, max_unpublished = user.get_puzzle_capacity()
+            current_unpublished = puzzle_service._count_unpublished_puzzles(user_id)
+            if current_unpublished >= max_unpublished:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"You have reached the maximum limit of {max_unpublished} unpublished puzzles. "
+                        "Delete or publish existing puzzles to create room."
+                    ),
+                )
+
         conn = get_db_conn()
         try:
             with tempfile.TemporaryDirectory() as temp_dir:

--- a/src/Backend/DomainLayer/User.py
+++ b/src/Backend/DomainLayer/User.py
@@ -49,11 +49,15 @@ class User:
         PUZZLE_CAPACITY_LEVEL_INCREMENT (2).  Admin overrides take priority.
         """
         from Backend import settings
+        # Clamp level increments to the range [0, total levels in the bonus window].
+        # min(...) caps the bonus at level END; max(..., 0) avoids a negative bonus
+        # when the user is below the START level.
+        total_bonus_levels = settings.PUZZLE_CAPACITY_LEVEL_END - settings.PUZZLE_CAPACITY_LEVEL_START + 1
         level_steps = max(
             0,
             min(
                 self.level - settings.PUZZLE_CAPACITY_LEVEL_START + 1,
-                settings.PUZZLE_CAPACITY_LEVEL_END - settings.PUZZLE_CAPACITY_LEVEL_START + 1,
+                total_bonus_levels,
             ),
         )
         level_bonus = level_steps * settings.PUZZLE_CAPACITY_LEVEL_INCREMENT

--- a/src/Backend/DomainLayer/User.py
+++ b/src/Backend/DomainLayer/User.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Optional
 
 from .Enums import UserRole
 from .Exceptions import ValidationError
@@ -16,6 +17,9 @@ class User:
     xp: int = 0
     is_discussion_banned: bool = False
     created_at: datetime = field(default_factory=utcnow)
+    # Admin-set overrides for puzzle capacity (None = use level-based default)
+    max_published_puzzles: Optional[int] = None
+    max_unpublished_puzzles: Optional[int] = None
 
     def __post_init__(self) -> None:
         self.id = ensure_non_negative_int("User.id", self.id)
@@ -23,6 +27,10 @@ class User:
             raise ValidationError("User.username is required")
         if self.xp < 0:
             raise ValidationError("User.xp cannot be negative")
+        if self.max_published_puzzles is not None and self.max_published_puzzles < 0:
+            raise ValidationError("User.max_published_puzzles cannot be negative")
+        if self.max_unpublished_puzzles is not None and self.max_unpublished_puzzles < 0:
+            raise ValidationError("User.max_unpublished_puzzles cannot be negative")
 
     @property
     def level(self) -> int:
@@ -33,12 +41,45 @@ class User:
     def is_experienced(self) -> bool:
         return self.level >= 5  
 
+    def get_puzzle_capacity(self) -> tuple:
+        """Returns (max_published, max_unpublished) for this creator.
+
+        Base capacity is 5/5.  For each level from PUZZLE_CAPACITY_LEVEL_START
+        (10) through PUZZLE_CAPACITY_LEVEL_END (15) the capacity increases by
+        PUZZLE_CAPACITY_LEVEL_INCREMENT (2).  Admin overrides take priority.
+        """
+        from Backend import settings
+        level_steps = max(
+            0,
+            min(
+                self.level - settings.PUZZLE_CAPACITY_LEVEL_START + 1,
+                settings.PUZZLE_CAPACITY_LEVEL_END - settings.PUZZLE_CAPACITY_LEVEL_START + 1,
+            ),
+        )
+        level_bonus = level_steps * settings.PUZZLE_CAPACITY_LEVEL_INCREMENT
+
+        default_published = settings.PUZZLE_BASE_PUBLISHED_PER_CREATOR + level_bonus
+        default_unpublished = settings.PUZZLE_BASE_UNPUBLISHED_PER_CREATOR + level_bonus
+
+        eff_published = (
+            self.max_published_puzzles
+            if self.max_published_puzzles is not None
+            else default_published
+        )
+        eff_unpublished = (
+            self.max_unpublished_puzzles
+            if self.max_unpublished_puzzles is not None
+            else default_unpublished
+        )
+        return eff_published, eff_unpublished
+
     def add_xp(self, amount: int) -> None:
         if amount < 0:
             raise ValidationError("XP amount must be non-negative")
         self.xp += amount
 
     def to_dict(self) -> dict:
+        eff_published, eff_unpublished = self.get_puzzle_capacity()
         return {
             "id": str(self.id),
             "username": self.username,
@@ -50,6 +91,10 @@ class User:
             "is_discussion_banned": self.is_discussion_banned,
             "created_at": self.created_at.isoformat(),
             "createdAt": int(self.created_at.timestamp() * 1000),
+            "max_published_override": self.max_published_puzzles,
+            "max_unpublished_override": self.max_unpublished_puzzles,
+            "effective_max_published": eff_published,
+            "effective_max_unpublished": eff_unpublished,
         }
 
     @staticmethod
@@ -64,6 +109,8 @@ class User:
             xp=int(d.get("xp", 0)),
             is_discussion_banned=bool(d.get("is_discussion_banned", False)),
             created_at=datetime.fromisoformat(d["created_at"]) if "created_at" in d else utcnow(),
+            max_published_puzzles=d.get("max_published_puzzles"),
+            max_unpublished_puzzles=d.get("max_unpublished_puzzles"),
         )
 
     # --- getters ---

--- a/src/Backend/PersistantLayer/UserRepo.py
+++ b/src/Backend/PersistantLayer/UserRepo.py
@@ -34,6 +34,11 @@ class UserRepo:
         cols = [row[1] for row in self.conn.execute("PRAGMA table_info(users)").fetchall()]
         if "is_discussion_banned" not in cols:
             self.conn.execute("ALTER TABLE users ADD COLUMN is_discussion_banned INTEGER NOT NULL DEFAULT 0")
+        # Migration: add puzzle capacity override columns if missing
+        if "max_published_puzzles" not in cols:
+            self.conn.execute("ALTER TABLE users ADD COLUMN max_published_puzzles INTEGER")
+        if "max_unpublished_puzzles" not in cols:
+            self.conn.execute("ALTER TABLE users ADD COLUMN max_unpublished_puzzles INTEGER")
 
     @staticmethod
     def _row_to_user(row) -> User:
@@ -46,6 +51,8 @@ class UserRepo:
             "xp": int(row["xp"]),
             "is_discussion_banned": bool(row["is_discussion_banned"]) if "is_discussion_banned" in row.keys() else False,
             "created_at": row["created_at"],
+            "max_published_puzzles": row["max_published_puzzles"] if "max_published_puzzles" in row.keys() else None,
+            "max_unpublished_puzzles": row["max_unpublished_puzzles"] if "max_unpublished_puzzles" in row.keys() else None,
         })
 
     @staticmethod
@@ -251,4 +258,18 @@ class UserRepo:
 
     def unban_from_discussions(self, user_id: int) -> None:
         self.conn.execute("UPDATE users SET is_discussion_banned=0 WHERE id=?", (int(user_id),))
+        self.conn.commit()
+
+    def update_puzzle_limits(
+        self,
+        user_id: int,
+        max_published: Optional[int],
+        max_unpublished: Optional[int],
+    ) -> None:
+        """Set per-creator puzzle capacity overrides.  Pass None to revert to the
+        level-based default for that field."""
+        self.conn.execute(
+            "UPDATE users SET max_published_puzzles=?, max_unpublished_puzzles=? WHERE id=?",
+            (max_published, max_unpublished, int(user_id)),
+        )
         self.conn.commit()

--- a/src/Backend/ServiceLayer/AdminService.py
+++ b/src/Backend/ServiceLayer/AdminService.py
@@ -296,6 +296,12 @@ class AdminService:
         if not puzzle:
             raise ValidationError("puzzle not found")
 
+        # Admins may not directly delete a published puzzle; they must unpublish first
+        if puzzle.status == PuzzleStatus.PUBLISHED:
+            raise ValidationError(
+                "Cannot delete a published puzzle. Unpublish it first, then delete."
+            )
+
         puzzle_name = puzzle.name
         creator_id = puzzle.creator_user_id
         status = puzzle.status.value
@@ -326,6 +332,97 @@ class AdminService:
         )
 
         return {"ok": True}
+
+    # ------------------------------------------------------------------ #
+    #  Admin Unpublish Puzzle (moderation — bypasses unpublished-limit)
+    # ------------------------------------------------------------------ #
+    def admin_unpublish_puzzle(self, session_token: str, puzzle_id: int) -> dict:
+        """Unpublish a published puzzle as an admin.
+
+        Unlike a creator unpublishing their own puzzle, this bypasses the
+        creator's unpublished-capacity limit — the puzzle is always unpublished,
+        but the creator may become blocked from editing/creating until they
+        remove enough puzzles.
+        """
+        admin_id = self._require_admin(session_token)
+
+        puzzle = self.puzzle_repo.get_by_id(puzzle_id)
+        if not puzzle:
+            raise ValidationError("puzzle not found")
+
+        if puzzle.status != PuzzleStatus.PUBLISHED:
+            raise ValidationError("puzzle is not published")
+
+        puzzle_name = puzzle.name
+        creator_id = puzzle.creator_user_id
+
+        self.puzzle_repo.conn.execute(
+            "UPDATE puzzles SET status = 'unpublished' WHERE id = ? AND status = 'published'",
+            (int(puzzle_id),),
+        )
+        self.puzzle_repo.conn.commit()
+
+        # Notify the creator
+        creator = self.user_repo.get_by_id(creator_id)
+        if creator:
+            self.notification_repo.create(
+                user_id=creator_id,
+                notif_type="puzzle_unpublished",
+                message=f"Your puzzle \"{puzzle_name}\" has been unpublished by an admin.",
+            )
+
+        # Audit log
+        self.audit_log.create(
+            admin_user_id=admin_id,
+            action_type=AuditActionType.UNPUBLISH_PUZZLE.value,
+            target_puzzle_id=puzzle_id,
+            target_user_id=creator_id,
+            details={"puzzle_name": puzzle_name},
+        )
+
+        return {"ok": True}
+
+    # ------------------------------------------------------------------ #
+    #  Admin: edit creator's puzzle capacity overrides
+    # ------------------------------------------------------------------ #
+    def update_creator_puzzle_limits(
+        self,
+        session_token: str,
+        target_user_id: int,
+        max_published: Optional[int],
+        max_unpublished: Optional[int],
+    ) -> dict:
+        """Set per-creator published/unpublished puzzle capacity overrides.
+
+        Pass None for either value to revert to the level-based default.
+        """
+        self._require_admin(session_token)
+
+        target = self.user_repo.get_by_id(target_user_id)
+        if not target:
+            raise ValidationError("target user not found")
+        if target.role not in (UserRole.CREATOR, UserRole.PENDING_CREATOR):
+            raise ValidationError("target user is not a creator")
+
+        if max_published is not None and max_published < 0:
+            raise ValidationError("max_published cannot be negative")
+        if max_unpublished is not None and max_unpublished < 0:
+            raise ValidationError("max_unpublished cannot be negative")
+
+        self.user_repo.update_puzzle_limits(target_user_id, max_published, max_unpublished)
+
+        # Re-fetch to return current effective values
+        updated = self.user_repo.get_by_id(target_user_id)
+        eff_published, eff_unpublished = updated.get_puzzle_capacity()
+
+        return {
+            "ok": True,
+            "user_id": target_user_id,
+            "max_published_override": max_published,
+            "max_unpublished_override": max_unpublished,
+            "effective_max_published": eff_published,
+            "effective_max_unpublished": eff_unpublished,
+        }
 
     # ------------------------------------------------------------------ #
     #  Admin Puzzle Listing (moderation view)

--- a/src/Backend/ServiceLayer/PuzzleService.py
+++ b/src/Backend/ServiceLayer/PuzzleService.py
@@ -5,7 +5,6 @@ import os
 import shutil
 
 from Backend import settings
-from Backend.settings import PUZZLE_MAX_PUBLISHED_PER_USER
 from Backend.DomainLayer.Exceptions import ValidationError
 from Backend.DomainLayer.Enums import UserRole, PuzzleStatus
 
@@ -381,6 +380,21 @@ class PuzzleService:
         if user.role not in (UserRole.CREATOR, UserRole.ADMIN):
             raise ValidationError("Only creators and admins can create puzzles. Contact an admin to upgrade your account to creator.")
 
+        # Non-admin creators: check unpublished capacity and blocked state
+        if not self._is_admin(user.role):
+            _, max_unpublished = user.get_puzzle_capacity()
+            current_unpublished = self._count_unpublished_puzzles(user_id)
+            if current_unpublished >= max_unpublished:
+                raise ValidationError(
+                    f"You have reached the maximum limit of {max_unpublished} unpublished puzzles. "
+                    "Delete or publish existing puzzles to create a new one."
+                )
+            if self._is_creator_blocked(user):
+                raise ValidationError(
+                    "You have exceeded your puzzle limits. Please remove puzzles until "
+                    "you are within your allowed amounts before creating new ones."
+                )
+
         from Backend.DomainLayer.Puzzle import Puzzle
         from Backend.DomainLayer.Enums import GateType, PuzzleDifficulty
 
@@ -477,6 +491,9 @@ class PuzzleService:
         now_iso = utcnow().isoformat()
         with transaction(self.repo.conn):
             if not is_admin:
+                # Use per-user published capacity
+                max_published, _ = user.get_puzzle_capacity()
+
                 published_rows = self.repo.conn.execute(
                     """
                     SELECT is_hall_of_fame, rating_count, avg_fun
@@ -502,11 +519,11 @@ class PuzzleService:
 
                 if (
                     p.status != PuzzleStatus.PUBLISHED
-                    and current_count >= PUZZLE_MAX_PUBLISHED_PER_USER
+                    and current_count >= max_published
                     and not target_is_popular
                 ):
                     raise ValidationError(
-                        f"You have reached the maximum limit of {PUZZLE_MAX_PUBLISHED_PER_USER} published puzzles."
+                        f"You have reached the maximum limit of {max_published} published puzzles."
                     )
 
             cur = self.repo.conn.execute(
@@ -525,6 +542,31 @@ class PuzzleService:
         if isinstance(role, UserRole):
             return role == UserRole.ADMIN
         return str(role).strip().lower() == UserRole.ADMIN.value
+
+    def _count_unpublished_puzzles(self, creator_user_id: int) -> int:
+        """Count DRAFT + UNPUBLISHED puzzles for a creator."""
+        row = self.repo.conn.execute(
+            "SELECT COUNT(*) FROM puzzles WHERE creator_user_id=? AND status IN ('draft','unpublished')",
+            (int(creator_user_id),),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def _count_published_puzzles(self, creator_user_id: int) -> int:
+        """Count PUBLISHED puzzles for a creator."""
+        row = self.repo.conn.execute(
+            "SELECT COUNT(*) FROM puzzles WHERE creator_user_id=? AND status='published'",
+            (int(creator_user_id),),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def _is_creator_blocked(self, user) -> bool:
+        """Return True if a creator is over their published or unpublished limit."""
+        max_published, max_unpublished = user.get_puzzle_capacity()
+        if self._count_published_puzzles(user.id) > max_published:
+            return True
+        if self._count_unpublished_puzzles(user.id) > max_unpublished:
+            return True
+        return False
 
     def unpublish(self, session_token: str, puzzle_id: int) -> dict:
         user_id = self.auth.require_user_id(session_token)
@@ -588,6 +630,13 @@ class PuzzleService:
 
         if user.role != UserRole.ADMIN and p.creator_user_id != user_id:
             raise ValidationError("not allowed")
+
+        # Non-admin creators: block editing when over their limits
+        if not self._is_admin(user.role) and self._is_creator_blocked(user):
+            raise ValidationError(
+                "You have exceeded your puzzle limits. Please remove puzzles until "
+                "you are within your allowed amounts before editing."
+            )
 
         # Build targeted SQL update — only write the fields actually being changed
         # to avoid clobbering concurrent rating recalculations or status changes

--- a/src/Backend/ServiceLayer/logicEngineService.py
+++ b/src/Backend/ServiceLayer/logicEngineService.py
@@ -14,8 +14,20 @@ class logicEngineService:
     """
 
     # ---------- existing evaluate ----------
-    def evaluate(self, circuit: Circuit, inputs: Dict[str, int]) -> Dict[str, int]:
-        data = self._load(circuit.structure_json)
+    def evaluate(
+        self,
+        circuit: Circuit,
+        inputs: Dict[str, int],
+        data: Dict[str, Any] | None = None,
+    ) -> Dict[str, int]:
+        loaded = self._load(circuit.structure_json)
+
+        # Allow callers to pass supplemental simulation fields (e.g. custom
+        # arsenal pieces) without having to mutate circuit.structure_json.
+        if isinstance(data, dict):
+            loaded.update(data)
+
+        data = loaded
         
         # Check if this is a simulation-ready circuit (from frontend solution)
         # It will have 'wires' and 'placedComponents' (or 'components')

--- a/src/Backend/settings.py
+++ b/src/Backend/settings.py
@@ -77,7 +77,18 @@ PUZZLE_CUSTOM_PIECES_MIN_INPUTS: int = 1
 PUZZLE_CUSTOM_PIECES_MIN_OUTPUTS: int = 1
 
 # ── Puzzle publishing ─────────────────────────────────────────────────────────
-PUZZLE_MAX_PUBLISHED_PER_USER: int = 10
+PUZZLE_MAX_PUBLISHED_PER_USER: int = 10  # Legacy — kept for reference; per-user limits now used
+
+# ── Puzzle capacity for creators ──────────────────────────────────────────────
+# Base capacity for all creators regardless of level
+PUZZLE_BASE_PUBLISHED_PER_CREATOR: int = 5
+PUZZLE_BASE_UNPUBLISHED_PER_CREATOR: int = 5
+# From this level onward, capacity increases by PUZZLE_CAPACITY_LEVEL_INCREMENT per level
+PUZZLE_CAPACITY_LEVEL_START: int = 10
+# Capacity stops increasing after this level
+PUZZLE_CAPACITY_LEVEL_END: int = 15
+# Amount added to capacity per qualifying level
+PUZZLE_CAPACITY_LEVEL_INCREMENT: int = 2
 PUZZLE_NAME_MAX_LENGTH: int = 100
 PUZZLE_DESCRIPTION_MAX_LENGTH: int = 2000
 PUZZLE_INSTRUCTIONS_MAX_BYTES: int = 5 * 1024

--- a/src/tests/DomainUnitTests/test_user.py
+++ b/src/tests/DomainUnitTests/test_user.py
@@ -236,3 +236,98 @@ class TestUserGetters:
         now = datetime.now(timezone.utc)
         user = User(id=1, username="test", created_at=now)
         assert user.get_created_at() == now
+
+
+class TestUserPuzzleCapacity:
+    """Tests for per-user puzzle capacity (level-based + admin overrides)."""
+
+    def test_capacity_below_level_10_is_base(self):
+        # Level 1 (xp=0) → base 5/5
+        user = User(id=1, username="test", xp=0)
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 5
+        assert max_unpub == 5
+
+    def test_capacity_at_level_9_is_base(self):
+        # Level 9: xp=800 → level = 1 + 8 = 9 → no bonus yet
+        user = User(id=1, username="test", xp=800)
+        assert user.level == 9
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 5
+        assert max_unpub == 5
+
+    def test_capacity_at_level_10_adds_2(self):
+        # Level 10: xp=900
+        user = User(id=1, username="test", xp=900)
+        assert user.level == 10
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 7
+        assert max_unpub == 7
+
+    def test_capacity_at_level_11_adds_4(self):
+        user = User(id=1, username="test", xp=1000)
+        assert user.level == 11
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 9
+        assert max_unpub == 9
+
+    def test_capacity_at_level_15_is_max(self):
+        # Level 15: xp=1400
+        user = User(id=1, username="test", xp=1400)
+        assert user.level == 15
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 17
+        assert max_unpub == 17
+
+    def test_capacity_above_level_15_stays_at_max(self):
+        # Level 20: xp=1900 — bonus capped at 6 increments
+        user = User(id=1, username="test", xp=1900)
+        assert user.level == 20
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 17
+        assert max_unpub == 17
+
+    def test_admin_override_published(self):
+        user = User(id=1, username="test", xp=0, max_published_puzzles=20)
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 20
+        assert max_unpub == 5  # still default
+
+    def test_admin_override_unpublished(self):
+        user = User(id=1, username="test", xp=0, max_unpublished_puzzles=3)
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 5
+        assert max_unpub == 3
+
+    def test_admin_override_both(self):
+        user = User(id=1, username="test", xp=900, max_published_puzzles=10, max_unpublished_puzzles=2)
+        max_pub, max_unpub = user.get_puzzle_capacity()
+        assert max_pub == 10
+        assert max_unpub == 2
+
+    def test_negative_override_rejected(self):
+        with pytest.raises(ValidationError):
+            User(id=1, username="test", max_published_puzzles=-1)
+
+    def test_to_dict_includes_capacity_fields(self):
+        user = User(id=1, username="test", xp=900, max_published_puzzles=10)
+        d = user.to_dict()
+        assert "effective_max_published" in d
+        assert "effective_max_unpublished" in d
+        assert "max_published_override" in d
+        assert d["max_published_override"] == 10
+        assert d["effective_max_published"] == 10
+
+    def test_from_dict_restores_overrides(self):
+        user = User(id=1, username="test", xp=0, max_published_puzzles=8, max_unpublished_puzzles=3)
+        d = user.to_dict()
+        # from_dict reads the raw override values, not the effective values
+        restored = User.from_dict({
+            "id": 1,
+            "username": "test",
+            "xp": 0,
+            "max_published_puzzles": 8,
+            "max_unpublished_puzzles": 3,
+        })
+        assert restored.max_published_puzzles == 8
+        assert restored.max_unpublished_puzzles == 3

--- a/src/tests/ServiceLayerTests/test_admin_service.py
+++ b/src/tests/ServiceLayerTests/test_admin_service.py
@@ -328,4 +328,204 @@ class TestAdminServiceModeration:
         assert result is not None
 
 
+class TestAdminServiceDeletePuzzle:
+    """Tests for AdminService.delete_puzzle with the published-puzzle restriction."""
+
+    def _make_service(self):
+        mock_user_repo = Mock()
+        mock_user_repo.conn = Mock()
+        mock_puzzle_repo = Mock()
+        mock_puzzle_repo.conn = Mock()
+        mock_solve_repo = Mock()
+        mock_rating_repo = Mock()
+        mock_audit_log = Mock()
+        mock_notification_repo = Mock()
+        mock_auth = Mock()
+
+        service = AdminService(
+            mock_user_repo,
+            mock_puzzle_repo,
+            mock_solve_repo,
+            mock_rating_repo,
+            mock_audit_log,
+            mock_notification_repo,
+            mock_auth,
+        )
+        return service, mock_user_repo, mock_puzzle_repo, mock_solve_repo, mock_rating_repo, mock_audit_log, mock_auth
+
+    def test_delete_published_puzzle_raises(self):
+        service, mock_user_repo, mock_puzzle_repo, *_ = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        puzzle = Mock(spec=Puzzle); puzzle.status = PuzzleStatus.PUBLISHED
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.return_value = admin
+        mock_puzzle_repo.get_by_id.return_value = puzzle
+
+        with pytest.raises(ValidationError, match="Cannot delete a published puzzle"):
+            service.delete_puzzle("token", 1)
+
+    def test_delete_draft_puzzle_succeeds(self):
+        service, mock_user_repo, mock_puzzle_repo, mock_solve_repo, mock_rating_repo, mock_audit_log, _ = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        puzzle = Mock(spec=Puzzle)
+        puzzle.status = PuzzleStatus.DRAFT
+        puzzle.name = "TestPuzzle"
+        puzzle.creator_user_id = 2
+        puzzle.id = 10
+
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.return_value = admin
+        mock_puzzle_repo.get_by_id.return_value = puzzle
+        mock_puzzle_repo.conn = Mock()
+        mock_puzzle_repo.conn.__enter__ = Mock(return_value=None)
+        mock_puzzle_repo.conn.__exit__ = Mock(return_value=False)
+
+        # patch transaction context manager
+        with pytest.MonkeyPatch().context() as mp:
+            import Backend.PersistantLayer._db as db_mod
+            mp.setattr(db_mod, "transaction", lambda conn: __import__("contextlib").nullcontext())
+            result = service.delete_puzzle("token", 10)
+        assert result["ok"] is True
+
+
+class TestAdminServiceAdminUnpublish:
+    """Tests for AdminService.admin_unpublish_puzzle."""
+
+    def _make_service(self):
+        mock_user_repo = Mock()
+        mock_user_repo.conn = Mock()
+        mock_puzzle_repo = Mock()
+        mock_puzzle_repo.conn = Mock()
+        mock_solve_repo = Mock()
+        mock_rating_repo = Mock()
+        mock_audit_log = Mock()
+        mock_notification_repo = Mock()
+        mock_auth = Mock()
+        service = AdminService(
+            mock_user_repo, mock_puzzle_repo, mock_solve_repo,
+            mock_rating_repo, mock_audit_log, mock_notification_repo, mock_auth,
+        )
+        return service, mock_user_repo, mock_puzzle_repo, mock_audit_log
+
+    def test_unpublish_non_published_raises(self):
+        service, mock_user_repo, mock_puzzle_repo, _ = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        puzzle = Mock(spec=Puzzle); puzzle.status = PuzzleStatus.DRAFT
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.return_value = admin
+        mock_puzzle_repo.get_by_id.return_value = puzzle
+
+        with pytest.raises(ValidationError, match="puzzle is not published"):
+            service.admin_unpublish_puzzle("token", 1)
+
+    def test_unpublish_not_found_raises(self):
+        service, mock_user_repo, mock_puzzle_repo, _ = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.return_value = admin
+        mock_puzzle_repo.get_by_id.return_value = None
+
+        with pytest.raises(ValidationError, match="puzzle not found"):
+            service.admin_unpublish_puzzle("token", 99)
+
+    def test_unpublish_published_succeeds(self):
+        service, mock_user_repo, mock_puzzle_repo, mock_audit_log = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        puzzle = Mock(spec=Puzzle)
+        puzzle.status = PuzzleStatus.PUBLISHED
+        puzzle.name = "MyPuzzle"
+        puzzle.creator_user_id = 5
+
+        service.auth.require_user_id.return_value = 1
+        # get_by_id called twice: once for admin auth, once for creator notification
+        mock_user_repo.get_by_id.side_effect = [admin, Mock(spec=User)]
+        mock_puzzle_repo.get_by_id.return_value = puzzle
+        mock_puzzle_repo.conn.execute = Mock()
+        mock_puzzle_repo.conn.commit = Mock()
+
+        result = service.admin_unpublish_puzzle("token", 42)
+        assert result["ok"] is True
+        mock_audit_log.create.assert_called_once()
+
+
+class TestAdminServiceUpdatePuzzleLimits:
+    """Tests for AdminService.update_creator_puzzle_limits."""
+
+    def _make_service(self):
+        mock_user_repo = Mock()
+        mock_user_repo.conn = Mock()
+        mock_puzzle_repo = Mock()
+        mock_solve_repo = Mock()
+        mock_rating_repo = Mock()
+        mock_audit_log = Mock()
+        mock_notification_repo = Mock()
+        mock_auth = Mock()
+        service = AdminService(
+            mock_user_repo, mock_puzzle_repo, mock_solve_repo,
+            mock_rating_repo, mock_audit_log, mock_notification_repo, mock_auth,
+        )
+        return service, mock_user_repo
+
+    def test_update_limits_target_not_found(self):
+        service, mock_user_repo = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.side_effect = [admin, None]
+
+        with pytest.raises(ValidationError, match="target user not found"):
+            service.update_creator_puzzle_limits("token", 99, 10, 5)
+
+    def test_update_limits_non_creator_raises(self):
+        service, mock_user_repo = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        target = Mock(spec=User); target.role = UserRole.SOLVER
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.side_effect = [admin, target]
+
+        with pytest.raises(ValidationError, match="not a creator"):
+            service.update_creator_puzzle_limits("token", 2, 10, 5)
+
+    def test_update_limits_negative_raises(self):
+        service, mock_user_repo = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        target = Mock(spec=User); target.role = UserRole.CREATOR
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.side_effect = [admin, target]
+
+        with pytest.raises(ValidationError, match="cannot be negative"):
+            service.update_creator_puzzle_limits("token", 2, -1, 5)
+
+    def test_update_limits_success(self):
+        service, mock_user_repo = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        target = Mock(spec=User); target.role = UserRole.CREATOR
+
+        updated_user = Mock(spec=User)
+        updated_user.max_published_puzzles = 10
+        updated_user.max_unpublished_puzzles = 5
+        updated_user.get_puzzle_capacity = Mock(return_value=(10, 5))
+
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.side_effect = [admin, target, updated_user]
+
+        result = service.update_creator_puzzle_limits("token", 2, 10, 5)
+        assert result["ok"] is True
+        assert result["max_published_override"] == 10
+        assert result["max_unpublished_override"] == 5
+        mock_user_repo.update_puzzle_limits.assert_called_once_with(2, 10, 5)
+
+    def test_update_limits_with_none_reverts_to_default(self):
+        service, mock_user_repo = self._make_service()
+        admin = Mock(spec=User); admin.role = UserRole.ADMIN
+        target = Mock(spec=User); target.role = UserRole.CREATOR
+
+        updated_user = Mock(spec=User)
+        updated_user.get_puzzle_capacity = Mock(return_value=(5, 5))
+
+        service.auth.require_user_id.return_value = 1
+        mock_user_repo.get_by_id.side_effect = [admin, target, updated_user]
+
+        result = service.update_creator_puzzle_limits("token", 2, None, None)
+        assert result["ok"] is True
+        mock_user_repo.update_puzzle_limits.assert_called_once_with(2, None, None)
 

--- a/src/tests/ServiceLayerTests/test_puzzle_service.py
+++ b/src/tests/ServiceLayerTests/test_puzzle_service.py
@@ -959,3 +959,167 @@ class TestPuzzleServiceUpdatePuzzle:
         with pytest.raises(ValidationError) as exc_info:
             self.service.update_puzzle("valid_token", 1, {"name": "New"})
         assert "user not found" in str(exc_info.value)
+
+
+class TestPuzzleServiceCapacityLimits:
+    """Tests for per-user puzzle capacity enforcement in PuzzleService."""
+
+    def setup_method(self):
+        self.mock_puzzle_repo = Mock(spec=PuzzleRepo)
+        self.mock_puzzle_repo.conn = Mock()
+        self.mock_puzzle_repo.conn.execute.return_value.fetchone.return_value = None
+        self.mock_user_repo = Mock(spec=UserRepo)
+        self.mock_auth = Mock(spec=AuthService)
+        self.service = PuzzleService(self.mock_puzzle_repo, self.mock_user_repo, self.mock_auth)
+
+    def _make_conn_execute(self, unpublished_count=0, published_count=0):
+        """Configure mock conn to return specific counts for capacity queries."""
+        def side_effect(sql, *args, **kwargs):
+            m = Mock()
+            if "status IN ('draft','unpublished')" in sql:
+                m.fetchone.return_value = (unpublished_count,)
+            elif "status='published'" in sql:
+                m.fetchone.return_value = (published_count,)
+            else:
+                m.fetchone.return_value = None
+                m.fetchall.return_value = []
+            return m
+        self.mock_puzzle_repo.conn.execute.side_effect = side_effect
+
+    # ── create_puzzle limits ────────────────────────────────────────────
+
+    def test_create_puzzle_blocked_by_unpublished_limit(self):
+        """Creator at their unpublished limit cannot create a new puzzle."""
+        # Default capacity for level-1 user is 5 unpublished
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=0)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = creator
+        self._make_conn_execute(unpublished_count=5, published_count=0)
+
+        with pytest.raises(ValidationError, match="maximum limit"):
+            self.service.create_puzzle("token", {"name": "New", "default_gate_set": []})
+
+    def test_create_puzzle_blocked_over_limit(self):
+        """Creator over their limits is blocked from creating."""
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=0)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = creator
+        self._make_conn_execute(unpublished_count=6, published_count=6)
+
+        with pytest.raises(ValidationError):
+            self.service.create_puzzle("token", {"name": "New", "default_gate_set": []})
+
+    def test_create_puzzle_admin_bypasses_limit(self):
+        """Admins are never blocked by capacity limits."""
+        admin = User(id=1, username="admin", role=UserRole.ADMIN, xp=0)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = admin
+
+        saved = Puzzle(id=5, name="AdminPuzzle", creator_user_id=1)
+        self.mock_puzzle_repo.create.return_value = saved
+        self.mock_user_repo.get_by_id.return_value = admin
+        # conn.execute for duplicate-name check returns None (no duplicate)
+        def conn_exec(sql, *args, **kwargs):
+            m = Mock()
+            m.fetchone.return_value = None
+            return m
+        self.mock_puzzle_repo.conn.execute.side_effect = conn_exec
+
+        result = self.service.create_puzzle("token", {
+            "name": "AdminPuzzle", "default_gate_set": []
+        })
+        assert result["name"] == "AdminPuzzle"
+
+    def test_create_puzzle_under_limit_succeeds(self):
+        """Creator below their limit can create a puzzle."""
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=0)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = creator
+
+        saved = Puzzle(id=2, name="MyPuzzle", creator_user_id=1)
+        self.mock_puzzle_repo.create.return_value = saved
+
+        def conn_exec(sql, *args, **kwargs):
+            m = Mock()
+            if "status IN" in sql:
+                m.fetchone.return_value = (2,)  # 2 unpublished < 5 limit
+            elif "status=" in sql:
+                m.fetchone.return_value = (1,)  # 1 published < 5 limit
+            else:
+                m.fetchone.return_value = None
+            return m
+        self.mock_puzzle_repo.conn.execute.side_effect = conn_exec
+
+        result = self.service.create_puzzle("token", {
+            "name": "MyPuzzle", "default_gate_set": []
+        })
+        assert result["name"] == "MyPuzzle"
+
+    # ── update_puzzle limits ────────────────────────────────────────────
+
+    def test_update_puzzle_blocked_over_limit(self):
+        """Creator over their limit cannot edit a puzzle."""
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=0)
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = creator
+        self.mock_puzzle_repo.get_by_id.return_value = puzzle
+        self._make_conn_execute(unpublished_count=10, published_count=10)
+
+        with pytest.raises(ValidationError, match="exceeded your puzzle limits"):
+            self.service.update_puzzle("token", 1, {"name": "New"})
+
+    def test_update_puzzle_admin_bypasses_limit(self):
+        """Admins can always edit puzzles even when creators are over limit."""
+        admin = User(id=1, username="admin", role=UserRole.ADMIN, xp=0)
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=2)
+        updated = Puzzle(id=1, name="Updated", creator_user_id=2)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = admin
+        self.mock_puzzle_repo.get_by_id.side_effect = [puzzle, updated]
+
+        def conn_exec(sql, *args, **kwargs):
+            m = Mock()
+            m.fetchone.return_value = None
+            return m
+        self.mock_puzzle_repo.conn.execute.side_effect = conn_exec
+
+        result = self.service.update_puzzle("token", 1, {"name": "Updated"})
+        assert result["name"] == "Updated"
+
+    # ── publish limits ──────────────────────────────────────────────────
+
+    def test_publish_uses_per_user_published_limit(self):
+        """Creator with admin-override limit can't publish past that limit."""
+        # Admin set max_published = 2; user has 2 published already
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=0,
+                       max_published_puzzles=2)
+        puzzle = Puzzle(id=1, name="Test", creator_user_id=1, status=PuzzleStatus.DRAFT)
+        self.mock_auth.require_user_id.return_value = 1
+        self.mock_user_repo.get_by_id.return_value = creator
+        self.mock_puzzle_repo.get_by_id.return_value = puzzle
+        self.mock_puzzle_repo.list_test_cases.return_value = [Mock()]
+
+        # Simulate 2 published, non-popular puzzles
+        def conn_exec(sql, *args, **kwargs):
+            m = Mock()
+            if "status = 'published'" in sql:
+                m.fetchall.return_value = [(0, 0, 0.0), (0, 0, 0.0)]
+            else:
+                m.fetchone.return_value = (1,)
+                m.fetchall.return_value = []
+            return m
+        self.mock_puzzle_repo.conn.execute.side_effect = conn_exec
+
+        import contextlib
+        with patch("Backend.PersistantLayer._db.transaction", lambda conn: contextlib.nullcontext()):
+            with pytest.raises(ValidationError, match="maximum limit of 2"):
+                self.service.publish("token", 1)
+
+    def test_publish_level_10_gets_higher_limit(self):
+        """Creator at level 10 (xp=900) has a published limit of 7, not 5."""
+        creator = User(id=1, username="creator", role=UserRole.CREATOR, xp=900)
+        assert creator.level == 10
+        max_pub, _ = creator.get_puzzle_capacity()
+        assert max_pub == 7
+

--- a/src/tests/ServiceLayerTests/test_puzzle_service.py
+++ b/src/tests/ServiceLayerTests/test_puzzle_service.py
@@ -1,3 +1,5 @@
+import contextlib
+import json
 import pytest
 from unittest.mock import Mock, patch
 from typing import Dict, Any
@@ -12,7 +14,6 @@ from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
 from Backend.PersistantLayer.UserRepo import UserRepo
 from Backend.ServiceLayer.AuthService import AuthService
 from Backend.settings import PUZZLE_MAX_PUBLISHED_PER_USER
-import json
 
 
 class TestPuzzleServiceCreation:
@@ -1111,8 +1112,8 @@ class TestPuzzleServiceCapacityLimits:
             return m
         self.mock_puzzle_repo.conn.execute.side_effect = conn_exec
 
-        import contextlib
-        with patch("Backend.PersistantLayer._db.transaction", lambda conn: contextlib.nullcontext()):
+        import Backend.PersistantLayer._db as db_mod
+        with patch.object(db_mod, "transaction", lambda conn: contextlib.nullcontext()):
             with pytest.raises(ValidationError, match="maximum limit of 2"):
                 self.service.publish("token", 1)
 


### PR DESCRIPTION
### Description
Implements level-gated puzzle capacity for creators with separate **published** and **unpublished** limits (base 5/5, scaling +2 per level from 10–15), plus admin per-creator overrides. Also enforces these limits consistently in both standard puzzle creation and form-upload creation flows. Admins cannot directly delete published puzzles and must unpublish first.

Creators who exceed limits are blocked from create/edit actions until they free capacity (publish or delete).

### Related Issues
Closes #124

## Backend

- **`settings.py`** — Added capacity constants:
  - `PUZZLE_BASE_PUBLISHED_PER_CREATOR`
  - `PUZZLE_BASE_UNPUBLISHED_PER_CREATOR`
  - `PUZZLE_CAPACITY_LEVEL_START`
  - `PUZZLE_CAPACITY_LEVEL_END`
  - `PUZZLE_CAPACITY_LEVEL_INCREMENT`
- **`User.py`** — Added nullable overrides:
  - `max_published_puzzles`
  - `max_unpublished_puzzles`
  - Added `get_puzzle_capacity() -> (published, unpublished)` with override-first behavior
  - Exposed effective/override capacity values in `to_dict()`
- **`UserRepo.py`** — Added schema migration columns for overrides and `update_puzzle_limits(...)`
- **`PuzzleService.py`** —
  - Enforces unpublished-cap and blocked-state checks for non-admin creators on create/edit
  - Uses per-user effective published limit for publish flow
- **`PuzzleController.py`** —
  - Added capacity enforcement to `POST /puzzles/create-puzzle-form` (upload-based creation path), so creators cannot bypass unpublished limits
- **`AdminService.py`** —
  - Rejects direct deletion of published puzzles
  - Added admin unpublish flow (`admin_unpublish_puzzle`) with audit log + creator notification
  - Added `update_creator_puzzle_limits(...)`
- **`AdminController.py`** — Added routes:
  - `POST /admin/puzzles/{id}/unpublish`
  - `PATCH /admin/users/{id}/puzzle-limits`

**Capacity formula:**
```python
# Level 1–9: 5, Level 10: 7, Level 11: 9, ..., Level 15+: 17
level_steps = max(0, min(level - LEVEL_START + 1, LEVEL_END - LEVEL_START + 1))
capacity = BASE + level_steps * INCREMENT
```
## Frontend
- creator-puzzle-limits.tsx — Admin control for per-creator published/unpublished overrides with increment/decrement + save
- admin-unpublish-puzzle.tsx — Confirmation dialog for admin unpublish action
 - users-list.tsx — Added creator “Limits” controls
- admin-puzzles-list.tsx — Published puzzles show Unpublish; non-published puzzles show Delete
- my-puzzles.tsx —
   - Capacity display now uses effective per-user limits (not legacy global constant)
   - Shows status-specific capacity by tab (Published tab vs Unpublished tab)
   - Prevents create navigation when unpublished capacity is full with clear user message
- create-puzzle/page.tsx —
   - Removed manual Creator Budget input from creator flow
   - Creator budget remains auto-derived from exported solution cost
- New API hooks:
   - useUpdatePuzzleLimits
   -useAdminUnpublishPuzzle

### Tests
Added/updated unit tests covering:

- test_user.py — capacity scaling, overrides, serialization, validation
- test_admin_service.py — puzzle-limit updates, admin unpublish flow, published delete rejection
- test_puzzle_service.py — create/edit enforcement for unpublished/blocked creators, publish cap behavior

### Checklist

- [x] I am confident this code can be pushed to deployment
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Screenshots (For UI/UX changes mandatory)
<img width="679" height="475" alt="p1" src="https://github.com/user-attachments/assets/6a92d1a5-3538-4e9d-974e-1e4be51c3997" />
<img width="274" height="192" alt="p2" src="https://github.com/user-attachments/assets/fd71958a-c148-4916-87f7-d8eda2069072" />

### Additional Information
Effective capacity is computed per user via get_puzzle_capacity() (default by level, override by admin when set).
Upload-based puzzle creation (create-puzzle-form) now enforces unpublished limits, closing the bypass path.
Admin unpublish intentionally bypasses creator unpublished-cap checks (to guarantee moderation action), while creator-side create/edit remains blocked until limits are respected.