### PR TITLE
added toggle for effects and volume bar plus fixed a bug i found in arsenal

### DIFF
--- a/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
+++ b/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown';
 import { Link } from '@/components/ui/link';
+import { SettingsMenu } from '@/components/ui/settings-menu';
 import { XPBar } from '@/components/ui/xp-bar';
 import { paths } from '@/config/paths';
 import { useLogout, useUser } from '@/lib/auth';
@@ -157,6 +158,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         <div className="flex items-center gap-3">
           <XPBar currentXP={user.data?.xp ?? 0} />
           <ThemeToggle />
+          <SettingsMenu />
           <div className="hidden md:flex items-center gap-2 text-[13px]">
             <span className="font-medium text-foreground">{user.data?.username}</span>
             <span className="text-border">|</span>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -8,6 +8,7 @@ import Confetti from 'react-confetti';
 
 import { Button } from '@/components/ui/button';
 import { useAudio } from '@/hooks/useAudio';
+import { useSettings } from '@/context/settings-context';
 import {
   Dialog,
   DialogContent,
@@ -160,6 +161,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   const startTime = useRef(Date.now());
   const queryClient = useQueryClient();
   const { playError, playSuccess } = useAudio();
+  const { visualEffectsEnabled } = useSettings();
 
   const puzzleQuery = usePuzzle({ id: puzzleId });
   const puzzle = puzzleQuery.data;
@@ -247,6 +249,11 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   } | null>(null);
   const [inspectingPlacedId, setInspectingPlacedId] = useState<string | null>(null);
   const [inspectingSandboxPlacedId, setInspectingSandboxPlacedId] = useState<string | null>(null);
+
+  // DEBUG: Log visual effects status
+  useEffect(() => {
+    console.log('[DEBUG] visualEffectsEnabled:', visualEffectsEnabled, 'showFirstSolveCelebration:', showFirstSolveCelebration, 'victoryFx.visible:', victoryFx.visible);
+  }, [visualEffectsEnabled, showFirstSolveCelebration, victoryFx.visible]);
 
   // Sync isSolved from API data (so page refresh preserves solved state)
   useEffect(() => {
@@ -1650,7 +1657,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
 
   return (
     <div className="flex w-full flex-col gap-3">
-      {showFirstSolveCelebration && viewportSize.width > 0 && viewportSize.height > 0 ? (
+      {visualEffectsEnabled && showFirstSolveCelebration && viewportSize.width > 0 && viewportSize.height > 0 ? (
         <Confetti
           width={viewportSize.width}
           height={viewportSize.height}
@@ -1661,7 +1668,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
         />
       ) : null}
 
-      {victoryFx.visible ? (
+      {visualEffectsEnabled && victoryFx.visible ? (
         <div
           key={victoryFx.key}
           className="pointer-events-none fixed left-1/2 top-1/2 z-[120] -translate-x-1/2 -translate-y-1/2 rounded-full border border-sky-200 bg-white px-5 py-2 font-semibold text-sky-700 shadow-xl"

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -12,6 +12,7 @@ import { useNotifications } from '@/components/ui/notifications';
 import { Spinner } from '@/components/ui/spinner';
 import { RippleEffect } from '@/components/ripple-effect';
 import { useAudio } from '@/hooks/useAudio';
+import { useSettings } from '@/context/settings-context';
 import type { Wire } from '@/types/api';
 import { cn } from '@/utils/cn';
 import { LogicNode } from './node';
@@ -166,6 +167,7 @@ export const WorkstationGrid = ({
   const gridCols = Math.max(1, boardCols ?? DEFAULT_GRID_COLS);
   const notifications = useNotifications();
   const { playDrop, playWireConnect } = useAudio();
+  const { visualEffectsEnabled } = useSettings();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
@@ -1403,7 +1405,7 @@ export const WorkstationGrid = ({
         )}
 
         {/* Ripple Effects */}
-        {activeRipples.map((ripple) => (
+        {visualEffectsEnabled && activeRipples.map((ripple) => (
           <RippleEffect key={ripple.id} x={ripple.x} y={ripple.y} />
         ))}
 

--- a/apps/nextjs-app/src/app/provider.tsx
+++ b/apps/nextjs-app/src/app/provider.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { MainErrorFallback } from '@/components/errors/main';
 import { NavigationLoadingProvider } from '@/components/ui/navigation-loading/navigation-loading';
 import { Notifications } from '@/components/ui/notifications';
+import { SettingsProvider } from '@/context/settings-context';
 import { queryConfig } from '@/lib/react-query';
 
 type AppProviderProps = {
@@ -29,11 +30,13 @@ export const AppProvider = ({ children }: AppProviderProps) => {
       <QueryClientProvider client={queryClient}>
         <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!}>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-            <NavigationLoadingProvider>
-              {process.env.DEV && <ReactQueryDevtools />}
-              <Notifications />
-              {children}
-            </NavigationLoadingProvider>
+            <SettingsProvider>
+              <NavigationLoadingProvider>
+                {process.env.DEV && <ReactQueryDevtools />}
+                <Notifications />
+                {children}
+              </NavigationLoadingProvider>
+            </SettingsProvider>
           </ThemeProvider>
         </GoogleOAuthProvider>
       </QueryClientProvider>

--- a/apps/nextjs-app/src/components/ui/settings-menu.tsx
+++ b/apps/nextjs-app/src/components/ui/settings-menu.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { Settings, Volume2, Wand2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown';
+import { useSettings } from '@/context/settings-context';
+import { cn } from '@/utils/cn';
+
+export const SettingsMenu = () => {
+  const { soundEnabled, setSoundEnabled, visualEffectsEnabled, setVisualEffectsEnabled, soundVolume, setSoundVolume } = useSettings();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-8 rounded-full text-slate-400"
+        aria-label="Settings"
+        disabled
+      >
+        <Settings className="size-4" />
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'size-8 rounded-full transition-colors',
+            'text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-100 dark:hover:bg-slate-800',
+          )}
+          aria-label="Settings"
+          title="Settings"
+        >
+          <Settings className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <div className="px-2 py-2 text-[13px] font-semibold text-foreground">
+          Settings
+        </div>
+        <DropdownMenuSeparator />
+        
+        {/* Sound Effects Toggle */}
+        <div className="px-3 py-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Volume2 className="size-4 text-slate-600 dark:text-slate-400" />
+              <label htmlFor="sound-toggle" className="text-[13px] font-medium text-foreground cursor-pointer">
+                Sound Effects
+              </label>
+            </div>
+            <button
+              id="sound-toggle"
+              onClick={() => setSoundEnabled(!soundEnabled)}
+              className={cn(
+                'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+                soundEnabled
+                  ? 'bg-emerald-600'
+                  : 'bg-slate-300 dark:bg-slate-600',
+              )}
+              role="switch"
+              aria-checked={soundEnabled}
+            >
+              <span
+                className={cn(
+                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                  soundEnabled ? 'translate-x-4' : 'translate-x-0.5',
+                )}
+              />
+            </button>
+          </div>
+
+          {/* Volume Slider */}
+          <div className={cn('space-y-2', !soundEnabled && 'opacity-50 pointer-events-none')}>
+            <label htmlFor="volume-slider" className="text-[12px] text-muted-foreground">
+              Volume: {Math.round(soundVolume * 100)}%
+            </label>
+            <input
+              id="volume-slider"
+              type="range"
+              min="0"
+              max="100"
+              value={Math.round(soundVolume * 100)}
+              onChange={(e) => setSoundVolume(parseInt(e.target.value) / 100)}
+              disabled={!soundEnabled}
+              className="w-full h-1.5 bg-slate-300 dark:bg-slate-600 rounded-lg appearance-none cursor-pointer outline-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-600 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-600 [&::-moz-range-thumb]:border-0"
+              aria-label="Sound volume"
+            />
+          </div>
+        </div>
+
+        <DropdownMenuSeparator />
+
+        {/* Visual Effects Toggle */}
+        <div className="px-3 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Wand2 className="size-4 text-slate-600 dark:text-slate-400" />
+              <label htmlFor="effects-toggle" className="text-[13px] font-medium text-foreground cursor-pointer">
+                Visual Effects
+              </label>
+            </div>
+            <button
+              id="effects-toggle"
+              onClick={() => setVisualEffectsEnabled(!visualEffectsEnabled)}
+              className={cn(
+                'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+                visualEffectsEnabled
+                  ? 'bg-emerald-600'
+                  : 'bg-slate-300 dark:bg-slate-600',
+              )}
+              role="switch"
+              aria-checked={visualEffectsEnabled}
+            >
+              <span
+                className={cn(
+                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                  visualEffectsEnabled ? 'translate-x-4' : 'translate-x-0.5',
+                )}
+              />
+            </button>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/nextjs-app/src/context/settings-context.tsx
+++ b/apps/nextjs-app/src/context/settings-context.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface SettingsContextType {
+  soundEnabled: boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  visualEffectsEnabled: boolean;
+  setVisualEffectsEnabled: (enabled: boolean) => void;
+  soundVolume: number;
+  setSoundVolume: (volume: number) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'escapecircuit-settings';
+
+interface StoredSettings {
+  soundEnabled?: boolean;
+  visualEffectsEnabled?: boolean;
+  soundVolume?: number;
+}
+
+export const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [visualEffectsEnabled, setVisualEffectsEnabled] = useState(true);
+  const [soundVolume, setSoundVolume] = useState(0.6);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Load settings from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const settings: StoredSettings = JSON.parse(stored);
+        if (settings.soundEnabled !== undefined) setSoundEnabled(settings.soundEnabled);
+        if (settings.visualEffectsEnabled !== undefined) setVisualEffectsEnabled(settings.visualEffectsEnabled);
+        if (settings.soundVolume !== undefined) setSoundVolume(settings.soundVolume);
+      }
+    } catch (error) {
+      console.error('Failed to load settings:', error);
+    } finally {
+      setIsHydrated(true);
+    }
+  }, []);
+
+  // Save settings to localStorage whenever they change
+  useEffect(() => {
+    if (!isHydrated) return;
+    
+    try {
+      const settings: StoredSettings = {
+        soundEnabled,
+        visualEffectsEnabled,
+        soundVolume,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    } catch (error) {
+      console.error('Failed to save settings:', error);
+    }
+  }, [soundEnabled, visualEffectsEnabled, soundVolume, isHydrated]);
+
+  const value: SettingsContextType = {
+    soundEnabled,
+    setSoundEnabled,
+    visualEffectsEnabled,
+    setVisualEffectsEnabled,
+    soundVolume,
+    setSoundVolume,
+  };
+
+  return (
+    <SettingsContext.Provider value={value}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (context === undefined) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+};

--- a/apps/nextjs-app/src/hooks/useAudio.ts
+++ b/apps/nextjs-app/src/hooks/useAudio.ts
@@ -2,13 +2,17 @@
  * Hook for playing UI sound effects in the puzzle workstation.
  * Uses native Audio API with graceful fallback if sounds aren't available.
  * Sound files should be placed in /public/sounds/ directory.
+ * Respects user settings for sound enabled state and volume control.
  * 
  * Usage:
- *   const { playDrop, playBloop, playError, playSuccess } = useAudio();
+ *   const { playDrop, playWireConnect, playError, playSuccess } = useAudio();
  *   playDrop(); // Play component drop sound
  */
 
+'use client';
+
 import { useCallback } from 'react';
+import { useSettings } from '@/context/settings-context';
 
 export type AudioSoundType = 'drop' | 'wire' | 'error' | 'success';
 
@@ -22,7 +26,12 @@ const SOUND_MAP: Record<AudioSoundType, string[]> = {
 const resolvedSources = new Map<AudioSoundType, string | null>();
 
 export const useAudio = () => {
-  const playSound = useCallback((soundType: AudioSoundType, volume: number = 0.6) => {
+  const { soundEnabled, soundVolume } = useSettings();
+
+  const playSound = useCallback((soundType: AudioSoundType, baseVolume: number = 0.6) => {
+    // Don't play sound if sound effects are disabled
+    if (!soundEnabled) return;
+
     const cached = resolvedSources.get(soundType);
     const candidates = cached ? [cached] : SOUND_MAP[soundType];
 
@@ -32,7 +41,8 @@ export const useAudio = () => {
 
       try {
         const audio = new Audio(source);
-        audio.volume = Math.max(0, Math.min(1, volume));
+        // Use the user's selected volume multiplied by the base volume for specific sound types
+        audio.volume = Math.max(0, Math.min(1, baseVolume * soundVolume));
         const playResult = audio.play();
         if (typeof playResult?.then === 'function') {
           playResult
@@ -51,7 +61,7 @@ export const useAudio = () => {
     };
 
     tryPlay(0);
-  }, []);
+  }, [soundEnabled, soundVolume]);
 
   const playDrop = useCallback(() => {
     playSound('drop', 0.7);

--- a/src/Backend/ServiceLayer/ArsenalService.py
+++ b/src/Backend/ServiceLayer/ArsenalService.py
@@ -247,11 +247,18 @@ class ArsenalService:
         
         Custom pieces are stored with puzzle_id set and is_arsenal=true.
         They are unique to the puzzle and available to all solvers.
+        Always available regardless of allow_arsenal setting.
         """
         try:
             pieces = self.repo.list_custom_pieces_by_puzzle(puzzle_id)
-            return [piece.to_circuit_component() for piece in pieces]
+            result = [piece.to_circuit_component() for piece in pieces]
+            if result:
+                print(f"✅ Custom pieces for puzzle {puzzle_id}: found {len(result)} pieces")
+            return result
         except Exception as e:
+            print(f"❌ ERROR getting custom pieces for puzzle {puzzle_id}: {e}")
+            import traceback
+            traceback.print_exc()
             return []
 
     def get_arsenal_pieces_by_ids(self, piece_ids: List[int]) -> List[dict]:
@@ -282,6 +289,43 @@ class ArsenalService:
                     continue
             
             return components
+        except Exception as e:
+            return []
+
+    def get_user_arsenal_filtered_by_gates(self, user_id: int, allowed_gates: Set[str]) -> List[dict]:
+        """Get all arsenal pieces for a user, filtered by allowed gates.
+        
+        Used when a puzzle allows arsenal but doesn't specify which pieces.
+        Returns only pieces whose basic gates are all in the allowed set.
+        
+        Args:
+            user_id: Creator's user ID
+            allowed_gates: Set of allowed gate types
+            
+        Returns:
+            List of CircuitComponent dicts that use only allowed gates
+        """
+        try:
+            if not user_id:
+                return []
+            
+            arsenal = self.repo.list_arsenal_by_user(user_id)
+            available = []
+            
+            for piece in arsenal:
+                try:
+                    # Parse the basic gates for this piece
+                    gates = json.loads(piece.basic_gates) if piece.basic_gates else []
+                    gates_set = set(gates)
+                    
+                    # Include this piece only if ALL its gates are allowed
+                    if gates_set.issubset(allowed_gates):
+                        available.append(piece.to_circuit_component())
+                except (json.JSONDecodeError, ValueError):
+                    # Skip pieces with invalid JSON
+                    continue
+            
+            return available
         except Exception as e:
             return []
 

--- a/src/Backend/ServiceLayer/PuzzleService.py
+++ b/src/Backend/ServiceLayer/PuzzleService.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Set
 import pathlib
 import os
 import shutil
@@ -8,7 +8,7 @@ import json
 
 from Backend import settings
 from Backend.DomainLayer.Exceptions import ValidationError
-from Backend.DomainLayer.Enums import UserRole, PuzzleStatus
+from Backend.DomainLayer.Enums import UserRole, PuzzleStatus, GateType
 
 from Backend.PersistantLayer._db import transaction
 from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
@@ -374,13 +374,16 @@ class PuzzleService:
         
         try:
             # Custom pieces are ALWAYS available for this puzzle, regardless of allow_arsenal setting
+            # They are not filtered by gates - they're puzzle-specific components
             custom_components = self.arsenal_service.get_custom_pieces_for_puzzle(puzzle_id)
+            print(f"🎯 DEBUG [PuzzleService.get] Puzzle {puzzle_id}:")
+            print(f"   - customComponents: {len(custom_components)} found")
             
             # Arsenal pieces only available if arsenal is enabled for this puzzle
             if self.arsenal_service and getattr(p, 'allow_arsenal', True):
                 # Get list of allowed Arsenal component IDs from puzzle config
                 allowed_ids = getattr(p, 'allowed_arsenal_component_ids', None) or []
-                print(f"🎯 DEBUG [PuzzleService.get] Puzzle {puzzle_id}:")
+                print(f"   - allowArsenal: True")
                 print(f"   - allowed_arsenal_component_ids = {allowed_ids}")
                 
                 if allowed_ids:
@@ -388,16 +391,36 @@ class PuzzleService:
                     # The creator selected specific pieces - we need to fetch those exact pieces by their IDs
                     arsenal_components = self.arsenal_service.get_arsenal_pieces_by_ids(allowed_ids)
                     print(f"✅ Fetched {len(arsenal_components)} arsenal pieces by IDs for puzzle {puzzle_id}")
-                    
-                    # Log the returned arsenal_components to verify they have description
-                    print(f"\n📊 ARSENAL COMPONENTS RETURNED FROM SERVICE:")
-                    for i, component in enumerate(arsenal_components):
-                        print(f"   [{i}] {component.get('id')} ({component.get('type')}):")
-                        print(f"       - description present: {('description' in component)}")
-                        print(f"       - description value: '{component.get('description', 'MISSING')}'")
-                        print(f"       - keys: {list(component.keys())}")
                 else:
-                    print(f"   - No allowed_arsenal_component_ids specified for puzzle {puzzle_id}")
+                    # If allow_arsenal is True but no specific pieces selected,
+                    # show the SOLVER's (current user's) arsenal pieces that use only allowed gates
+                    if user_id:
+                        print(f"   - No specific IDs selected; fetching all arsenal for solver (user {user_id})")
+                        # Get the allowed gates for this puzzle (convert from GateType enum to strings)
+                        allowed_gates_set = {g.value for g in p.default_gate_set} if p.default_gate_set else set()
+                        arsenal_components = self.arsenal_service.get_user_arsenal_filtered_by_gates(
+                            user_id, allowed_gates_set
+                        )
+                        print(f"✅ Fetched {len(arsenal_components)} arsenal pieces filtered by allowed gates: {allowed_gates_set}")
+                    else:
+                        print(f"   - No user_id found for solver")
+            else:
+                print(f"   - allowArsenal: False (no arsenal pieces available)")
+                
+            # Log the returned components to verify they have description
+            if arsenal_components:
+                print(f"\n📊 ARSENAL COMPONENTS RETURNED FROM SERVICE:")
+                for i, component in enumerate(arsenal_components):
+                    print(f"   [{i}] {component.get('id')} ({component.get('type')}):")
+                    print(f"       - description present: {('description' in component)}")
+                    print(f"       - description value: '{component.get('description', 'MISSING')}'")
+                    print(f"       - keys: {list(component.keys())}")
+            
+            if custom_components:
+                print(f"\n📊 CUSTOM COMPONENTS RETURNED FROM SERVICE:")
+                for i, component in enumerate(custom_components):
+                    print(f"   [{i}] {component.get('id')} ({component.get('type')}):")
+                    print(f"       - keys: {list(component.keys())}")
             
             # For backward compatibility, also include both in specialComponents
             d["specialComponents"] = custom_components + arsenal_components
@@ -406,9 +429,8 @@ class PuzzleService:
             d["arsenalComponents"] = arsenal_components
             
             print(f"\n✅ FINAL DICT RETURNED TO API:")
+            print(f"   - customComponents count: {len(d['customComponents'])}")
             print(f"   - arsenalComponents count: {len(d['arsenalComponents'])}")
-            if d['arsenalComponents']:
-                print(f"   - First component description: '{d['arsenalComponents'][0].get('description', 'MISSING')}'")
             
         except Exception as e:
             # If service fails, try to at least return custom pieces

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -256,13 +256,19 @@ class SolvingService:
         
         # Check if arsenal pieces are allowed in this puzzle
         if not getattr(p, 'allow_arsenal', True):
-            # Check if solution contains any arsenal pieces (numeric componentIds)
+            # Check if solution contains any PERSONAL arsenal pieces (numeric componentIds that are NOT custom pieces)
             placed_components = solution_payload.get("placedComponents", []) or solution_payload.get("components", [])
             for placed in placed_components:
                 component_id = placed.get("componentId")
-                # If componentId is numeric, it's an arsenal piece
+                # If componentId is numeric, it might be an arsenal piece
                 if isinstance(component_id, int) or (isinstance(component_id, str) and component_id.isdigit()):
-                    raise ValidationError("Arsenal pieces are not allowed in this puzzle. Only basic gates (AND, OR, XOR, NOT, NAND, NOR, XNOR, DFF) are permitted.")
+                    # Check if this is a custom piece (puzzle-specific) or personal arsenal piece
+                    component = self.circuit_repo.get_by_id(int(component_id))
+                    
+                    # Custom pieces (with puzzle_id set) are always allowed
+                    # Only personal arsenal pieces (puzzle_id is None) are blocked
+                    if component and component.puzzle_id is None:
+                        raise ValidationError("Arsenal pieces are not allowed in this puzzle. Only basic gates (AND, OR, XOR, NOT, NAND, NOR, XNOR, DFF) are permitted.")
         
         # Expand arsenal pieces in the solution
         expanded_solution = self._expand_arsenal_pieces(solution_payload)


### PR DESCRIPTION
This pull request introduces a user settings system for toggling sound and visual effects, with persistent storage and UI controls, and integrates these settings throughout the Next.js app. It also adds a new backend method to filter user arsenal pieces by allowed gates and improves error handling in the arsenal service.

**Frontend: User Settings System**

* Added a `SettingsProvider` context (`settings-context.tsx`) to manage `soundEnabled`, `visualEffectsEnabled`, and `soundVolume`, persisting these settings in `localStorage` and exposing them via a custom hook `useSettings`.
* Introduced a new `SettingsMenu` component in the dashboard layout, allowing users to toggle sound effects, visual effects, and adjust sound volume, all connected to the settings context [[1]](diffhunk://#diff-c5e09f30d5f371c904984558c0f5c90bec9c80e35be7bd0f4f4a84c41c16eaf2R1-R144) [[2]](diffhunk://#diff-32e17850ba048e9eecba82baa012da697db80f2312a834c37b24287a80c8615dR20) [[3]](diffhunk://#diff-32e17850ba048e9eecba82baa012da697db80f2312a834c37b24287a80c8615dR161).
* Wrapped the app in `SettingsProvider` to make settings available throughout the app (`provider.tsx`) [[1]](diffhunk://#diff-9d4598b63b46eda2e23d12607f855ecc4a835e738900c3ad70fb4b77b4b155b1R13) [[2]](diffhunk://#diff-9d4598b63b46eda2e23d12607f855ecc4a835e738900c3ad70fb4b77b4b155b1R33-R39).

**Frontend: Integration of Settings**

* Updated the puzzle workstation and grid components to respect the `visualEffectsEnabled` setting, disabling confetti and ripple effects when turned off (`puzzle-workstation.tsx`, `workstation-grid.tsx`) ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxR164](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6R164), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL1653-R1660](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L1653-R1660), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL1664-R1671](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L1664-R1671), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxR170](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76R170), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL1406-R1408](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L1406-R1408)).
* Modified the `useAudio` hook to respect `soundEnabled` and `soundVolume` from user settings, so sound effects are played or muted according to user preference (`useAudio.ts`) [[1]](diffhunk://#diff-f231dbeb346d4d6f18471f6e7b2c1d984cd7b332f2daefe771e1e4ef4dc09b82R5-R15) [[2]](diffhunk://#diff-f231dbeb346d4d6f18471f6e7b2c1d984cd7b332f2daefe771e1e4ef4dc09b82L25-R34) [[3]](diffhunk://#diff-f231dbeb346d4d6f18471f6e7b2c1d984cd7b332f2daefe771e1e4ef4dc09b82L35-R45) [[4]](diffhunk://#diff-f231dbeb346d4d6f18471f6e7b2c1d984cd7b332f2daefe771e1e4ef4dc09b82L54-R64).

**Backend: Arsenal Service Enhancements**

* Added a new method `get_user_arsenal_filtered_by_gates` to `ArsenalService.py`, allowing retrieval of user arsenal pieces filtered by allowed gates, which is useful for puzzles with specific arsenal restrictions.
* Improved error handling and logging in `get_custom_pieces_for_puzzle` to aid debugging and clarify behavior.

**Backend: Typing Improvements**

* Updated import statements in `PuzzleService.py` to include `Set` for improved type annotations.