### PR TITLE
add DFF support for arsenal pieces with correct sequential debugger output

### DIFF
--- a/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
@@ -37,7 +37,7 @@ const BASIC_COMPONENTS: CircuitComponent[] = [
   { id: 'NAND', type: 'NAND', cost: 1, pins: 3 },
   { id: 'NOR', type: 'NOR', cost: 1, pins: 3 },
   { id: 'XNOR', type: 'XNOR', cost: 1, pins: 3 },
-  // DFF intentionally excluded from arsenal creation
+  { id: 'DFF', type: 'DFF', cost: 1, pins: 2 },
 ];
 
 type SaveState =

--- a/apps/nextjs-app/src/config/tourSteps.ts
+++ b/apps/nextjs-app/src/config/tourSteps.ts
@@ -175,7 +175,7 @@ export const arsenalTourSteps: Step[] = [
   {
     target: '.tour-arsenal-preview',
     content:
-      'Preview the internal logic and truth table of your saved pieces.',
+      'Preview the internal logic of your saved pieces.',
     placement: 'top',
   },
   {

--- a/src/Backend/ServiceLayer/ArsenalService.py
+++ b/src/Backend/ServiceLayer/ArsenalService.py
@@ -119,10 +119,14 @@ class ArsenalService:
         # Now flatten basic gates with arsenal pieces for final storage
         basic_gates = self._flatten_used_arsenal_pieces(basic_gates, used_arsenal_piece_ids, user_id)
 
-        # Get or calculate truth table
-        truth_table = payload.get("truth_table")
-        if truth_table is None or (isinstance(truth_table, dict) and len(truth_table) == 0):
-            truth_table = self._calculate_truth_table(num_inputs, num_outputs, structure)
+        # Get or calculate truth table. Stateful pieces are structure-driven and
+        # should not persist a static truth table.
+        if self._is_stateful_structure(structure):
+            truth_table = {}
+        else:
+            truth_table = payload.get("truth_table")
+            if truth_table is None or (isinstance(truth_table, dict) and len(truth_table) == 0):
+                truth_table = self._calculate_truth_table(num_inputs, num_outputs, structure)
 
         if not isinstance(truth_table, dict):
             raise ValidationError("truth_table must be a dictionary")
@@ -346,6 +350,30 @@ class ArsenalService:
         basic = [g for g in used if g in basic_gate_values]
         return basic
 
+    def _is_stateful_structure(self, structure: dict) -> bool:
+        """Return True when structure includes stateful behavior (e.g. DFF)."""
+        if not isinstance(structure, dict):
+            return False
+
+        state_ports = structure.get("state")
+        if isinstance(state_ports, list) and len(state_ports) > 0:
+            return True
+
+        placed = (
+            structure.get("placedComponents")
+            or structure.get("components")
+            or structure.get("placed")
+            or []
+        )
+        if not isinstance(placed, list):
+            return False
+
+        for comp in placed:
+            if isinstance(comp, dict) and str(comp.get("componentId")) == "DFF":
+                return True
+
+        return False
+
     def _calculate_truth_table(
         self, num_inputs: int, num_outputs: int, structure: dict
     ) -> dict:
@@ -353,6 +381,10 @@ class ArsenalService:
         
         Uses the logic engine to evaluate the circuit for all possible input combinations.
         """
+        # Stateful pieces cannot be represented by a static truth table.
+        if self._is_stateful_structure(structure):
+            return {}
+
         # Check if structure already has truth_table
         if "truth_table" in structure:
             return structure["truth_table"]

--- a/src/Backend/ServiceLayer/ArsenalService.py
+++ b/src/Backend/ServiceLayer/ArsenalService.py
@@ -97,7 +97,7 @@ class ArsenalService:
         if not isinstance(num_outputs, int) or num_outputs < self.MIN_OUTPUTS or num_outputs > self.MAX_OUTPUTS:
             raise ValidationError(f"Number of outputs must be between {self.MIN_OUTPUTS} and {self.MAX_OUTPUTS}. Adjust your circuit accordingly.")
 
-        # Extract and validate gates - no DFF allowed in arsenal pieces
+        # Extract and validate gates used by this arsenal piece
         # Use provided basic_gates if available, otherwise extract from structure
         basic_gates_str = payload.get("basic_gates", "")
         used_arsenal_piece_ids = payload.get("used_arsenal_pieces", [])
@@ -118,9 +118,6 @@ class ArsenalService:
         
         # Now flatten basic gates with arsenal pieces for final storage
         basic_gates = self._flatten_used_arsenal_pieces(basic_gates, used_arsenal_piece_ids, user_id)
-
-        if GateType.DFF.value in basic_gates:
-            raise ValidationError("DFF (Dynamic Flip-Flop) gates are not allowed in custom arsenal pieces. Design your circuit using other available gates.")
 
         # Get or calculate truth table
         truth_table = payload.get("truth_table")
@@ -344,8 +341,8 @@ class ArsenalService:
     def _extract_basic_gates(self, structure_json: str) -> List[str]:
         """Extract basic gates used in the circuit structure"""
         used = self.engine.extract_used_gates(structure_json)
-        # Only keep basic gates (no DFF, no other special gates)
-        basic_gate_values = {g.value for g in GateType if g != GateType.DFF}
+        # Keep only known built-in gate values, including DFF.
+        basic_gate_values = {g.value for g in GateType}
         basic = [g for g in used if g in basic_gate_values]
         return basic
 

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -1021,11 +1021,12 @@ class SolvingService:
                     for k in actual_stream.keys():
                         actual_stream[k].append(step_result.get(k, 0))
                     
-                    # 4. Update the state for the NEXT cycle (Injecting the 'D' logic)
-                    # We take the values that were at the DFF inputs and save them
-                    for did in dff_ids:
-                        next_val = step_result.get(f"{did}_next")
-                        current_state[str(did)] = next_val if next_val is not None else 0
+                    # 4. Update state for the NEXT cycle.
+                    # This includes top-level DFFs and namespaced macro-internal DFF state keys.
+                    for out_key, out_val in step_result.items():
+                        if isinstance(out_key, str) and out_key.endswith("_next"):
+                            state_key = out_key[:-5]
+                            current_state[state_key] = int(out_val) if out_val is not None else 0
 
                 # 5. Final check of the output stream
                 if actual_stream != expected_stream:
@@ -1057,13 +1058,17 @@ class SolvingService:
                     try:
                         print(f"[VALIDATION] Test case {i}: inputs={inputs}, expected={expected}")
                         out = self.logic_engine.evaluate(circuit, inputs)
-                        print(f"[VALIDATION] Test case {i}: actual output={out}")
-                        if out != expected:
-                            print(f"[VALIDATION] MISMATCH! Expected {expected} but got {out}")
+                        visible_out = {
+                            k: v for k, v in out.items()
+                            if not str(k).endswith("_next")
+                        }
+                        print(f"[VALIDATION] Test case {i}: actual output={visible_out}")
+                        if visible_out != expected:
+                            print(f"[VALIDATION] MISMATCH! Expected {expected} but got {visible_out}")
                             return False, "Wrong output", [{
                                 "inputs": inputs,
                                 "expected": expected,
-                                "actual": out
+                                "actual": visible_out
                             }]
                         else:
                             print(f"[VALIDATION] Test case {i}: PASS")
@@ -1377,14 +1382,20 @@ class SolvingService:
                             
                             print(f"[ARSENAL EXPAND]     -> Truth table keys: {list(truth_table.keys())[:3]}...")  # Show first 3 keys
                             
-                            # Store the truth table and input/output info
-                            expanded["_arsenal_pieces"][placed_id] = {
+                            piece_info = {
                                 "id": piece_id,
                                 "name": arsenal_piece.name,
                                 "num_inputs": num_inputs_val,
                                 "num_outputs": num_outputs_val,
                                 "truth_table": truth_table,
+                                "structure": self._load_structure_dict(getattr(arsenal_piece, "structure_json", "")),
                             }
+
+                            # Register piece under multiple keys so both top-level
+                            # and nested macro simulation can resolve it.
+                            expanded["_arsenal_pieces"][placed_id] = piece_info
+                            expanded["_arsenal_pieces"][str(piece_id)] = piece_info
+                            expanded["_arsenal_pieces"][arsenal_piece.name] = piece_info
                             print(f"[ARSENAL EXPAND]     -> Stored arsenal piece {arsenal_piece.name}")
                         else:
                             print(f"[ARSENAL EXPAND]     -> Not a custom piece (no truth_table or inputs/outputs)")
@@ -1444,13 +1455,11 @@ class SolvingService:
         
         seq_length = lengths[0]
 
-        # Preserve DFF state between cycles for sequential behavior.
-        dff_ids = [
-            pc.get("id")
-            for pc in expanded_solution.get("placedComponents", [])
-            if pc.get("componentId") == "DFF" and pc.get("id")
-        ]
-        dff_state = {str(dff_id): 0 for dff_id in dff_ids}
+        # Preserve state between cycles for top-level and macro-internal DFFs.
+        dff_state: Dict[str, int] = {}
+        for pc in expanded_solution.get("placedComponents", []):
+            if pc.get("componentId") == "DFF" and pc.get("id"):
+                dff_state[str(pc.get("id"))] = 0
         
         # Simulate each step
         all_steps = []
@@ -1469,11 +1478,11 @@ class SolvingService:
 
             raw_outputs = result.get("puzzleOutputs", {}) or {}
 
-            # Advance DFF state from this cycle's computed next-state outputs.
-            for dff_id in dff_ids:
-                next_key = f"{dff_id}_next"
-                next_val = raw_outputs.get(next_key)
-                dff_state[str(dff_id)] = int(next_val) if next_val is not None else 0
+            # Advance all state outputs (top-level + macro-internal namespaced).
+            for out_key, out_val in raw_outputs.items():
+                if isinstance(out_key, str) and out_key.endswith("_next"):
+                    state_key = out_key[:-5]
+                    dff_state[state_key] = int(out_val) if out_val is not None else 0
 
             # Hide internal next-state wires from puzzle output display.
             result["puzzleOutputs"] = {
@@ -1512,7 +1521,11 @@ class SolvingService:
                         "truth_table": piece.truth_table if piece.truth_table else "{}",
                         "num_inputs": piece.num_inputs or 0,
                         "num_outputs": piece.num_outputs or 0,
+                        "structure": self._load_structure_dict(getattr(piece, "structure_json", "")),
+                        "id": piece.id,
+                        "name": piece_name,
                     }
+                    arsenal_pieces[str(piece.id)] = arsenal_pieces[piece_name]
                     print(f"[SOLVING_SERVICE]   Added to arsenal_pieces: {arsenal_pieces[piece_name]}")
             except Exception as e:
                 # If we can't fetch custom pieces, just continue with what we have

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -1630,7 +1630,6 @@ class SolvingService:
                 arsenal_info = arsenal_pieces[comp_id]
                 num_inputs = arsenal_info.get("num_inputs", 0)
                 num_outputs = arsenal_info.get("num_outputs", 0)
-                truth_table = arsenal_info.get("truth_table", {})
                 
                 print(f"[DEBUGGER] Evaluating arsenal piece {comp_id}: {num_inputs} inputs, {num_outputs} outputs")
                 
@@ -1652,6 +1651,32 @@ class SolvingService:
                 gate_inputs = [v if v is not None else 0 for v in gate_inputs]
                 
                 print(f"[DEBUGGER]   Inputs: {gate_inputs}")
+                
+                # First, try macro evaluation using the internal structure
+                structure = arsenal_info.get("structure")
+                if structure:
+                    try:
+                        print(f"[DEBUGGER]   Using macro evaluation for arsenal piece with structure")
+                        # Build inputs dict for macro piece (in0, in1, ...)
+                        macro_inputs = {f"in{i}": int(gate_inputs[i]) for i in range(num_inputs)}
+                        
+                        # Call logic engine simulate on the internal structure
+                        macro_outputs = self.logic_engine.simulate(structure, macro_inputs, arsenal_pieces)
+                        
+                        # Extract output values
+                        output_vals = []
+                        for i in range(num_outputs):
+                            out_val = macro_outputs.get(f"out{i}", 0)
+                            output_vals.append(str(int(out_val)))
+                        
+                        print(f"[DEBUGGER]   Macro evaluation outputs: {output_vals}")
+                        gate_result_cache[comp_id] = output_vals
+                        return output_vals
+                    except Exception as e:
+                        print(f"[DEBUGGER]   Macro evaluation failed: {str(e)}, falling back to truth table")
+                
+                # Fallback to truth table lookup
+                truth_table = arsenal_info.get("truth_table", {})
                 
                 # Try different key formats for the truth table lookup
                 try:

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -1390,6 +1390,9 @@ class SolvingService:
                                 "truth_table": truth_table,
                                 "structure": self._load_structure_dict(getattr(arsenal_piece, "structure_json", "")),
                             }
+                            
+                            loaded_structure = piece_info["structure"]
+                            print(f"[ARSENAL EXPAND]     -> Structure loaded: type={type(loaded_structure).__name__}, keys={list(loaded_structure.keys()) if isinstance(loaded_structure, dict) else 'N/A'}")
 
                             # Register piece under multiple keys so both top-level
                             # and nested macro simulation can resolve it.
@@ -1630,6 +1633,7 @@ class SolvingService:
                 arsenal_info = arsenal_pieces[comp_id]
                 num_inputs = arsenal_info.get("num_inputs", 0)
                 num_outputs = arsenal_info.get("num_outputs", 0)
+                truth_table = arsenal_info.get("truth_table", {})
                 
                 print(f"[DEBUGGER] Evaluating arsenal piece {comp_id}: {num_inputs} inputs, {num_outputs} outputs")
                 
@@ -1652,31 +1656,50 @@ class SolvingService:
                 
                 print(f"[DEBUGGER]   Inputs: {gate_inputs}")
                 
-                # First, try macro evaluation using the internal structure
+                # First try macro evaluation if available
                 structure = arsenal_info.get("structure")
-                if structure:
+                if structure and isinstance(structure, dict):
                     try:
-                        print(f"[DEBUGGER]   Using macro evaluation for arsenal piece with structure")
-                        # Build inputs dict for macro piece (in0, in1, ...)
+                        print(f"[DEBUGGER]   Trying macro evaluation for arsenal piece")
+                        # Build inputs for macro
                         macro_inputs = {f"in{i}": int(gate_inputs[i]) for i in range(num_inputs)}
                         
-                        # Call logic engine simulate on the internal structure
-                        macro_outputs = self.logic_engine.simulate(structure, macro_inputs, arsenal_pieces)
+                        # Add any internal state from parent inputs (de-namespace)
+                        for input_key, input_val in inputs.items():
+                            if isinstance(input_key, str) and input_key.startswith(f"{comp_id}::"):
+                                internal_key = input_key[len(f"{comp_id}::"):]
+                                macro_inputs[internal_key] = input_val
                         
-                        # Extract output values
+                        # Normalize structure shape before evaluation. Stored arsenal
+                        # pieces may use 'placed' while the engine expects
+                        # 'placedComponents'/'components'.
+                        normalized_structure = {
+                            "placedComponents": (
+                                structure.get("placedComponents")
+                                or structure.get("components")
+                                or structure.get("placed")
+                                or []
+                            ),
+                            "wires": structure.get("wires", []),
+                        }
+                        # Preserve embedded arsenal registry when present.
+                        if isinstance(structure.get("_arsenal_pieces"), dict):
+                            normalized_structure["_arsenal_pieces"] = structure.get("_arsenal_pieces")
+
+                        # Evaluate the macro
+                        macro_outputs = self.logic_engine.simulate(normalized_structure, macro_inputs, arsenal_pieces)
+                        
+                        # Extract output values for this component
                         output_vals = []
                         for i in range(num_outputs):
                             out_val = macro_outputs.get(f"out{i}", 0)
                             output_vals.append(str(int(out_val)))
                         
-                        print(f"[DEBUGGER]   Macro evaluation outputs: {output_vals}")
+                        print(f"[DEBUGGER]   Macro outputs: {output_vals}")
                         gate_result_cache[comp_id] = output_vals
                         return output_vals
                     except Exception as e:
                         print(f"[DEBUGGER]   Macro evaluation failed: {str(e)}, falling back to truth table")
-                
-                # Fallback to truth table lookup
-                truth_table = arsenal_info.get("truth_table", {})
                 
                 # Try different key formats for the truth table lookup
                 try:

--- a/src/Backend/ServiceLayer/logicEngineService.py
+++ b/src/Backend/ServiceLayer/logicEngineService.py
@@ -72,15 +72,33 @@ class logicEngineService:
         raise ValidationError("logic engine format not supported")
 
     # ---------- Simulation Logic ----------
-    def simulate(self, data: Dict[str, Any], inputs: Dict[str, int], arsenal_pieces: Dict[str, Any] = None) -> Dict[str, int]:
+    def simulate(
+        self,
+        data: Dict[str, Any],
+        inputs: Dict[str, int],
+        arsenal_pieces: Dict[str, Any] = None,
+        active_macro_stack: Set[str] | None = None,
+    ) -> Dict[str, int]:
         """
         Simulates combinatorial circuit.
         data: parsed JSON containing 'placedComponents' and 'wires'.
         inputs: dict {"A": 0, "B": 1...}
         arsenal_pieces: dict mapping placed component ID -> arsenal piece metadata
         """
+        if active_macro_stack is None:
+            active_macro_stack = set()
+
         if arsenal_pieces is None:
             arsenal_pieces = {}
+
+        # Merge registry embedded in data with explicit call-time registry.
+        # Explicit values win so callers can override when needed.
+        registry_from_data = data.get("_arsenal_pieces", {}) if isinstance(data, dict) else {}
+        merged_arsenal_pieces = {}
+        if isinstance(registry_from_data, dict):
+            merged_arsenal_pieces.update(registry_from_data)
+        if isinstance(arsenal_pieces, dict):
+            merged_arsenal_pieces.update(arsenal_pieces)
         # 1. Build Graph
         # Nodes are (componentId, portId) -> value (0/1/None)
         # But wires connect (componentId, pinIndex)??
@@ -180,6 +198,8 @@ class logicEngineService:
                     root = find(pk)
                     net_values[root] = val
                 
+        macro_next_state_updates: Dict[str, int] = {}
+
         # Iteration
         for _ in range(MAX_ITER):
             changed = False
@@ -224,20 +244,44 @@ class logicEngineService:
                     
                     v0 = net_values.get(p0)
                     inputs_vals = [v0]
-                elif cid in arsenal_pieces or ctype in arsenal_pieces:
+                elif cid in merged_arsenal_pieces or ctype in merged_arsenal_pieces:
                     # Check if this is an arsenal/custom piece (by ID or by type/name)
-                    arsenal_info = arsenal_pieces.get(cid) or arsenal_pieces.get(ctype)
+                    arsenal_info = merged_arsenal_pieces.get(cid) or merged_arsenal_pieces.get(ctype)
                     if arsenal_info:
-                        print(f"[CUSTOM_PIECE_DEBUG] Found custom piece: cid={cid}, ctype={ctype}")
+                        macro_outputs = self._evaluate_macro_piece(
+                            cid=cid,
+                            ctype=ctype,
+                            arsenal_info=arsenal_info,
+                            parent=parent,
+                            find=find,
+                            net_values=net_values,
+                            inputs=inputs,
+                            registry=merged_arsenal_pieces,
+                            active_macro_stack=active_macro_stack,
+                        )
+
+                        if macro_outputs is not None:
+                            macro_values = macro_outputs.get("outputs", [])
+                            macro_next_state_updates.update(macro_outputs.get("next_state", {}))
+                            num_inputs = int(arsenal_info.get("num_inputs", 0) or 0)
+                            num_outputs = int(arsenal_info.get("num_outputs", 0) or 0)
+                            for out_idx in range(num_outputs):
+                                if out_idx >= len(macro_values):
+                                    break
+                                pk_out = f"{cid}#{num_inputs + out_idx}"
+                                if pk_out in parent:
+                                    root = find(pk_out)
+                                    new_out = int(macro_values[out_idx])
+                                    if net_values.get(root) != new_out:
+                                        net_values[root] = new_out
+                                        changed = True
+                            continue
+
                         try:
                             truth_table_str = arsenal_info.get("truth_table", "{}")
                             num_inputs = arsenal_info.get("num_inputs", 0)
                             num_outputs = arsenal_info.get("num_outputs", 0)
-                            print(f"[CUSTOM_PIECE_DEBUG] num_inputs={num_inputs}, num_outputs={num_outputs}")
-                            print(f"[CUSTOM_PIECE_DEBUG] truth_table_str type={type(truth_table_str)}, value={truth_table_str}")
-                            
                             truth_table = json.loads(truth_table_str) if isinstance(truth_table_str, str) else truth_table_str
-                            print(f"[CUSTOM_PIECE_DEBUG] truth_table keys={list(truth_table.keys()) if isinstance(truth_table, dict) else 'NOT_A_DICT'}")
                             
                             # Build input key for the truth table
                             # Truth table keys are binary strings like "00", "01", "10", "11"
@@ -245,22 +289,16 @@ class logicEngineService:
                             for i in range(num_inputs):
                                 pk = find(f"{cid}#{i}") if f"{cid}#{i}" in parent else None
                                 val = net_values.get(pk)
-                                print(f"[CUSTOM_PIECE_DEBUG] Input {i}: pk={pk}, val={val}")
                                 if val is None:
                                     break
                                 input_bits.append(str(int(val)))
                             
-                            print(f"[CUSTOM_PIECE_DEBUG] Collected input_bits={input_bits}, len={len(input_bits)}")
-                            
                             if len(input_bits) == num_inputs:
                                 # Look up in truth table using binary string key
                                 key = "".join(input_bits)  # e.g. "0011" for inputs 0,0,1,1
-                                print(f"[CUSTOM_PIECE_DEBUG] Looking up key={key} in truth_table")
                                 
                                 if key in truth_table:
-                                    print(f"[CUSTOM_PIECE_DEBUG] Key found in truth_table!")
                                     outputs = truth_table[key]
-                                    print(f"[CUSTOM_PIECE_DEBUG] outputs={outputs}, type={type(outputs)}")
                                     # Set all output pins based on the truth table
                                     if isinstance(outputs, dict):
                                         for out_idx in range(num_outputs):
@@ -268,7 +306,6 @@ class logicEngineService:
                                             if out_key in outputs:
                                                 new_out = outputs[out_key]
                                                 pk_out = f"{cid}#{num_inputs + out_idx}"
-                                                print(f"[CUSTOM_PIECE_DEBUG] Setting output {out_idx}: pk_out={pk_out}, new_out={new_out}")
                                                 if pk_out in parent:
                                                     root = find(pk_out)
                                                     if net_values.get(root) != new_out:
@@ -278,14 +315,11 @@ class logicEngineService:
                                         # Single output case (outputs is just a number)
                                         new_out = int(outputs)
                                         pk_out = f"{cid}#{num_inputs}"
-                                        print(f"[CUSTOM_PIECE_DEBUG] Setting single output: pk_out={pk_out}, new_out={new_out}")
                                         if pk_out in parent:
                                             root = find(pk_out)
                                             if net_values.get(root) != new_out:
                                                 net_values[root] = new_out
                                                 changed = True
-                                else:
-                                    print(f"[CUSTOM_PIECE_DEBUG] Key NOT found in truth_table. Keys available: {list(truth_table.keys())}")
                         except Exception as e:
                             # If truth table evaluation fails, skip this component
                             pass
@@ -354,8 +388,105 @@ class logicEngineService:
                         d_val = v
                 
                 results[f"{cid}_next"] = d_val
+
+        for state_key, next_value in macro_next_state_updates.items():
+            results[f"{state_key}_next"] = int(next_value)
                      
         return results
+
+    def _normalize_macro_structure(self, structure: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = dict(structure)
+        if "placedComponents" not in normalized and isinstance(normalized.get("placed"), list):
+            normalized["placedComponents"] = normalized.get("placed", [])
+        if "components" not in normalized and isinstance(normalized.get("placedComponents"), list):
+            normalized["components"] = normalized["placedComponents"]
+        if "wires" not in normalized or not isinstance(normalized.get("wires"), list):
+            normalized["wires"] = []
+        return normalized
+
+    def _evaluate_macro_piece(
+        self,
+        cid: str,
+        ctype: str,
+        arsenal_info: Dict[str, Any],
+        parent: Dict[str, str],
+        find,
+        net_values: Dict[str, int],
+        inputs: Dict[str, int],
+        registry: Dict[str, Any],
+        active_macro_stack: Set[str],
+    ) -> Dict[str, Any] | None:
+        num_inputs = int(arsenal_info.get("num_inputs", 0) or 0)
+        num_outputs = int(arsenal_info.get("num_outputs", 0) or 0)
+        if num_inputs <= 0 or num_outputs <= 0:
+            return None
+
+        structure = arsenal_info.get("structure") or arsenal_info.get("solution")
+        if isinstance(structure, str):
+            try:
+                structure = json.loads(structure)
+            except Exception:
+                return None
+        if not isinstance(structure, dict):
+            return None
+
+        macro_inputs: Dict[str, int] = {}
+        for i in range(num_inputs):
+            pin_key = f"{cid}#{i}"
+            if pin_key not in parent:
+                return None
+            root = find(pin_key)
+            value = net_values.get(root)
+            if value is None:
+                return None
+            macro_inputs[f"in{i}"] = int(value)
+
+        # Pass persisted nested state to this macro instance.
+        macro_state_prefix = f"{cid}::"
+        for input_key, input_val in inputs.items():
+            if isinstance(input_key, str) and input_key.startswith(macro_state_prefix):
+                nested_key = input_key[len(macro_state_prefix):]
+                try:
+                    macro_inputs[nested_key] = int(input_val)
+                except (TypeError, ValueError):
+                    continue
+
+        macro_key = str(arsenal_info.get("id") or arsenal_info.get("name") or ctype or cid)
+        if macro_key in active_macro_stack:
+            return None
+
+        macro_data = self._normalize_macro_structure(structure)
+        nested_registry = macro_data.get("_arsenal_pieces", {}) if isinstance(macro_data.get("_arsenal_pieces"), dict) else {}
+        combined_registry = dict(registry)
+        combined_registry.update(nested_registry)
+        macro_data["_arsenal_pieces"] = combined_registry
+
+        try:
+            macro_outputs = self.simulate(
+                macro_data,
+                macro_inputs,
+                combined_registry,
+                active_macro_stack=active_macro_stack | {macro_key},
+            )
+        except Exception:
+            return None
+
+        outputs = [int(macro_outputs.get(f"out{i}", 0)) for i in range(num_outputs)]
+
+        next_state: Dict[str, int] = {}
+        for output_key, output_value in macro_outputs.items():
+            if not isinstance(output_key, str) or not output_key.endswith("_next"):
+                continue
+            nested_state_key = output_key[:-5]
+            try:
+                next_state[f"{cid}::{nested_state_key}"] = int(output_value)
+            except (TypeError, ValueError):
+                next_state[f"{cid}::{nested_state_key}"] = 0
+
+        return {
+            "outputs": outputs,
+            "next_state": next_state,
+        }
 
     def _compute_gate(self, gtype: str, inputs: list) -> int | None:
         # None if any input is None (unknown/floating)

--- a/src/Backend/ServiceLayer/logicEngineService.py
+++ b/src/Backend/ServiceLayer/logicEngineService.py
@@ -174,16 +174,34 @@ class logicEngineService:
         # Limit iterations to avoid infinite loops (oscillations)
         MAX_ITER = 50 
         
+        # Build set of DFF component IDs (for state handling)
+        dff_ids = set()
+        for p in placed:
+            if p.get("componentId") == "DFF":
+                dff_ids.add(p["id"])
+        
         # Pre-set Inputs
         # Inputs are typically represented as components like "IO:IN:A"
         # Or wires connected to them.
+        # Also handle arsenal pieces which may use direct "in0", "in1" naming
+        # NOTE: Skip keys that match DFF IDs (those are state, not inputs)
         for input_name, val in inputs.items():
-            # In PuzzleWorkstation, inputs are "IO:IN:A". Port 0 usually.
+            # Skip DFF state keys (those are handled separately below)
+            if input_name in dff_ids:
+                continue
+                
+            # Try standard "IO:IN:X" format first (PuzzleWorkstation)
             comp_id = f"IO:IN:{input_name}"
             pk = f"{comp_id}#0"
             if pk in parent:
                 root = find(pk)
                 net_values[root] = val
+            else:
+                # Try direct component ID (arsenal pieces)
+                pk2 = f"{input_name}#0"
+                if pk2 in parent:
+                    root = find(pk2)
+                    net_values[root] = val
 
         # Pre-set State (DFF Outputs)
         for p in placed:
@@ -349,29 +367,29 @@ class logicEngineService:
                 break
                 
         # 3. Read Outputs
-        # Outputs are components "IO:OUT:S". Port 0.
+        # Outputs are components "IO:OUT:S". Port 0 for standard circuits.
+        # Arsenal pieces use direct "out0", "out1" naming.
         results = {}
-        # We need to know expected output names. 
-        # But we only return mapped outputs.
-        # Find all keys in parent that start with IO:OUT
-        
-        # We scan all pins or just construct from known outputs if we had them.
-        # We can scan the parent keys.
-        
-        # Or better: The test case inputs has keys, expected outputs has keys.
-        # We should try to read all "IO:OUT:*" signals.
         
         possible_roots = set(parent.keys())
         for pk in possible_roots:
+            # Handle standard "IO:OUT:Name" format
             if pk.startswith("IO:OUT:"):
-                # format: IO:OUT:Name#0
                 parts = pk.split("#")[0].split(":")
                 if len(parts) == 3:
                      name = parts[2]
                      root = find(pk)
-                     val = net_values.get(root, 0) # Default to 0 if floating?
-                     # Floating outputs usually 0 or X. Let's say 0 for safety.
+                     val = net_values.get(root, 0)
                      results[name] = val if val is not None else 0
+            # Handle direct "outN" format (arsenal pieces)
+            elif pk.startswith("IO:OUT") == False and "#" in pk:
+                comp_name, pin_idx = pk.split("#")
+                pin_idx = int(pin_idx)
+                # Collect outputs that look like "outX"
+                if comp_name.startswith("out"):
+                    root = find(pk)
+                    val = net_values.get(root, 0)
+                    results[comp_name] = val if val is not None else 0
 
         # 4. Capture Next State (DFF Inputs)
         for p in placed:

--- a/src/tests/ServiceLayerTests/test_arsenal_service.py
+++ b/src/tests/ServiceLayerTests/test_arsenal_service.py
@@ -791,17 +791,32 @@ class TestArsenalServiceSaveAdvanced:
         self.mock_engine.extract_used_gates.return_value = ["AND", "DFF"]
         
         payload = {
-            "name": "bad_piece",
+            "name": "dff_piece",
             "num_inputs": 1,
             "num_outputs": 1,
             "structure_json": "{}",
             "basic_gates": '["AND", "DFF"]',
+            "truth_table": {"0": {"out0": 0}, "1": {"out0": 1}},
         }
-        
-        with pytest.raises(ValidationError) as exc_info:
-            self.service.save_arsenal_piece(token, payload)
-        
-        assert "DFF" in str(exc_info.value)
+
+        saved_circuit = Circuit(
+            id=321,
+            user_id=user_id,
+            name="dff_piece",
+            cost=2,
+            structure_json="{}",
+            is_arsenal=True,
+            basic_gates='["AND", "DFF"]',
+            truth_table='{"0": {"out0": 0}, "1": {"out0": 1}}',
+            num_inputs=1,
+            num_outputs=1,
+        )
+        self.mock_circuit_repo.create.return_value = saved_circuit
+
+        result = self.service.save_arsenal_piece(token, payload)
+
+        assert result["id"] == 321
+        assert "DFF" in result["basic_gates"]
 
     def test_save_arsenal_piece_invalid_structure_json(self):
         user_id = 1

--- a/src/tests/ServiceLayerTests/test_logic_engine_simulation.py
+++ b/src/tests/ServiceLayerTests/test_logic_engine_simulation.py
@@ -71,6 +71,56 @@ class TestLogicEngineSimulation:
         assert result["Out"] == 1
         assert result["dff1_next"] == 0
 
+    def test_simulate_macro_with_internal_dff_state(self):
+        macro_structure = {
+            "placedComponents": [
+                {"id": "IO:IN:in0", "componentId": "IO:IN:in0"},
+                {"id": "dff1", "componentId": "DFF"},
+                {"id": "IO:OUT:out0", "componentId": "IO:OUT:out0"},
+            ],
+            "wires": [
+                {"from": {"componentId": "IO:IN:in0", "pinIndex": 0}, "to": {"componentId": "dff1", "pinIndex": 0}},
+                {"from": {"componentId": "dff1", "pinIndex": 1}, "to": {"componentId": "IO:OUT:out0", "pinIndex": 0}},
+            ],
+        }
+
+        structure = {
+            "placedComponents": [
+                {"id": "IO:IN:In", "componentId": "IO:IN:In"},
+                {"id": "m1", "componentId": "MacroDff"},
+                {"id": "IO:OUT:Out", "componentId": "IO:OUT:Out"},
+            ],
+            "wires": [
+                {"from": {"componentId": "IO:IN:In", "pinIndex": 0}, "to": {"componentId": "m1", "pinIndex": 0}},
+                {"from": {"componentId": "m1", "pinIndex": 1}, "to": {"componentId": "IO:OUT:Out", "pinIndex": 0}},
+            ],
+            "_arsenal_pieces": {
+                "m1": {
+                    "id": 101,
+                    "name": "MacroDff",
+                    "num_inputs": 1,
+                    "num_outputs": 1,
+                    "structure": macro_structure,
+                },
+                "MacroDff": {
+                    "id": 101,
+                    "name": "MacroDff",
+                    "num_inputs": 1,
+                    "num_outputs": 1,
+                    "structure": macro_structure,
+                },
+            },
+        }
+        circuit = Circuit(id=1, user_id=1, name="MacroDffTest", structure_json=json.dumps(structure), cost=0)
+
+        first = self.service.evaluate(circuit, {"In": 1})
+        assert first["Out"] == 0
+        assert first["m1::dff1_next"] == 1
+
+        second = self.service.evaluate(circuit, {"In": 0, "m1::dff1": 1})
+        assert second["Out"] == 1
+        assert second["m1::dff1_next"] == 0
+
     def test_simulate_disconnected_components(self):
         structure = {
             "placedComponents": [


### PR DESCRIPTION

### Description
Support for DFF-based arsenal components in sequence simulation and debugger display.

## Problem
- Arsenal pieces containing DFF are stateful and cannot be represented by a static truth table.
- Debugger macro evaluation path could receive structure in a shape that was not normalized for engine simulation.
- In practice this caused incorrect per-step debugger values even when final puzzle outputs were correct.

### Related Issues
Closes #203 

## What Changed
1. **Debugger macro evaluation normalization**
   - Normalize arsenal structure before macro simulation so stored formats are handled consistently.
   - Ensure macro evaluation uses circuit structure (not just truth-table fallback) for stateful pieces.

2. **Stateful arsenal truth-table policy**
   - Added detection for stateful structures (DFF/state ports).
   - Disabled static truth-table generation for stateful arsenal pieces.
   - Stateful pieces are now treated as structure-driven at runtime, preventing misleading persisted truth tables.

3. **Regression safety**
   - Kept existing sequence-state propagation behavior intact.
   - Preserved non-stateful arsenal behavior (truth tables still valid for combinational pieces).


### Tests
Passed both automated and manual tests for both validation and debugger visualization

## Notes
- Existing older stateful arsenal records may still contain stale static truth tables from before this fix. Runtime behavior is now structure-driven for stateful pieces, but optional data cleanup/migration can be done separately.

## Checklist
- [x] DFF in arsenal evaluated correctly across cycles
- [x] Debugger output matches actual simulation output
- [x] No regressions in solving/arsenal service tests
- [x] Stateful arsenal pieces no longer rely on static truth-table synthesis