### PR TITLE
198 make lowest cost leaderboard work

### DIFF
--- a/src/Backend/PersistantLayer/SolveRepo.py
+++ b/src/Backend/PersistantLayer/SolveRepo.py
@@ -313,18 +313,37 @@ class SolveRepo:
         ).fetchall()
         return {int(r["puzzle_id"]): int(r["solver_count"]) for r in rows}
 
-    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0) -> int:
-        """Convenience: insert a passed attempt with time/xp/medal metadata and return its id."""
+    def get_recent_solve(self, user_id: int, puzzle_id: int, seconds: int = 5):
+        """Get the most recent solve for this user/puzzle if it's within the last N seconds."""
+        from Backend.DomainLayer.Utils import utcnow
+        from datetime import timedelta
+        cutoff = utcnow() - timedelta(seconds=seconds)
+        row = self.conn.execute(
+            """
+            SELECT id, submitted_at, cost_used, time_taken_seconds, xp_earned, highest_medal
+            FROM solve_attempts
+            WHERE user_id = ? AND puzzle_id = ? AND passed = 1 
+                AND submitted_at IS NOT NULL
+                AND submitted_at > ?
+            ORDER BY submitted_at DESC
+            LIMIT 1
+            """,
+            (int(user_id), int(puzzle_id), cutoff.isoformat()),
+        ).fetchone()
+        return row
+
+    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0, cost_used: int = 0) -> int:
+        """Convenience: insert a passed attempt with time/xp/medal/cost metadata and return its id."""
         from Backend.DomainLayer.Utils import utcnow
         now = utcnow()
         cur = self.conn.execute(
             """
             INSERT INTO solve_attempts(puzzle_id, user_id, started_at, submitted_at, passed,
-                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal)
-            VALUES(?,?,?,?,1,?,?,?,?)
+                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal, cost_used)
+            VALUES(?,?,?,?,1,?,?,?,?,?)
             """,
             (int(puzzle_id), int(user_id), now.isoformat(), now.isoformat(),
-             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal)),
+             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal), int(cost_used)),
         )
         return int(cur.lastrowid)
 

--- a/src/Backend/PersistantLayer/SolveRepo.py
+++ b/src/Backend/PersistantLayer/SolveRepo.py
@@ -313,11 +313,17 @@ class SolveRepo:
         ).fetchall()
         return {int(r["puzzle_id"]): int(r["solver_count"]) for r in rows}
 
-    def get_recent_solve(self, user_id: int, puzzle_id: int, seconds: int = 5):
-        """Get the most recent solve for this user/puzzle if it's within the last N seconds."""
+    def get_duplicate_submission(self, user_id: int, puzzle_id: int, solution_json: str, seconds: int = 5):
+        """Get a recent solve with the EXACT same solution (detects network retries).
+        Only returns a match if the solution JSON is identical, not just any recent solve.
+        """
+        import hashlib
         from Backend.DomainLayer.Utils import utcnow
         from datetime import timedelta
-        cutoff = utcnow() - timedelta(seconds=seconds)
+        
+        cutoff = (utcnow() - timedelta(seconds=seconds)).isoformat()
+        solution_hash = hashlib.md5(solution_json.encode()).hexdigest()
+        
         row = self.conn.execute(
             """
             SELECT id, submitted_at, cost_used, time_taken_seconds, xp_earned, highest_medal
@@ -325,25 +331,34 @@ class SolveRepo:
             WHERE user_id = ? AND puzzle_id = ? AND passed = 1 
                 AND submitted_at IS NOT NULL
                 AND submitted_at > ?
+                AND solution_hash = ?
             ORDER BY submitted_at DESC
             LIMIT 1
             """,
-            (int(user_id), int(puzzle_id), cutoff.isoformat()),
+            (int(user_id), int(puzzle_id), cutoff, solution_hash),
         ).fetchone()
+        return dict(row) if row else None
         return row
 
-    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0, cost_used: int = 0) -> int:
+    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0, cost_used: int = 0, solution_json: str = None) -> int:
         """Convenience: insert a passed attempt with time/xp/medal/cost metadata and return its id."""
+        import hashlib
         from Backend.DomainLayer.Utils import utcnow
         now = utcnow()
+        
+        # Compute solution hash if solution is provided
+        solution_hash = None
+        if solution_json:
+            solution_hash = hashlib.md5(solution_json.encode()).hexdigest()
+        
         cur = self.conn.execute(
             """
             INSERT INTO solve_attempts(puzzle_id, user_id, started_at, submitted_at, passed,
-                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal, cost_used)
-            VALUES(?,?,?,?,1,?,?,?,?,?)
+                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal, cost_used, solution_hash)
+            VALUES(?,?,?,?,1,?,?,?,?,?,?)
             """,
             (int(puzzle_id), int(user_id), now.isoformat(), now.isoformat(),
-             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal), int(cost_used)),
+             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal), int(cost_used), solution_hash),
         )
         return int(cur.lastrowid)
 

--- a/src/Backend/PersistantLayer/SolveRepo.py
+++ b/src/Backend/PersistantLayer/SolveRepo.py
@@ -58,6 +58,7 @@ class SolveRepo:
             "time_taken_seconds INTEGER",
             "xp_earned INTEGER DEFAULT 0",
             "highest_medal INTEGER DEFAULT 0",
+            "solution_hash TEXT",
         ]:
             self._add_column_if_missing("solve_attempts", coldef)
 

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -365,18 +365,19 @@ class SolvingService:
             #     same puzzle from both reading stale progress and double-awarding XP.
             with transaction(self.conn):
                 # IDEMPOTENCY CHECK: Prevent duplicate solves from retries
-                # If a solve was just created for this user/puzzle, return it instead
-                recent_solve = self.solve_repo.get_recent_solve(user_id, puzzle_id, seconds=5) if hasattr(self.solve_repo, 'get_recent_solve') else None
-                if recent_solve:
-                    # This is a retry - return the cached result
-                    print(f"[SOLVING_SERVICE] Duplicate solve detected (retry), returning cached result for puzzle_id={puzzle_id}")
-                    medal_name = ["NONE", "BRONZE", "SILVER", "GOLD"][int(recent_solve["highest_medal"])] if recent_solve["highest_medal"] else "NONE"
+                # Only detect exact duplicate submissions (same solution), allow different solutions
+                solution_json = json.dumps(solution_payload)
+                duplicate_solve = self.solve_repo.get_duplicate_submission(user_id, puzzle_id, solution_json, seconds=5) if hasattr(self.solve_repo, 'get_duplicate_submission') else None
+                if duplicate_solve:
+                    # This is a retry with the exact same solution - return the cached result
+                    print(f"[SOLVING_SERVICE] Exact duplicate submission detected (retry), returning cached result for puzzle_id={puzzle_id}")
+                    medal_name = ["NONE", "BRONZE", "SILVER", "GOLD"][int(duplicate_solve["highest_medal"])] if duplicate_solve["highest_medal"] else "NONE"
                     return {
                         "passed": True,
-                        "message": "Puzzle already solved moments ago - returning cached result",
+                        "message": "You just submitted this exact solution - returning cached result",
                         "medal": medal_name,
-                        "medal_value": int(recent_solve["highest_medal"]) if recent_solve["highest_medal"] else 0,
-                        "xp_earned": int(recent_solve["xp_earned"]) if recent_solve["xp_earned"] else 0,
+                        "medal_value": int(duplicate_solve["highest_medal"]) if duplicate_solve["highest_medal"] else 0,
+                        "xp_earned": int(duplicate_solve["xp_earned"]) if duplicate_solve["xp_earned"] else 0,
                         "first_time_solve": False,
                     }
                 
@@ -389,6 +390,7 @@ class SolvingService:
                         xp_earned=raw_xp,
                         medal=medal.value if isinstance(medal, Medal) else int(medal),
                         cost_used=cost_used,
+                        solution_json=solution_json,
                     )
 
                 if hasattr(self.solve_repo, 'upsert_progress'):

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -364,6 +364,22 @@ class SolvingService:
             #     transaction (C2).  This prevents two concurrent solves of the
             #     same puzzle from both reading stale progress and double-awarding XP.
             with transaction(self.conn):
+                # IDEMPOTENCY CHECK: Prevent duplicate solves from retries
+                # If a solve was just created for this user/puzzle, return it instead
+                recent_solve = self.solve_repo.get_recent_solve(user_id, puzzle_id, seconds=5) if hasattr(self.solve_repo, 'get_recent_solve') else None
+                if recent_solve:
+                    # This is a retry - return the cached result
+                    print(f"[SOLVING_SERVICE] Duplicate solve detected (retry), returning cached result for puzzle_id={puzzle_id}")
+                    medal_name = ["NONE", "BRONZE", "SILVER", "GOLD"][int(recent_solve["highest_medal"])] if recent_solve["highest_medal"] else "NONE"
+                    return {
+                        "passed": True,
+                        "message": "Puzzle already solved moments ago - returning cached result",
+                        "medal": medal_name,
+                        "medal_value": int(recent_solve["highest_medal"]) if recent_solve["highest_medal"] else 0,
+                        "xp_earned": int(recent_solve["xp_earned"]) if recent_solve["xp_earned"] else 0,
+                        "first_time_solve": False,
+                    }
+                
                 attempt_id = None
                 if hasattr(self.solve_repo, 'add_solve'):
                     attempt_id = self.solve_repo.add_solve(
@@ -372,6 +388,7 @@ class SolvingService:
                         time_taken_seconds=time_taken_s,
                         xp_earned=raw_xp,
                         medal=medal.value if isinstance(medal, Medal) else int(medal),
+                        cost_used=cost_used,
                     )
 
                 if hasattr(self.solve_repo, 'upsert_progress'):

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -368,18 +368,25 @@ class SolvingService:
                 # Only detect exact duplicate submissions (same solution), allow different solutions
                 solution_json = json.dumps(solution_payload)
                 duplicate_solve = self.solve_repo.get_duplicate_submission(user_id, puzzle_id, solution_json, seconds=5) if hasattr(self.solve_repo, 'get_duplicate_submission') else None
-                if duplicate_solve:
-                    # This is a retry with the exact same solution - return the cached result
-                    print(f"[SOLVING_SERVICE] Exact duplicate submission detected (retry), returning cached result for puzzle_id={puzzle_id}")
-                    medal_name = ["NONE", "BRONZE", "SILVER", "GOLD"][int(duplicate_solve["highest_medal"])] if duplicate_solve["highest_medal"] else "NONE"
-                    return {
-                        "passed": True,
-                        "message": "You just submitted this exact solution - returning cached result",
-                        "medal": medal_name,
-                        "medal_value": int(duplicate_solve["highest_medal"]) if duplicate_solve["highest_medal"] else 0,
-                        "xp_earned": int(duplicate_solve["xp_earned"]) if duplicate_solve["xp_earned"] else 0,
-                        "first_time_solve": False,
-                    }
+                if duplicate_solve and isinstance(duplicate_solve, dict):
+                    # Only treat as a true retry if the time is also very similar (within 1 second)
+                    # Otherwise, allow re-submission to try for better performance
+                    previous_time = duplicate_solve.get("time_taken_seconds", 0)
+                    if previous_time is not None and abs(int(time_taken_s) - int(previous_time)) <= 1:
+                        # This is a true retry with the exact same solution and time - return the cached result
+                        print(f"[SOLVING_SERVICE] Exact duplicate submission detected (retry), returning cached result for puzzle_id={puzzle_id}")
+                        medal_name = ["NONE", "BRONZE", "SILVER", "GOLD"][int(duplicate_solve["highest_medal"])] if duplicate_solve["highest_medal"] else "NONE"
+                        return {
+                            "solved": True,
+                            "message": "You just submitted this exact solution - returning cached result",
+                            "medal": medal_name,
+                            "medal_value": int(duplicate_solve["highest_medal"]) if duplicate_solve["highest_medal"] else 0,
+                            "xp_earned": 0,
+                            "puzzle_total_xp": int(duplicate_solve["xp_earned"]) if duplicate_solve["xp_earned"] else 0,
+                            "xp_left_for_max": 0,
+                            "time_taken": 0,
+                            "first_time_solve": False,
+                        }
                 
                 attempt_id = None
                 if hasattr(self.solve_repo, 'add_solve'):


### PR DESCRIPTION
This pull request introduces an idempotency check to the puzzle solving workflow, ensuring that duplicate submissions with the exact same solution (such as from network retries) do not result in awarding XP or medals multiple times. The main changes involve computing a hash of the submitted solution, detecting recent identical submissions, and returning the cached result instead of creating a new solve attempt. Additional metadata fields have also been added to the solve record.

**Idempotency and Duplicate Submission Detection:**

* Added a new method `get_duplicate_submission` to `SolveRepo.py` that checks for recent identical solve submissions by hashing the solution JSON and returning the most recent matching attempt.
* In `SolvingService.py`, before awarding XP or medals, the service now checks for an exact duplicate submission within the last 5 seconds and returns the cached result if found, preventing duplicate rewards.

**Solve Attempt Metadata Enhancements:**

* The `add_solve` method in `SolveRepo.py` now accepts and stores additional metadata: `cost_used` and a hash of the solution JSON (`solution_hash`).
* When recording a solve attempt, the service now passes `cost_used` and the solution JSON to `add_solve` for completeness and traceability.