### PR TITLE
V0.2/dishon me/189/frontend/fix filters UI

### DIFF
--- a/apps/nextjs-app/src/features/puzzles/api/get-puzzles.ts
+++ b/apps/nextjs-app/src/features/puzzles/api/get-puzzles.ts
@@ -8,8 +8,7 @@ export interface PuzzleFilters {
   page?: number;
   search?: string;
   creator?: string;
-  minDifficulty?: number;
-  maxDifficulty?: number;
+  selectedDifficulties?: number[];
   onlyExperiencedDifficulty?: boolean;
   minClearness?: number;
   maxClearness?: number;
@@ -40,8 +39,10 @@ export const getPuzzles = (
 
   if (filters.search !== undefined) params.search = filters.search;
   if (filters.creator !== undefined) params.creator = filters.creator;
-  if (filters.minDifficulty !== undefined) params.min_difficulty = filters.minDifficulty;
-  if (filters.maxDifficulty !== undefined) params.max_difficulty = filters.maxDifficulty;
+  if (filters.selectedDifficulties && filters.selectedDifficulties.length > 0) {
+    params.min_difficulty = Math.min(...filters.selectedDifficulties);
+    params.max_difficulty = Math.max(...filters.selectedDifficulties);
+  }
   if (filters.creator_id !== undefined) params.creator_id = filters.creator_id;
   if (filters.experienceLevel && filters.experienceLevel !== 'all') {
     params.creator_experience_level = filters.experienceLevel;

--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -55,7 +55,7 @@ export const PuzzlesList = () => {
   const [leaderboardPuzzleId, setLeaderboardPuzzleId] = useState<string | null>(null);
   const [ratingPuzzleId, setRatingPuzzleId] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
-  const [filters, setFilters] = useState<PuzzleFilters>({ page: 1 });
+  const [filters, setFilters] = useState<PuzzleFilters>({ page: 1, selectedDifficulties: [1, 2, 3] });
   const [creatorSearchInput, setCreatorSearchInput] = useState('');
   const debouncedCreatorSearch = useDebouncedValue(creatorSearchInput, 400);
 
@@ -178,7 +178,7 @@ export const PuzzlesList = () => {
             variant="ghost"
             size="sm"
             onClick={() => {
-              setFilters({ page: 1 });
+              setFilters({ page: 1, selectedDifficulties: [1, 2, 3] });
               setCreatorSearchInput('');
             }}
             className="text-muted-foreground text-[13px]"
@@ -192,7 +192,7 @@ export const PuzzlesList = () => {
       {/* Filter Panel */}
       {showFilters && (
         <div className="rounded-xl border border-border bg-card p-5 space-y-5">
-          {/* Top Level: name, creator, min difficulty, min fun, min clearness */}
+          {/* Top Level: name, creator, difficulty, min fun, min clearness */}
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
             {/* Search Name */}
             <div>
@@ -218,19 +218,42 @@ export const PuzzlesList = () => {
               />
             </div>
 
-            {/* Min Difficulty */}
+            {/* Difficulty */}
             <div>
-              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Min Difficulty</label>
-              <select
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                value={filters.minDifficulty || ''}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, minDifficulty: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
-              >
-                <option value="">Any</option>
-                <option value="1">Easy</option>
-                <option value="2">Medium</option>
-                <option value="3">Hard</option>
-              </select>
+              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Difficulty</label>
+              <div className="space-y-2">
+                {[
+                  { value: 1, label: 'Easy' },
+                  { value: 2, label: 'Medium' },
+                  { value: 3, label: 'Hard' },
+                ].map((difficulty) => (
+                  <div key={difficulty.value} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id={`difficulty-${difficulty.value}`}
+                      checked={(filters.selectedDifficulties || []).includes(difficulty.value)}
+                      onChange={(e) => {
+                        const selected = filters.selectedDifficulties || [1, 2, 3];
+                        const newSelected = e.target.checked
+                          ? [...selected, difficulty.value].sort()
+                          : selected.filter((d) => d !== difficulty.value);
+                        setFilters({
+                          ...filters,
+                          selectedDifficulties: newSelected.length > 0 ? newSelected : undefined,
+                          page: 1,
+                        });
+                      }}
+                      className="rounded border border-border"
+                    />
+                    <label
+                      htmlFor={`difficulty-${difficulty.value}`}
+                      className="text-[13px] cursor-pointer"
+                    >
+                      {difficulty.label}
+                    </label>
+                  </div>
+                ))}
+              </div>
             </div>
 
             {/* Min Fun */}
@@ -264,7 +287,7 @@ export const PuzzlesList = () => {
             </div>
           </div>
 
-          {/* Mid Level: order, max difficulty, max fun, max clearness */}
+          {/* Mid Level: order, max fun, max clearness */}
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
             {/* Order By */}
             <div>
@@ -278,21 +301,6 @@ export const PuzzlesList = () => {
                 <option value="difficulty">Difficulty</option>
                 <option value="fun">Fun</option>
                 <option value="clearness">Clearness</option>
-              </select>
-            </div>
-
-            {/* Max Difficulty */}
-            <div>
-              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Max Difficulty</label>
-              <select
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                value={filters.maxDifficulty || ''}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, maxDifficulty: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
-              >
-                <option value="">Any</option>
-                <option value="1">Easy</option>
-                <option value="2">Medium</option>
-                <option value="3">Hard</option>
               </select>
             </div>
 

--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -13,6 +13,8 @@ import {
   X,
   Bookmark,
   Trophy,
+  ArrowUp,
+  ArrowDown,
 } from 'lucide-react';
 import { useMemo, useState, ChangeEvent, useEffect } from 'react';
 
@@ -58,6 +60,21 @@ export const PuzzlesList = () => {
   const [filters, setFilters] = useState<PuzzleFilters>({ page: 1, selectedDifficulties: [1, 2, 3] });
   const [creatorSearchInput, setCreatorSearchInput] = useState('');
   const debouncedCreatorSearch = useDebouncedValue(creatorSearchInput, 400);
+
+  const getActiveFilterCount = () => {
+    let count = 0;
+    Object.entries(filters).forEach(([key, value]) => {
+      if (key === 'page' || !value) return;
+      if (key === 'selectedDifficulties') {
+        if (Array.isArray(value) && !(value.length === 3 && value.includes(1) && value.includes(2) && value.includes(3))) {
+          count++;
+        }
+        return;
+      }
+      if (value && value !== 1) count++;
+    });
+    return count;
+  };
 
   useEffect(() => {
     setFilters((prev) => {
@@ -171,9 +188,9 @@ export const PuzzlesList = () => {
           className="gap-2"
         >
           <Filter className="size-4" />
-          Filters {Object.values(filters).filter((v) => v && v !== 1).length > 0 && `(${Object.values(filters).filter((v) => v && v !== 1).length})`}
+          Filters {getActiveFilterCount() > 0 && `(${getActiveFilterCount()})`}
         </Button>
-        {Object.values(filters).filter((v) => v && v !== 1).length > 0 && (
+        {getActiveFilterCount() > 0 && (
           <Button
             variant="ghost"
             size="sm"
@@ -339,15 +356,29 @@ export const PuzzlesList = () => {
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {/* Direction */}
             <div>
-              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Direction</label>
-              <select
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                value={filters.orderDirection || 'ASC'}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, orderDirection: e.target.value as any, page: 1 })}
+              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Direction: </label>
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() => {
+                  const currentDirection = filters.orderDirection || 'ASC';
+                  const newDirection = currentDirection === 'ASC' ? 'DESC' : 'ASC';
+                  setFilters({ ...filters, orderDirection: newDirection as any, page: 1 });
+                }}
+                className="gap-1 px-2 py-1 inline-flex items-center whitespace-nowrap"
               >
-                <option value="ASC">Ascending</option>
-                <option value="DESC">Descending</option>
-              </select>
+                {(filters.orderDirection || 'ASC') === 'ASC' ? (
+                  <>
+                    <ArrowUp className="size-3 inline-block" />
+                    <span> Ascending</span>
+                  </>
+                ) : (
+                  <>
+                    <ArrowDown className="size-3 inline-block" />
+                    <span> Descending</span>
+                  </>
+                )}
+              </Button>
             </div>
 
             {/* Experience Level */}

--- a/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzles-list.tsx
@@ -209,8 +209,8 @@ export const PuzzlesList = () => {
       {/* Filter Panel */}
       {showFilters && (
         <div className="rounded-xl border border-border bg-card p-5 space-y-5">
-          {/* Top Level: name, creator, difficulty, min fun, min clearness */}
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+          {/* Top Level: name, creator, difficulty, and all ratings */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-7">
             {/* Search Name */}
             <div>
               <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Search Name</label>
@@ -282,7 +282,7 @@ export const PuzzlesList = () => {
                 max="5"
                 step="0.5"
                 placeholder="0-5"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                className="w-24 rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 value={filters.minFun || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setFilters({ ...filters, minFun: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
               />
@@ -297,28 +297,10 @@ export const PuzzlesList = () => {
                 max="5"
                 step="0.5"
                 placeholder="0-5"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                className="w-24 rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 value={filters.minClearness || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setFilters({ ...filters, minClearness: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
               />
-            </div>
-          </div>
-
-          {/* Mid Level: order, max fun, max clearness */}
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {/* Order By */}
-            <div>
-              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Order By</label>
-              <select
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                value={filters.orderBy || 'created_at'}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, orderBy: e.target.value as any, page: 1 })}
-              >
-                <option value="created_at">Newest</option>
-                <option value="difficulty">Difficulty</option>
-                <option value="fun">Fun</option>
-                <option value="clearness">Clearness</option>
-              </select>
             </div>
 
             {/* Max Fun */}
@@ -330,7 +312,7 @@ export const PuzzlesList = () => {
                 max="5"
                 step="0.5"
                 placeholder="0-5"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                className="w-24 rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 value={filters.maxFun || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setFilters({ ...filters, maxFun: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
               />
@@ -345,21 +327,36 @@ export const PuzzlesList = () => {
                 max="5"
                 step="0.5"
                 placeholder="0-5"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                className="w-24 rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 value={filters.maxClearness || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setFilters({ ...filters, maxClearness: e.target.value ? parseFloat(e.target.value) : undefined, page: 1 })}
               />
             </div>
           </div>
 
-          {/* Last Level: direction, experienced/inexperienced/all, and medal filter */}
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {/* Bottom Level: order, direction, experience, medal */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {/* Order By */}
+            <div>
+              <label className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Order By</label>
+              <select
+                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                value={filters.orderBy || 'created_at'}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setFilters({ ...filters, orderBy: e.target.value as any, page: 1 })}
+              >
+                <option value="created_at">Newest</option>
+                <option value="difficulty">Difficulty</option>
+                <option value="fun">Fun</option>
+                <option value="clearness">Clearness</option>
+              </select>
+            </div>
+
             {/* Direction */}
             <div>
-              <label className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Direction: </label>
+              <label className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Direction</label>
               <Button
                 variant="outline"
-                size="xs"
+                size="sm"
                 onClick={() => {
                   const currentDirection = filters.orderDirection || 'ASC';
                   const newDirection = currentDirection === 'ASC' ? 'DESC' : 'ASC';


### PR DESCRIPTION
### Description
This PR refines the puzzle filters UI on the home page for better usability and layout consistency.

Changes included:
- Replaced `Min Difficulty` / `Max Difficulty` dropdowns with a single `Difficulty` multi-toggle
- Replaced direction dropdown with a toggle button.
- Reorganized filter layout

### Related Issues
Closes #189

### Checklist
- [x] I am confident this code can be pushed to deployment

### Testing
Manual UI verification on the puzzle home page

### Screenshots
<img width="1951" height="584" alt="image" src="https://github.com/user-attachments/assets/68a002ce-6ecb-4850-b3bd-7633ce5eb0ee" />


### Additional Information
No backend/API contract changes were introduced