### PR TITLE
fix: grant maximum time-based XP when a puzzle has no time limit

### DIFF
--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -378,7 +378,8 @@ class SolvingService:
                     new_best_medal = medal.value if isinstance(medal, Medal) else int(medal)
                     timer_upgraded = getattr(old_progress, 'timer_upgraded', False)
                     tight_upgraded = getattr(old_progress, 'tight_upgraded', False)
-                    if p.time_limit_seconds and time_taken_s <= p.time_limit_seconds:
+                    # If there's no time limit OR time was within the limit, mark timer as upgraded
+                    if p.time_limit_seconds is None or p.time_limit_seconds == 0 or time_taken_s <= p.time_limit_seconds:
                         timer_upgraded = True
                     p_creator_budget = getattr(p, 'creator_budget', None)
                     if isinstance(p_creator_budget, int) and p_creator_budget > 0 and cost_used <= p_creator_budget:

--- a/src/Backend/ServiceLayer/XPService.py
+++ b/src/Backend/ServiceLayer/XPService.py
@@ -91,8 +91,9 @@ class XPService:
 
         bonus_count = 0
 
-        # Condition 1: Beats the timer
-        if time_limit is not None and time_limit > 0 and time_taken <= time_limit:
+        # Condition 1: Beats the timer (or no time limit exists)
+        # When time_limit is None or 0, automatically award timer bonus (no time pressure)
+        if time_limit is None or time_limit == 0 or time_taken <= time_limit:
             bonus_count += 1
 
         # Condition 2: Creator Budget (cost <= creator's solution cost)

--- a/src/tests/ServiceLayerTests/test_xp_service.py
+++ b/src/tests/ServiceLayerTests/test_xp_service.py
@@ -265,20 +265,23 @@ class TestXPServiceMedalCalculation:
         medal = self.service.calculate_medal(passed=True, time_taken=30, time_limit=60, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.GOLD
 
-    def test_medal_bronze_no_time_limit(self):
-        # No time limit set, over budget -> only budget condition could count
+    def test_medal_silver_no_time_limit(self):
+        # No time limit set = automatic timer bonus (1 condition), over budget (no budget bonus)
+        # Result: 1 bonus condition = SILVER
         medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=15, budget=10)
-        assert medal == Medal.BRONZE
-
-    def test_medal_silver_no_time_limit_but_beats_creator_budget(self):
-        # No time limit, beats creator budget -> 1 condition
-        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.SILVER
 
-    def test_medal_bronze_no_creator_budget_set(self):
-        # No creator_budget and no time limit -> no bonuses -> BRONZE
+    def test_medal_gold_no_time_limit_beats_creator_budget(self):
+        # No time limit = automatic timer bonus (1 condition), beats creator budget (1 condition)
+        # Result: 2 bonus conditions = GOLD (maximum XP for untimed puzzles!)
+        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10, creator_budget=10)
+        assert medal == Medal.GOLD
+
+    def test_medal_silver_no_creator_budget_no_time_limit(self):
+        # No time limit = automatic timer bonus (1 condition), no creator budget
+        # Result: 1 bonus condition = SILVER
         medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=None, cost_used=5, budget=10)
-        assert medal == Medal.BRONZE
+        assert medal == Medal.SILVER
 
     def test_medal_bronze_creator_budget_not_met(self):
         # cost exceeds creator_budget -> no budget bonus
@@ -298,6 +301,18 @@ class TestXPServiceMedalCalculation:
     def test_medal_gold_timer_and_creator_budget(self):
         # Beats both timer and creator_budget -> GOLD
         medal = self.service.calculate_medal(passed=True, time_taken=20, time_limit=60, cost_used=3, budget=20, creator_budget=5)
+        assert medal == Medal.GOLD
+
+    def test_medal_silver_no_time_limit_zero(self):
+        # time_limit=0 also means no time limit = automatic timer bonus (1 condition), over budget
+        # Result: 1 bonus condition = SILVER
+        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=0, cost_used=15, budget=10)
+        assert medal == Medal.SILVER
+
+    def test_medal_gold_no_time_limit_zero_beats_creator_budget(self):
+        # time_limit=0 = automatic timer bonus (1 condition), beats creator budget (1 condition)
+        # Result: 2 bonus conditions = GOLD (maximum XP for untimed puzzles!)
+        medal = self.service.calculate_medal(passed=True, time_taken=10, time_limit=0, cost_used=5, budget=10, creator_budget=10)
         assert medal == Medal.GOLD
 
 class TestXPServiceArsenalCapacity:


### PR DESCRIPTION
This pull request updates the way timer-based bonuses are awarded for puzzles with no time limit (i.e., `time_limit` is `None` or `0`). Now, if a puzzle has no time limit, the timer bonus is automatically granted, which affects how medals are calculated and awarded. The test suite has been updated to reflect these new rules and to ensure correct medal assignment in untimed scenarios.

Medal calculation and validation logic changes:

* The logic in `XPService.py` and `SolvingService.py` now treats puzzles with `time_limit=None` or `time_limit=0` as automatically satisfying the timer bonus condition, granting the timer bonus even if there is no explicit time pressure. [[1]](diffhunk://#diff-adf9cc2ea04a853381c2bdcb7d4c51d03943881f313ec04ee8e038a00bc2edfaL94-R96) [[2]](diffhunk://#diff-34b2fcddc3898423ee694b634bd937b1377fa264ae4a81a50fced1fafe0d9529L381-R382)

Test suite updates:

* The tests in `test_xp_service.py` have been revised to match the new untimed puzzle rules:
  - Untimed puzzles (no time limit set or `time_limit=0`) now grant the timer bonus by default, resulting in higher medals (SILVER or GOLD) depending on whether the creator budget is met.
  - Additional test cases have been added to explicitly cover scenarios with `time_limit=0`, ensuring consistent behavior with `time_limit=None`.