### PR TITLE
181 pre placed locked components on the board for puzzle solvers

### DIFF
--- a/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
@@ -33,7 +33,7 @@ import {
 import type { Wire } from "@/types/api";
 import { cn } from "@/utils/cn";
 
-type TabName = "basic" | "test-cases" | "python-tests" | "instructions" | "solution" | "custom-pieces";
+type TabName = "basic" | "test-cases" | "python-tests" | "instructions" | "initial-board" | "solution" | "custom-pieces";
 
 interface BasicInfo {
   name: string;
@@ -347,6 +347,12 @@ export default function CreatePuzzleForm() {
   const [selectedComponent, setSelectedComponent] = useState<SelectedComponentState>({ mode: 'none' });
   const [draggedPaletteComponentId, setDraggedPaletteComponentId] = useState<string | null>(null);
 
+  // Workstation state for initial board design (locked components)
+  const [initialBoardPlaced, setInitialBoardPlaced] = useState<PlacedGridComponent[]>([]);
+  const [initialBoardWires, setInitialBoardWires] = useState<Wire[]>([]);
+  const [initialBoardSelectedComponent, setInitialBoardSelectedComponent] = useState<SelectedComponentState>({ mode: 'none' });
+  const [initialBoardDraggedPaletteComponentId, setInitialBoardDraggedPaletteComponentId] = useState<string | null>(null);
+
   const [data, setData] = useState<CreatePuzzleData>({
     basic: {
       name: "",
@@ -507,6 +513,19 @@ export default function CreatePuzzleForm() {
       setPrevNumOutputs(customPieceForm.numOutputs);
     }
   }, [customPieceForm.numInputs, customPieceForm.numOutputs, prevNumInputs, prevNumOutputs]);
+
+  // Wrapper callbacks to auto-lock components/wires on initial board
+  const handleInitialBoardPlacedChange = (newPlaced: PlacedGridComponent[]) => {
+    // Ensure all items are locked
+    const lockedPlaced = newPlaced.map(c => ({ ...c, isLocked: true }));
+    setInitialBoardPlaced(lockedPlaced);
+  };
+
+  const handleInitialBoardWiresChange = (newWires: Wire[]) => {
+    // Ensure all wires are locked
+    const lockedWires = newWires.map(w => ({ ...w, isLocked: true }));
+    setInitialBoardWires(lockedWires);
+  };
 
   const handleBasicChange = (
     field: keyof BasicInfo,
@@ -878,6 +897,29 @@ export default function CreatePuzzleForm() {
 
     return catalog;
   }, [data.basic.gateSet, customPieces, selectedArsenalPieces]);
+
+  // Handler: When switching FROM initial-board TO solution tab, auto-populate solution with all initial board components
+  const handleTabChange = (tab: TabName) => {
+    if (tab === 'solution' && activeTab === 'initial-board') {
+      // Auto-populate solution tab with all initial board components (they're all locked by default)
+      const allPlaced = initialBoardPlaced;
+      const allWires = initialBoardWires;
+      
+      // Merge items into solution (avoid duplicates by ID)
+      setPlaced((prev) => {
+        const idMap = new Map(prev.map((c) => [c.id, c]));
+        allPlaced.forEach((c) => idMap.set(c.id, c));
+        return Array.from(idMap.values());
+      });
+      
+      setWires((prev) => {
+        const idMap = new Map(prev.map((w) => [w.id, w]));
+        allWires.forEach((w) => idMap.set(w.id, w));
+        return Array.from(idMap.values());
+      });
+    }
+    setActiveTab(tab);
+  };
 
   // Export solution from workstation
   const exportSolution = useCallback(async () => {
@@ -1326,6 +1368,28 @@ export default function CreatePuzzleForm() {
             rows: data.basic.boardRows,
             cols: data.basic.boardCols,
           },
+          // Initial board: locked components pre-placed for solver
+          initial_board: initialBoardPlaced.length > 0 || initialBoardWires.length > 0 
+            ? {
+                locked_placed: initialBoardPlaced
+                  .filter((c) => c.isLocked)
+                  .map((c) => ({
+                    id: c.id,
+                    componentId: c.componentId,
+                    origin: c.origin,
+                    rotation: c.rotation,
+                    isLocked: true,
+                  })),
+                locked_wires: initialBoardWires
+                  .filter((w) => w.isLocked)
+                  .map((w) => ({
+                    id: w.id,
+                    from: w.from,
+                    to: w.to,
+                    isLocked: true,
+                  })),
+              }
+            : undefined,
         },
         test_cases: convertedTestCases,
       };
@@ -1424,11 +1488,11 @@ export default function CreatePuzzleForm() {
 
       {/* Tabs */}
       <div className="flex border-b mb-6">
-        {(["basic", "test-cases", "python-tests", "custom-pieces", "instructions", "solution"] as TabName[]).map(
+        {(["basic", "test-cases", "python-tests", "custom-pieces", "instructions", "initial-board", "solution"] as TabName[]).map(
           (tab) => (
             <button
               key={tab}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => handleTabChange(tab)}
               className={`px-6 py-2 text-[13px] font-semibold transition-colors ${
                 activeTab === tab
                   ? "border-b-2 border-foreground text-foreground"
@@ -1445,7 +1509,9 @@ export default function CreatePuzzleForm() {
                       ? "Custom Pieces"
                       : tab === "instructions"
                         ? "Instructions"
-                        : "Solution"}
+                        : tab === "initial-board"
+                          ? "Initial Board"
+                          : "Solution"}
             </button>
           )
         )}
@@ -1944,7 +2010,7 @@ export default function CreatePuzzleForm() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => setActiveTab('basic')}
+                      onClick={() => handleTabChange('basic')}
                       className="rounded-lg border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-secondary transition-colors"
                     >
                       Open Basic Info
@@ -2196,8 +2262,84 @@ export default function CreatePuzzleForm() {
           </div>
         )}
 
-        {activeTab === "solution" && (
+        {activeTab === "initial-board" && (
           <div className="space-y-4">
+            <div className="bg-secondary/50 border border-border p-4 rounded-lg">
+              <h3 className="font-semibold text-foreground mb-2">📌 Design Your Initial Board (Pre-placed Locked Components)</h3>
+              <div className="text-[13px] text-foreground mb-3 space-y-2">
+                <p>
+                  <strong>Instructions:</strong> Place the components that will be pre-placed for the solver. All components you place here are automatically locked and will:
+                </p>
+                <ul className="list-disc list-inside ml-2 space-y-1">
+                  <li>Be immovable (cannot be dragged by solver)</li>
+                  <li>Be undeletable (cannot be removed by solver)</li>
+                  <li>Be mandatory (must be connected to validate the solution)</li>
+                  <li>Be counted in the puzzle cost</li>
+                </ul>
+                <p className="text-blue-700 font-semibold mt-2">
+                  💡 Just drag and place components. They automatically get a 🔒 icon and dashed wires when locked.
+                </p>
+              </div>
+            </div>
+
+            {/* Workstation Grid for Initial Board (similar to Solution) */}
+            <div className="grid grid-cols-[240px_1fr] gap-4 rounded-xl border border-border bg-card shadow-card h-[700px]">
+              {/* Gate Palette Sidebar */}
+              <div className="border-r p-3 overflow-y-auto bg-secondary/50">
+                <div className="text-[13px] font-semibold text-foreground mb-3">Available Components</div>
+                {data.basic.gateSet.length === 0 && customPieces.length === 0 && selectedArsenalPieces.length === 0 ? (
+                  <p className="text-[11px] text-muted-foreground">Select gates in "Basic Info" tab</p>
+                ) : (
+                  <div className="space-y-2">
+                    {/* Basic Gates */}
+                    {data.basic.gateSet.map((gateName) => (
+                      <div
+                        key={`initial-gate-${gateName}`}
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.effectAllowed = 'copy';
+                          e.dataTransfer.setData('application/x-escapecircuit-component', gateName);
+                          setInitialBoardDraggedPaletteComponentId(gateName);
+                        }}
+                        onDragEnd={() => setInitialBoardDraggedPaletteComponentId(null)}
+                        className="flex items-center gap-2 p-2 border border-border bg-card rounded-lg cursor-move hover:bg-secondary/50 transition"
+                      >
+                        <span className="font-medium text-[13px] text-foreground">{gateName}</span>
+                        <div className="flex-1" />
+                        <div className="text-[10px] text-muted-foreground flex-shrink-0">
+                          cost {GATE_PROPERTIES[gateName]?.cost ?? 1}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Workstation Grid */}
+              <div className="overflow-hidden rounded-lg border border-border">
+                <WorkstationGrid
+                  puzzleId="initial-board"
+                  inputs={data.basic.inputs}
+                  outputs={data.basic.outputs}
+                  catalog={uiCatalog}
+                  placed={initialBoardPlaced}
+                  wires={initialBoardWires}
+                  selectedComponent={initialBoardSelectedComponent}
+                  onSelectedComponentChange={setInitialBoardSelectedComponent}
+                  onPlacedChange={handleInitialBoardPlacedChange}
+                  onWiresChange={handleInitialBoardWiresChange}
+                  draggedPaletteComponentId={initialBoardDraggedPaletteComponentId}
+                  boardRows={data.basic.boardRows}
+                  boardCols={data.basic.boardCols}
+                  isEditMode={true}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab === "solution" && (
+          <div className="space-y-6">
             <div className="bg-secondary/50 border border-border p-4 rounded-lg">
               <h3 className="font-semibold text-foreground mb-2">⚡ Design Your Solution Circuit</h3>
               <div className="text-[13px] text-foreground mb-3 space-y-2">

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -262,6 +262,62 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     }
   }, [puzzle?.is_solved]);
 
+  // Initialize placed/wires with locked components from initial_board
+  // These are pre-placed by the puzzle creator and cannot be moved/deleted by the solver
+  // This MUST run whenever puzzle loads, or whenever placed/wires might have been cleared
+  useEffect(() => {
+    console.log('[InitialBoard] Checking for initial_board...');
+    console.log('[InitialBoard] puzzle?.initial_board:', puzzle?.initial_board);
+    
+    if (!puzzle?.initial_board) {
+      console.log('[InitialBoard] No initial_board found, returning');
+      return;
+    }
+    
+    const { locked_placed, locked_wires } = puzzle.initial_board;
+    console.log('[InitialBoard] locked_placed:', locked_placed);
+    console.log('[InitialBoard] locked_wires:', locked_wires);
+    console.log('[InitialBoard] Current placed:', placed);
+    
+    // CRITICAL: Ensure locked items are ALWAYS present on the board
+    // If they're missing, re-add them (handles "Try Again" scenario)
+    if (locked_placed && locked_placed.length > 0) {
+      console.log('[InitialBoard] Ensuring', locked_placed.length, 'locked components are present');
+      setPlaced((prev) => {
+        // Check which locked items are missing
+        const existingIds = new Set(prev.map((c) => c.id));
+        const missingLocked = (locked_placed || [])
+          .filter((c) => !existingIds.has(c.id))
+          .map((c) => ({ ...c, isLocked: true }));
+        
+        if (missingLocked.length > 0) {
+          console.log('[InitialBoard] Re-adding', missingLocked.length, 'missing locked components');
+          return [...prev, ...missingLocked];
+        }
+        console.log('[InitialBoard] All locked components already present');
+        return prev;
+      });
+    }
+    
+    if (locked_wires && locked_wires.length > 0) {
+      console.log('[InitialBoard] Ensuring', locked_wires.length, 'locked wires are present');
+      setWires((prev) => {
+        // Check which locked wires are missing
+        const existingIds = new Set(prev.map((w) => w.id));
+        const missingLocked = (locked_wires || [])
+          .filter((w) => !existingIds.has(w.id))
+          .map((w) => ({ ...w, isLocked: true }));
+        
+        if (missingLocked.length > 0) {
+          console.log('[InitialBoard] Re-adding', missingLocked.length, 'missing locked wires');
+          return [...prev, ...missingLocked];
+        }
+        console.log('[InitialBoard] All locked wires already present');
+        return prev;
+      });
+    }
+  }, [puzzle?.initial_board, placed.length, wires.length]);
+
   useEffect(() => {
     const tick = () => {
       setElapsedSeconds(Math.floor((Date.now() - startTime.current) / 1000));
@@ -1398,6 +1454,33 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     if (issues.length) {
       setConnectivityIssues(issues);
       return;
+    }
+
+    // Validate that all locked components are used (have at least 1 connected wire)
+    const lockedComponentIds = placed
+      .filter((c) => c.isLocked === true)
+      .map((c) => c.id);
+
+    if (lockedComponentIds.length > 0) {
+      const connectedLockedIds = new Set<string>();
+      for (const wire of wires) {
+        if (lockedComponentIds.includes(wire.from.componentId)) {
+          connectedLockedIds.add(wire.from.componentId);
+        }
+        if (lockedComponentIds.includes(wire.to.componentId)) {
+          connectedLockedIds.add(wire.to.componentId);
+        }
+      }
+
+      const unusedLockedIds = lockedComponentIds.filter((id) => !connectedLockedIds.has(id));
+      if (unusedLockedIds.length > 0) {
+        notifications.addNotification({
+          type: 'warning',
+          title: 'Pre-placed Components Not Connected',
+          message: `You must connect and use all pre-placed locked components! ${unusedLockedIds.length} component(s) are not connected to any wires. (Look for 🔒 icons on the board)`,
+        });
+        return;
+      }
     }
 
     setIsPowerSurge(true);

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -41,6 +41,7 @@ export type PlacedGridComponent = {
   componentId: string; // catalog id
   origin: HoleCoord;
   rotation: 0 | 90;
+  isLocked?: boolean; // If true, component is immovable, undeletable, and mandatory to use
 };
 
 export type PortAddress = {
@@ -132,6 +133,7 @@ export const WorkstationGrid = ({
   debuggerSequences = {},
   onDebuggerSequenceChange,
   onInspectComponent,
+  isEditMode = false,
 }: {
   puzzleId: string;
   inputs: string[];
@@ -162,6 +164,7 @@ export const WorkstationGrid = ({
   onDebuggerSequenceChange?: (inputName: string, sequence: string) => void;
   onInspectComponent?: (placedId: string) => void;
   arsenalComponentDisplayModes?: Record<string, 'circuit' | 'description'>;
+  isEditMode?: boolean;
 }) => {
   const gridRows = Math.max(1, boardRows ?? DEFAULT_GRID_ROWS);
   const gridCols = Math.max(1, boardCols ?? DEFAULT_GRID_COLS);
@@ -343,14 +346,24 @@ export const WorkstationGrid = ({
 
       if (selectedEntity.type === 'component' && selectedEntity.placedIds.length > 0) {
         console.log('[Delete Key] Deleting components:', selectedEntity.placedIds);
-        // Delete all selected components
+        // Delete all selected components (skip locked ones)
         for (const placedId of selectedEntity.placedIds) {
+          const component = placed.find((c) => c.id === placedId);
+          if (component?.isLocked) {
+            console.log('[Delete] Cannot delete locked component:', placedId);
+            continue;
+          }
           console.log('[Delete] Removing component:', placedId);
           removeComponent(placedId);
         }
       } else if (selectedEntity.type === 'wire') {
         console.log('[Delete Key] Deleting wire:', selectedEntity.wireId);
-        removeWire(selectedEntity.wireId);
+        const wire = wires.find((w) => w.id === selectedEntity.wireId);
+        if (!wire?.isLocked) {
+          removeWire(selectedEntity.wireId);
+        } else {
+          console.log('[Delete] Cannot delete locked wire:', selectedEntity.wireId);
+        }
       }
     };
 
@@ -1542,6 +1555,9 @@ export const WorkstationGrid = ({
               : isRecentlyConnected
                 ? '#bfdbfe'
                 : '#93c5fd';
+            
+            // Check if wire is locked (at least one endpoint is locked)
+            const isWireLocked = w.isLocked === true;
 
             return (
               <g key={w.id}>
@@ -1555,6 +1571,7 @@ export const WorkstationGrid = ({
                   fill="none"
                   stroke={strokeColor}
                   strokeWidth={isPowerSurge ? 4.2 : isSelected ? 3 : isRecentlyConnected ? 4 : 2}
+                  strokeDasharray={isWireLocked ? '6,3' : undefined}
                   style={{
                     filter: isDeleteWarn
                       ? 'drop-shadow(0 0 8px rgba(239,68,68,0.85))'
@@ -1748,6 +1765,10 @@ export const WorkstationGrid = ({
 
             const left = origin.col * CELL_PX;
             const top = origin.row * CELL_PX;
+            
+            if (p.isLocked) {
+              console.log('[Render] Locked component:', {id: p.id, componentId: p.componentId, isLocked: p.isLocked, label: def.label});
+            }
 
             const isSelected =
               selectedEntity.type === 'component' &&
@@ -1814,6 +1835,12 @@ export const WorkstationGrid = ({
                     });
                   } else {
                     setSelectedEntity({ type: 'component', placedIds: [p.id] });
+                  }
+
+                  // Prevent drag if component is locked (but allow in edit mode)
+                  if (p.isLocked && !isEditMode) {
+                    console.log('[Locked Component] Cannot drag locked component:', p.id);
+                    return;
                   }
 
                   const el = containerRef.current;
@@ -1949,7 +1976,8 @@ export const WorkstationGrid = ({
                       </button>
                     )}
 
-                    {/* Delete Button */}
+                    {/* Delete Button - Hidden if locked */}
+                    {!p.isLocked && (
                     <button
                       type="button"
                       className="flex size-5 items-center justify-center rounded-full bg-white text-red-600 shadow-sm ring-1 ring-gray-200 transition-all hover:scale-110 hover:bg-red-100 hover:text-red-700 hover:ring-red-300"
@@ -1978,6 +2006,29 @@ export const WorkstationGrid = ({
                         <path d="M6 6l1 16h10l1-16" />
                       </svg>
                     </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Lock Indicator (🔒 icon for locked components) */}
+                {p.isLocked && (
+                  <div
+                    className="absolute top-0 left-1/2 z-40 flex items-center justify-center transform -translate-x-1/2 -translate-y-1/2"
+                    style={{
+                      width: '24px',
+                      height: '24px',
+                      backgroundColor: '#fbbf24',
+                      borderRadius: '50%',
+                      border: '2px solid #f59e0b',
+                      fontSize: '12px',
+                      lineHeight: '1',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                    title="This component is locked and cannot be moved or deleted"
+                  >
+                    🔒
                   </div>
                 )}
 

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -346,11 +346,11 @@ export const WorkstationGrid = ({
 
       if (selectedEntity.type === 'component' && selectedEntity.placedIds.length > 0) {
         console.log('[Delete Key] Deleting components:', selectedEntity.placedIds);
-        // Delete all selected components (skip locked ones)
+        // Delete all selected components (skip locked ones unless in edit mode)
         for (const placedId of selectedEntity.placedIds) {
           const component = placed.find((c) => c.id === placedId);
-          if (component?.isLocked) {
-            console.log('[Delete] Cannot delete locked component:', placedId);
+          if (component?.isLocked && !isEditMode) {
+            console.log('[Delete] Cannot delete locked component (not in edit mode):', placedId);
             continue;
           }
           console.log('[Delete] Removing component:', placedId);
@@ -359,10 +359,10 @@ export const WorkstationGrid = ({
       } else if (selectedEntity.type === 'wire') {
         console.log('[Delete Key] Deleting wire:', selectedEntity.wireId);
         const wire = wires.find((w) => w.id === selectedEntity.wireId);
-        if (!wire?.isLocked) {
+        if (!wire?.isLocked || isEditMode) {
           removeWire(selectedEntity.wireId);
         } else {
-          console.log('[Delete] Cannot delete locked wire:', selectedEntity.wireId);
+          console.log('[Delete] Cannot delete locked wire (not in edit mode):', selectedEntity.wireId);
         }
       }
     };
@@ -1976,8 +1976,8 @@ export const WorkstationGrid = ({
                       </button>
                     )}
 
-                    {/* Delete Button - Hidden if locked */}
-                    {!p.isLocked && (
+                    {/* Delete Button - Hidden if locked (unless in edit mode) */}
+                    {(!p.isLocked || isEditMode) && (
                     <button
                       type="button"
                       className="flex size-5 items-center justify-center rounded-full bg-white text-red-600 shadow-sm ring-1 ring-gray-200 transition-all hover:scale-110 hover:bg-red-100 hover:text-red-700 hover:ring-red-300"
@@ -1992,7 +1992,7 @@ export const WorkstationGrid = ({
                         e.stopPropagation();
                         triggerDeleteComponent(p.id);
                       }}
-                      title="Delete component"
+                      title={p.isLocked && isEditMode ? "Delete locked component" : "Delete component"}
                     >
                       <svg
                         viewBox="0 0 24 24"

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -169,6 +169,17 @@ export type Puzzle = Entity<{
   user_rating?: RatingEntry | null;
   // Rating metrics (injected by browse/get endpoints)
   rating_metrics?: RatingMetrics;
+  // Initial board: locked components pre-placed for solver
+  initial_board?: { 
+    locked_placed: Array<{
+      id: string;
+      componentId: string;
+      origin: { row: number; col: number };
+      rotation: 0 | 90;
+      isLocked?: boolean;
+    }>;
+    locked_wires: Wire[];
+  } | null;
 }>;
 
 export type CircuitComponent = {
@@ -193,12 +204,14 @@ export type PlacedComponent = {
   componentId: string;
   x: number;
   y: number;
+  isLocked?: boolean;
 };
 
 export type Wire = {
   id: string;
   from: { componentId: string; pinIndex: number; portId: string };
   to: { componentId: string; pinIndex: number; portId: string };
+  isLocked?: boolean;
 };
 
 export type CircuitSolution = {

--- a/src/Backend/DomainLayer/Puzzle.py
+++ b/src/Backend/DomainLayer/Puzzle.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Set, List
+import json
 
 from Backend import settings
 from .Enums import GateType, PuzzleStatus, PuzzleDifficulty
@@ -36,6 +37,9 @@ class Puzzle:
     # Board dimensions (None = use defaults)
     board_rows: Optional[int] = None
     board_cols: Optional[int] = None
+
+    # Initial board configuration: JSON string containing locked placed components and wires
+    initial_board_json: Optional[str] = None
 
     rating_count: int = 0
     is_hall_of_fame: bool = False
@@ -118,6 +122,8 @@ class Puzzle:
             "max_cycles": self.max_cycles,
             "board_rows": self.board_rows if self.board_rows is not None else settings.PUZZLE_DEFAULT_BOARD_ROWS,
             "board_cols": self.board_cols if self.board_cols is not None else settings.PUZZLE_DEFAULT_BOARD_COLS,
+            "initial_board_json": self.initial_board_json,
+            "initial_board": json.loads(self.initial_board_json) if self.initial_board_json else None,
             "rating": self.avg_difficulty, # Frontend expects 'rating' (number)
             "rating_count": self.rating_count,
             "is_hall_of_fame": self.is_hall_of_fame,
@@ -135,6 +141,15 @@ class Puzzle:
     @staticmethod
     def from_dict(d: dict) -> "Puzzle":
         from datetime import datetime
+        import json as json_module
+        
+        # Parse initial_board: accept either JSON string or parsed object
+        initial_board_json = None
+        if "initial_board_json" in d:
+            initial_board_json = d["initial_board_json"]
+        elif "initial_board" in d and d["initial_board"] is not None:
+            initial_board_json = json_module.dumps(d["initial_board"])
+        
         return Puzzle(
             id=int(d.get("id", 0)),
             name=d["name"],
@@ -160,6 +175,7 @@ class Puzzle:
             allow_arsenal=d.get("allow_arsenal", True),
             allowed_arsenal_component_ids=d.get("allowed_arsenal_component_ids") or d.get("allowedArsenalComponentIds"),
             arsenal_component_display_modes=d.get("arsenal_component_display_modes") or d.get("arsenalComponentDisplayModes"),
+            initial_board_json=initial_board_json,
             rating_count=int(d.get("rating_count", 0)),
             is_hall_of_fame=bool(d.get("is_hall_of_fame", d.get("isHallOfFame", False))),
             avg_difficulty=float(d.get("avg_difficulty", 0.0)),

--- a/src/Backend/PersistantLayer/PuzzleRepo.py
+++ b/src/Backend/PersistantLayer/PuzzleRepo.py
@@ -75,6 +75,8 @@ class PuzzleRepo:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN arsenal_component_display_modes TEXT;")
             if "riddle_base_name" not in cols:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN riddle_base_name TEXT;")
+            if "initial_board_json" not in cols:
+                self.conn.execute("ALTER TABLE puzzles ADD COLUMN initial_board_json TEXT;")
         except Exception:
             pass
         self.conn.execute("""
@@ -157,8 +159,8 @@ class PuzzleRepo:
                 rating_count, is_hall_of_fame, avg_difficulty, avg_fun, avg_clearness,
                 min_gate_count, total_gate_count, min_cycles, max_cycles,
                 riddle_base_name, allow_arsenal, allowed_arsenal_component_ids, arsenal_component_display_modes,
-                created_at
-            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                initial_board_json, created_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """, (
             puzzle.name,
             puzzle.creator_user_id,
@@ -184,6 +186,7 @@ class PuzzleRepo:
             1 if puzzle.allow_arsenal else 0,
             json.dumps(puzzle.allowed_arsenal_component_ids) if puzzle.allowed_arsenal_component_ids else None,
             json.dumps(puzzle.arsenal_component_display_modes) if puzzle.arsenal_component_display_modes else None,
+            puzzle.initial_board_json,
             puzzle.created_at.isoformat(),
         ))
         puzzle.id = int(cur.lastrowid)
@@ -218,7 +221,8 @@ class PuzzleRepo:
                 max_cycles=?,
                 allow_arsenal=?,
                 allowed_arsenal_component_ids=?,
-                arsenal_component_display_modes=?
+                arsenal_component_display_modes=?,
+                initial_board_json=?
             WHERE id=?
         """, (
             puzzle.name,
@@ -244,6 +248,7 @@ class PuzzleRepo:
             1 if puzzle.allow_arsenal else 0,
             json.dumps(puzzle.allowed_arsenal_component_ids) if puzzle.allowed_arsenal_component_ids else None,
             json.dumps(puzzle.arsenal_component_display_modes) if puzzle.arsenal_component_display_modes else None,
+            puzzle.initial_board_json,
             puzzle.id
         ))
 
@@ -968,6 +973,11 @@ class PuzzleRepo:
             riddle_base_name = row["riddle_base_name"]
         except (IndexError, KeyError):
             riddle_base_name = None
+        # Safely read initial_board_json — may be missing in old DBs
+        try:
+            initial_board_json = row["initial_board_json"]
+        except (IndexError, KeyError):
+            initial_board_json = None
         return Puzzle.from_dict({
             "id": int(row["id"]),
             "name": row["name"],
@@ -997,4 +1007,5 @@ class PuzzleRepo:
             "avg_clearness": float(row["avg_clearness"]),
             "created_at": row["created_at"],
             "riddle_base_name": riddle_base_name,
+            "initial_board_json": initial_board_json,
         })

--- a/src/insert_riddles.py
+++ b/src/insert_riddles.py
@@ -225,6 +225,11 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
     basic_circuits = config.get('basic_circuits', []) or puzzle_data.get('basic_circuits', [])
     custom_pieces = config.get('custom_pieces', []) or puzzle_data.get('custom_pieces', [])
     
+    # Extract initial_board if present (pre-placed locked components)
+    initial_board_json = None
+    if puzzle_data.get('initial_board'):
+        initial_board_json = json.dumps(puzzle_data['initial_board'])
+    
     # Determine gates JSON
     gates_json = json.dumps(puzzle_data.get('default_gate_set', []))
 
@@ -255,7 +260,7 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
                 default_gate_set=?, difficulty=?,
                 min_gate_count=?, total_gate_count=?, min_cycles=?, max_cycles=?,
                 board_rows=?, board_cols=?,
-                allow_arsenal=?, allowed_arsenal_component_ids=?, arsenal_component_display_modes=?, riddle_base_name=?
+                allow_arsenal=?, allowed_arsenal_component_ids=?, arsenal_component_display_modes=?, riddle_base_name=?, initial_board_json=?
             WHERE id=?
         """, (
             description,
@@ -275,6 +280,7 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             json.dumps(puzzle_data.get('allowed_arsenal_component_ids')) if puzzle_data.get('allowed_arsenal_component_ids') else None,
             json.dumps(puzzle_data.get('arsenal_component_display_modes')) if puzzle_data.get('arsenal_component_display_modes') else None,
             puzzle_data.get('riddle_base_name'),
+            initial_board_json,
             puzzle_id
         ))
         # Clear old test cases for this puzzle (they get re-imported below)
@@ -288,9 +294,9 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
                 avg_difficulty, avg_fun, avg_clearness,
                 min_gate_count, total_gate_count, min_cycles, max_cycles,
                 allow_arsenal, allowed_arsenal_component_ids, arsenal_component_display_modes,
-                board_rows, board_cols, riddle_base_name,
+                board_rows, board_cols, riddle_base_name, initial_board_json,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             puzzle_data['name'],
             creator_id,
@@ -313,6 +319,7 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             puzzle_data.get('board', {}).get('rows'),
             puzzle_data.get('board', {}).get('cols'),
             puzzle_data.get('riddle_base_name'),
+            initial_board_json,
             utcnow().isoformat()
         ))
         puzzle_id = c.lastrowid


### PR DESCRIPTION
**Description:**
This PR introduces the "Initial Board" feature, allowing puzzle creators to define a fixed starting state for solvers. Creators can now place and lock specific gates and wires that act as mandatory architectural constraints for the puzzle.

**Key Changes:**

Creator UI: Added a new "Initial Board" tab in the puzzle creation form where creators can build the starting circuit and toggle a "Locked" state on individual nodes and wires.

Visual Indicators: Locked nodes display a 🔒 icon, and locked wires use a dashed stroke pattern for clear visibility.

Gameplay Restrictions: Pre-placed locked components cannot be dragged, moved, or deleted by the player.

Mandatory Use Validation: Implemented a pre-simulation check ensuring players must connect and utilize all locked components to solve the puzzle.

Cost Calculation: Locked components are successfully integrated into the puzzle's total cost calculation.