### PR TITLE
Puzzle solution mid-solving save via scoped TTL localStorage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# EscapeCircuit — Agent Instructions
+
+Logic-circuit puzzle web app. Monorepo: Next.js frontend + FastAPI backend.
+
+## Stack
+- **Frontend:** Next.js 14 (App Router), TypeScript, Tailwind, Zustand, React Query, Radix UI, next-themes. Runtime: Node 20+, Yarn 1.22+.
+- **Backend:** FastAPI + Uvicorn, Pydantic, SQLite (WAL mode), JWT auth, Google OAuth. Runtime: Python 3.10+.
+- **Tests:** Vitest (frontend unit), Playwright (e2e), Pytest (backend). Storybook for component dev.
+
+## Layout
+- `apps/nextjs-app/` — frontend. See [apps/nextjs-app/README.md](apps/nextjs-app/README.md).
+- `src/Backend/` — layered FastAPI app: `APILayer/` (controllers) · `ServiceLayer/` · `DomainLayer/` (models) · `PersistantLayer/` (SQLite queries). Entry: `main.py`.
+- `riddles/` — puzzle definitions (`*_config.json`, `*_instructions.tex`, `*_sample_solution.json`).
+- `src/tests/` — backend tests.
+- `escape_circuit.db` — dev SQLite at repo root, WAL mode.
+- Seed scripts: `src/init_db.py`, `src/insert_riddles.py`, `src/seed_admin.py`.
+
+## Commands
+- **Dev (both servers):** `python init_env.py` from repo root (API :8080 + Next :3000).
+- **Backend only:** `python -m uvicorn Backend.main:app --reload --host 127.0.0.1 --port 8080` from `src/`.
+- **Frontend only:** `yarn dev` in `apps/nextjs-app/`.
+- **Tests:** `pytest` at root; `yarn test` in `apps/nextjs-app/`.
+- **Typecheck / lint / build:** `yarn check-types` / `yarn lint` / `yarn build` in `apps/nextjs-app/`.
+- **DB reset:** `python src/reinit_db.py` (or the three seed scripts in order).
+
+## Conventions
+- **Before commit/push:** run `yarn check-types`, `yarn lint`, `yarn test`, `yarn build` in `apps/nextjs-app/`, and `pytest` at root. If touching env loading or shell scripts, reason through `deploy.sh` and `run_server.sh` — they use `set -euo pipefail`, so an unbound var will break deploy.
+- **SQLite is WAL mode.** Never delete `*.db-wal` / `*.db-shm`. Don't `kill -9` uvicorn — use SIGTERM so WAL checkpoints cleanly. See the header comment in [deploy.sh](deploy.sh) for rollback and WAL rationale.
+- **Secrets:** only in `apps/nextjs-app/.env` (gitignored). `NEXT_PUBLIC_GOOGLE_CLIENT_ID` lives there; `init_env.py` propagates it to the backend. Don't commit `.env`.
+- **Dev admin:** `admin` / `password123`. Dev-only.
+- **Branch naming:** `<issue-number>-<kebab-slug>` (e.g. `231-puzzle-solution-mid-solving-saving`).
+- **Backend layering:** controllers call services, services call domain + persistent. Don't shortcut APILayer → PersistantLayer.
+
+## Don't
+- Don't commit `escape_circuit.db*`, `node_modules/`, or `.env`.
+- Don't add a new start script at repo root — extend `init_env.py`, `run_server.sh`, or `run_server.bat`.
+- Don't introduce a second state or data-fetching library — use Zustand + React Query.
+- Don't restructure `src/Backend/` layers without saying so explicitly.
+
+## References
+- Setup: [HOWTORUN.md](HOWTORUN.md), [docs/SETUP.md](docs/SETUP.md)
+- Features: [docs/FEATURES.md](docs/FEATURES.md)
+- Backend class diagram: [backend_class_diagram.mmd](backend_class_diagram.mmd)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,14 @@
 # EscapeCircuit — Agent Instructions
 
-Logic-circuit puzzle web app. Monorepo: Next.js frontend + FastAPI backend.
+## Project Overview
+Logic-circuit puzzle web app — students wire logic gates to solve riddles (binary adder, palindrome detector, counters, etc.). Academic project: advisor Niv Gilboa; clients Gera Weiss + Oded Margalit. Monorepo: Next.js frontend + FastAPI backend.
 
-## Stack
+## Tech Stack & Versions
 - **Frontend:** Next.js 14 (App Router), TypeScript, Tailwind, Zustand, React Query, Radix UI, next-themes. Runtime: Node 20+, Yarn 1.22+.
 - **Backend:** FastAPI + Uvicorn, Pydantic, SQLite (WAL mode), JWT auth, Google OAuth. Runtime: Python 3.10+.
 - **Tests:** Vitest (frontend unit), Playwright (e2e), Pytest (backend). Storybook for component dev.
 
-## Layout
+## Architecture & Folder Map
 - `apps/nextjs-app/` — frontend. See [apps/nextjs-app/README.md](apps/nextjs-app/README.md).
 - `src/Backend/` — layered FastAPI app: `APILayer/` (controllers) · `ServiceLayer/` · `DomainLayer/` (models) · `PersistantLayer/` (SQLite queries). Entry: `main.py`.
 - `riddles/` — puzzle definitions (`*_config.json`, `*_instructions.tex`, `*_sample_solution.json`).
@@ -23,19 +24,22 @@ Logic-circuit puzzle web app. Monorepo: Next.js frontend + FastAPI backend.
 - **Typecheck / lint / build:** `yarn check-types` / `yarn lint` / `yarn build` in `apps/nextjs-app/`.
 - **DB reset:** `python src/reinit_db.py` (or the three seed scripts in order).
 
-## Conventions
-- **Before commit/push:** run `yarn check-types`, `yarn lint`, `yarn test`, `yarn build` in `apps/nextjs-app/`, and `pytest` at root. If touching env loading or shell scripts, reason through `deploy.sh` and `run_server.sh` — they use `set -euo pipefail`, so an unbound var will break deploy.
-- **SQLite is WAL mode.** Never delete `*.db-wal` / `*.db-shm`. Don't `kill -9` uvicorn — use SIGTERM so WAL checkpoints cleanly. See the header comment in [deploy.sh](deploy.sh) for rollback and WAL rationale.
-- **Secrets:** only in `apps/nextjs-app/.env` (gitignored). `NEXT_PUBLIC_GOOGLE_CLIENT_ID` lives there; `init_env.py` propagates it to the backend. Don't commit `.env`.
-- **Dev admin:** `admin` / `password123`. Dev-only.
-- **Branch naming:** `<issue-number>-<kebab-slug>` (e.g. `231-puzzle-solution-mid-solving-saving`).
-- **Backend layering:** controllers call services, services call domain + persistent. Don't shortcut APILayer → PersistantLayer.
+## Coding Conventions
+- **Backend layering:** controllers call services; services call domain + persistent. Don't shortcut APILayer → PersistantLayer.
+- **State/data:** use Zustand + React Query. Don't introduce a second library for either.
+- **Frontend components:** kebab-case filenames (e.g. `workstation-grid.tsx`), PascalCase exports.
 
-## Don't
-- Don't commit `escape_circuit.db*`, `node_modules/`, or `.env`.
-- Don't add a new start script at repo root — extend `init_env.py`, `run_server.sh`, or `run_server.bat`.
-- Don't introduce a second state or data-fetching library — use Zustand + React Query.
-- Don't restructure `src/Backend/` layers without saying so explicitly.
+## Critical Rules
+- **ALWAYS before commit/push:** run `yarn check-types`, `yarn lint`, `yarn test`, `yarn build` in `apps/nextjs-app/` and `pytest` at root. If touching env loading or shell scripts, reason through `deploy.sh` and `run_server.sh` — both use `set -euo pipefail`, so an unbound var breaks deploy.
+- **NEVER delete `*.db-wal` / `*.db-shm`** — SQLite is WAL mode. Don't `kill -9` uvicorn; use SIGTERM so WAL checkpoints cleanly. See [deploy.sh](deploy.sh) header for rollback + WAL rationale.
+- **NEVER commit `.env`, `escape_circuit.db*`, or `node_modules/`.** Secrets live only in `apps/nextjs-app/.env`; `init_env.py` propagates `NEXT_PUBLIC_GOOGLE_CLIENT_ID` to the backend.
+- **NEVER add a new start script at repo root** — extend `init_env.py`, `run_server.sh`, or `run_server.bat`.
+- **NEVER restructure `src/Backend/` layers** without calling it out explicitly.
+- **Dev admin creds:** `admin` / `password123` — dev-only; never ship.
+
+## Naming & Git
+- **Branches:** `<issue-number>-<kebab-slug>` (e.g. `231-puzzle-solution-mid-solving-saving`).
+- **PRs:** merged via GitHub PRs (see recent `Merge pull request #...` commits); reference the issue number.
 
 ## References
 - Setup: [HOWTORUN.md](HOWTORUN.md), [docs/SETUP.md](docs/SETUP.md)

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -48,6 +48,7 @@ import { InfoPopup } from '@/components/ui/info-popup';
 import { Bug, ChevronDown, StepBack, StepForward, ArrowRight, Trash2 } from 'lucide-react';
 import { PageTourLauncher } from '@/components/ui/page-tour-launcher';
 import { workstationTourSteps } from '@/config/tourSteps';
+import { useWorkstationDraft } from '@/features/puzzles/hooks/use-workstation-draft';
 
 const BASIC_COMPONENTS: CircuitComponent[] = [
   { id: 'AND', type: 'AND', cost: 1, pins: 3 },
@@ -831,8 +832,6 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     };
   }, [inputs, outputs, wires]);
 
-  const STATE_KEY = `escapecircuit.workstation.state.v2:${puzzleId}`;
-
   const buildHoleState = useCallback(() => {
     const holes: Record<
       string,
@@ -926,44 +925,118 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     applyParsedStateRef.current = applyParsedState;
   }, [applyParsedState]);
 
-  // Load state from localStorage
-  useEffect(() => {
-    let cancelled = false;
+  // Draft persistence via scoped TTL cache (see plan issue #231).
+  const { storageKey, loadDraft, saveDraft, clearDraft } =
+    useWorkstationDraft(puzzleId);
+  const didHydrateRef = useRef(false);
+  const hydratedKeyRef = useRef<string | null>(null);
+  // Mirror the current storageKey in a ref so the save/flush effects can read
+  // it WITHOUT listing it as a dep — critical to avoid writing a previous
+  // scope's `placed`/`wires` under a freshly-changed storageKey in the same
+  // commit as the load effect.
+  const storageKeyRef = useRef<string | null>(storageKey);
+  storageKeyRef.current = storageKey;
 
-    const loadState = async () => {
-      // Load from localStorage
-      if (cancelled) return;
-      try {
-        const raw = window.localStorage.getItem(STATE_KEY);
-        if (!raw) return;
-        const parsed = JSON.parse(raw);
-        applyParsedStateRef.current(parsed);
-      } catch {
-        // ignore
+  // Mirror placed/wires in refs so the flush handler always has the latest
+  // values without re-registering listeners on every edit.
+  const placedRef = useRef(placed);
+  placedRef.current = placed;
+  const wiresRef = useRef(wires);
+  wiresRef.current = wires;
+
+  // Set synchronously in checkSolution when res.solved === true. Gates both the
+  // save effect and the pagehide flush so neither can re-create the draft that
+  // was just cleared on solve. Reset in onSolveAgain's reset branch.
+  const solvedRef = useRef(false);
+
+  // Load effect: rehydrates whenever the effective storageKey changes
+  // (puzzleId change, auth transition, user swap).
+  useEffect(() => {
+    if (storageKey === null) return;
+    if (hydratedKeyRef.current === storageKey) return;
+
+    didHydrateRef.current = false;
+    // Scope change means we're looking at a different puzzle/user — the prior
+    // solved-gate no longer applies.
+    solvedRef.current = false;
+    const draft = loadDraft();
+    if (draft) {
+      applyParsedStateRef.current(draft);
+      // Sync the flush refs synchronously. Without this, in React 18 concurrent
+      // rendering the re-render from setPlaced/setWires can be time-sliced,
+      // leaving placedRef/wiresRef holding the PREVIOUS scope's values while
+      // hydratedKeyRef already points to the new scope — a flush in that window
+      // would write previous-scope state under the new key.
+      placedRef.current = draft.placed;
+      wiresRef.current = draft.wires;
+    } else {
+      // No draft under the new scope — reset the board so we don't leak the
+      // previous scope's state into this one.
+      setPlaced([]);
+      setWires([]);
+      placedRef.current = [];
+      wiresRef.current = [];
+    }
+    hydratedKeyRef.current = storageKey;
+    didHydrateRef.current = true;
+  }, [storageKey, loadDraft]);
+
+  // Save effect: writes the current board under the hydrated scope.
+  // Intentionally omits `storageKey` from deps — it's read via storageKeyRef.
+  // The effect fires on placed/wires changes, which (after an in-place scope
+  // change) only happen on the render AFTER the load effect's setPlaced/setWires
+  // have committed — so placed/wires always correspond to storageKeyRef.current.
+  useEffect(() => {
+    const key = storageKeyRef.current;
+    if (key === null) return;
+    if (!didHydrateRef.current || hydratedKeyRef.current !== key) return;
+    // Post-solve: suppress writes so the winning board can't re-populate the
+    // key that checkSolution just cleared. Reset in onSolveAgain.
+    if (solvedRef.current) return;
+
+    if (placed.length === 0 && wires.length === 0) {
+      clearDraft();
+    } else {
+      saveDraft({ placed, wires });
+    }
+  }, [placed, wires, saveDraft, clearDraft]);
+
+  // Lifecycle flush for tab-close / visibility-hidden. Reads the latest values
+  // via refs so listeners are installed once and kept stable.
+  useEffect(() => {
+    const flush = () => {
+      const key = storageKeyRef.current;
+      if (key === null) return;
+      if (!didHydrateRef.current || hydratedKeyRef.current !== key) return;
+      // Post-solve: the draft was just cleared in checkSolution; don't let a
+      // tab-close / tab-switch re-create it from the still-resident winning state.
+      if (solvedRef.current) return;
+      const currentPlaced = placedRef.current;
+      const currentWires = wiresRef.current;
+      if (currentPlaced.length === 0 && currentWires.length === 0) {
+        clearDraft();
+      } else {
+        saveDraft({ placed: currentPlaced, wires: currentWires });
       }
     };
 
-    loadState();
-    return () => { cancelled = true; };
-  }, [STATE_KEY, puzzleId]);
+    const onPageHide = () => flush();
+    const onVisibilityChange = () => {
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'hidden'
+      ) {
+        flush();
+      }
+    };
 
-  // Save to localStorage (immediate)
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(
-        STATE_KEY,
-        JSON.stringify({
-          grid: { rows: 10, cols: 14 },
-          placed,
-          wires,
-          holes: buildHoleState(),
-        }),
-      );
-    } catch {
-      // ignore
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [STATE_KEY, placed, wires]);
+    window.addEventListener('pagehide', onPageHide);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('pagehide', onPageHide);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [saveDraft, clearDraft]);
 
   const ratingMinAttemptSeconds = puzzle?.rating_min_attempt_seconds;
   const hasAttemptedMinTime = ratingMinAttemptSeconds != null
@@ -1451,6 +1524,10 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
 
       setBoardFeedback(res.solved ? 'success' : 'failure');
       if (res.solved) {
+        // Synchronously suppress any subsequent save/flush before clearing,
+        // so a tab-close in the post-solve window can't re-save the winning board.
+        solvedRef.current = true;
+        clearDraft();
         const isFirstSolve = Boolean(
           (res as any).is_first_solve ??
             (res as any).first_solve ??
@@ -1547,14 +1624,12 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     // For "Try again" after a failed check, keep the user's board.
     // For "Solve again" after success, start from a clean board.
     if (shouldResetBoard) {
-      try {
-        window.localStorage.removeItem(STATE_KEY);
-      } catch {
-        // ignore
-      }
+      clearDraft();
       setPlaced([]);
       setWires([]);
       setIsSolved(false);
+      // Re-enable save/flush for the fresh attempt.
+      solvedRef.current = false;
       startTime.current = Date.now();
     }
 

--- a/apps/nextjs-app/src/app/provider.tsx
+++ b/apps/nextjs-app/src/app/provider.tsx
@@ -11,6 +11,11 @@ import { MainErrorFallback } from '@/components/errors/main';
 import { NavigationLoadingProvider } from '@/components/ui/navigation-loading/navigation-loading';
 import { Notifications } from '@/components/ui/notifications';
 import { SettingsProvider } from '@/context/settings-context';
+import {
+  sweepExpired,
+  WORKSTATION_CACHE_VERSION,
+  WORKSTATION_KEY_PREFIX,
+} from '@/lib/cache-storage';
 import { queryConfig } from '@/lib/react-query';
 
 type AppProviderProps = {
@@ -24,6 +29,12 @@ export const AppProvider = ({ children }: AppProviderProps) => {
         defaultOptions: queryConfig,
       }),
   );
+
+  // One-shot cleanup of expired / legacy workstation draft entries on app mount.
+  // Silent, best-effort — never throws (SSR-safe inside sweepExpired).
+  React.useEffect(() => {
+    sweepExpired(WORKSTATION_KEY_PREFIX, WORKSTATION_CACHE_VERSION);
+  }, []);
 
   return (
     <ErrorBoundary FallbackComponent={MainErrorFallback}>

--- a/apps/nextjs-app/src/features/puzzles/hooks/use-workstation-draft.ts
+++ b/apps/nextjs-app/src/features/puzzles/hooks/use-workstation-draft.ts
@@ -1,0 +1,165 @@
+import Cookies from 'js-cookie';
+import { useMemo, useRef, useCallback } from 'react';
+
+import { useUser } from '@/lib/auth';
+import {
+  setWithTTL,
+  getWithTTL,
+  removeWithTTL,
+  workstationKeyForUser,
+  workstationKeyForAnon,
+  WORKSTATION_CACHE_VERSION,
+  WORKSTATION_TTL_MS,
+} from '@/lib/cache-storage';
+import type { Wire } from '@/types/api';
+import { AUTH_TOKEN_COOKIE_NAME } from '@/utils/auth-constants';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// Structural shape of a placed component as serialized in a draft. Kept local
+// to avoid importing from the app/ route layer (see import/no-restricted-paths).
+// Mirrors PlacedGridComponent in workstation-grid.tsx — the hook only needs a
+// serializable shape; the consumer applies its own migrations.
+type PlacedDraftComponent = {
+  id: string;
+  componentId: string;
+  origin: { row: number; col: number };
+  rotation: 0 | 90;
+  isLocked?: boolean;
+};
+
+export type WorkstationDraft = {
+  placed: PlacedDraftComponent[];
+  wires: Wire[];
+};
+
+type AuthState =
+  | { state: 'anonymous' }
+  | { state: 'loading' }
+  | { state: 'authenticated'; userId: string }
+  | { state: 'error' };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useWorkstationDraft(puzzleId: string): {
+  authReady: boolean;
+  storageKey: string | null;
+  loadDraft: () => WorkstationDraft | null;
+  saveDraft: (draft: WorkstationDraft) => void;
+  clearDraft: () => void;
+  flushNow: () => void;
+} {
+  const user = useUser();
+
+  // Derive four-state auth. The order of checks matches the spec exactly:
+  //
+  //   1. No cookie → anonymous (query is disabled; isPending would be a
+  //      stale/initial state, not a real loading state — so we check the
+  //      cookie first before touching query status at all).
+  //   2. Cookie present + isPending → loading.
+  //   3. Cookie present + data.id → authenticated.
+  //   4. Cookie present + isError (or any other terminal non-data state) → error.
+  //
+  // Reading the cookie at render time is safe here because this hook only
+  // runs in client components (the puzzle workstation is a client-only route).
+  const auth = useMemo((): AuthState => {
+    const hasCookie =
+      typeof window !== 'undefined'
+        ? !!Cookies.get(AUTH_TOKEN_COOKIE_NAME)
+        : false;
+
+    if (!hasCookie) {
+      return { state: 'anonymous' };
+    }
+
+    if (user.isPending) {
+      return { state: 'loading' };
+    }
+
+    if (user.data?.id) {
+      return { state: 'authenticated', userId: String(user.data.id) };
+    }
+
+    // Cookie present, query settled with error or unexpectedly no data.
+    // We do NOT coerce to anonymous — the user may be legitimately logged in
+    // and writing under the anon key could overwrite an authenticated draft.
+    return { state: 'error' };
+  }, [user.isPending, user.data]);
+
+  // Derived stable values from auth + puzzleId.
+  const storageKey = useMemo((): string | null => {
+    if (auth.state === 'authenticated') {
+      return workstationKeyForUser(puzzleId, auth.userId);
+    }
+    if (auth.state === 'anonymous') {
+      return workstationKeyForAnon(puzzleId);
+    }
+    // loading or error → no I/O
+    return null;
+  }, [auth, puzzleId]);
+
+  const envelopeUserId = useMemo((): string | null => {
+    if (auth.state === 'authenticated') {
+      return auth.userId;
+    }
+    return null;
+  }, [auth]);
+
+  const authReady = storageKey !== null;
+
+  // Refs so callbacks can always close over the latest values without
+  // needing to be recreated on each render (stable identity for consumers).
+  const keyRef = useRef<string | null>(storageKey);
+  const envelopeUserIdRef = useRef<string | null>(envelopeUserId);
+
+  // Keep refs in sync on every render.
+  keyRef.current = storageKey;
+  envelopeUserIdRef.current = envelopeUserId;
+
+  // ---------------------------------------------------------------------------
+  // Callbacks — read from refs, never from closed-over values, so they stay
+  // stable while always operating on the current scope.
+  // ---------------------------------------------------------------------------
+
+  const loadDraft = useCallback((): WorkstationDraft | null => {
+    if (keyRef.current === null) return null;
+    return getWithTTL<WorkstationDraft>(keyRef.current, {
+      version: WORKSTATION_CACHE_VERSION,
+      userId: envelopeUserIdRef.current,
+    });
+  }, []);
+
+  const saveDraft = useCallback((draft: WorkstationDraft): void => {
+    if (keyRef.current === null) return;
+    setWithTTL(keyRef.current, draft, {
+      ttlMs: WORKSTATION_TTL_MS,
+      version: WORKSTATION_CACHE_VERSION,
+      userId: envelopeUserIdRef.current,
+    });
+  }, []);
+
+  const clearDraft = useCallback((): void => {
+    if (keyRef.current === null) return;
+    removeWithTTL(keyRef.current);
+  }, []);
+
+  // Placeholder for a future debounced variant. Synchronous writes make this
+  // a no-op in v1 — when a debounced saveDraft is introduced, this will flush
+  // any pending timer-delayed write immediately (e.g. on pagehide).
+  const flushNow = useCallback((): void => {
+    // no-op
+  }, []);
+
+  return {
+    authReady,
+    storageKey,
+    loadDraft,
+    saveDraft,
+    clearDraft,
+    flushNow,
+  };
+}

--- a/apps/nextjs-app/src/lib/cache-storage.ts
+++ b/apps/nextjs-app/src/lib/cache-storage.ts
@@ -1,0 +1,212 @@
+// Generic TTL-localStorage utility.
+// SSR-safe, throw-free, no external dependencies.
+
+export type Envelope<T> = {
+  value: T;
+  expiresAt: number; // epoch ms
+  version: string;
+  userId: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isStorageAvailable(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function tryRemove(key: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // quota / private-mode errors — swallow silently
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+export function setWithTTL<T>(
+  key: string,
+  value: T,
+  opts: { ttlMs: number; version: string; userId: string | null },
+): void {
+  if (!isStorageAvailable()) return;
+
+  const envelope: Envelope<T> = {
+    value,
+    expiresAt: Date.now() + opts.ttlMs,
+    version: opts.version,
+    userId: opts.userId,
+  };
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(envelope));
+  } catch {
+    // Quota exceeded, private-browsing write failures — swallow silently.
+  }
+}
+
+export function getWithTTL<T>(
+  key: string,
+  opts: { version: string; userId: string | null },
+): T | null {
+  if (!isStorageAvailable()) return null;
+
+  let raw: string | null = null;
+
+  try {
+    raw = window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+
+  if (raw === null) return null;
+
+  let envelope: Envelope<T>;
+
+  try {
+    envelope = JSON.parse(raw) as Envelope<T>;
+  } catch {
+    // Malformed JSON — remove and return null.
+    tryRemove(key);
+    return null;
+  }
+
+  // Basic shape check — if essential fields are missing it is malformed.
+  if (
+    envelope === null ||
+    typeof envelope !== 'object' ||
+    typeof envelope.expiresAt !== 'number' ||
+    typeof envelope.version !== 'string' ||
+    !(
+      (envelope as any).userId === null ||
+      typeof (envelope as any).userId === 'string'
+    )
+  ) {
+    tryRemove(key);
+    return null;
+  }
+
+  // Version mismatch — remove and return null.
+  if (envelope.version !== opts.version) {
+    tryRemove(key);
+    return null;
+  }
+
+  // Expired — remove and return null.
+  if (Date.now() > envelope.expiresAt) {
+    tryRemove(key);
+    return null;
+  }
+
+  // userId mismatch — paranoid cross-user guard. Return null but do NOT remove
+  // (another user's entry may be sitting under a recycled key by accident; we
+  // do not want to silently delete data that doesn't belong to the caller).
+  if (envelope.userId !== opts.userId) {
+    return null;
+  }
+
+  return envelope.value;
+}
+
+export function removeWithTTL(key: string): void {
+  if (!isStorageAvailable()) return;
+  tryRemove(key);
+}
+
+export function sweepExpired(prefix: string, version: string): void {
+  if (!isStorageAvailable()) return;
+
+  // Collect keys first, then remove. Mutating localStorage while iterating
+  // via index shifts indices and causes entries to be skipped.
+  const keysToCheck: string[] = [];
+
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k !== null && k.startsWith(prefix)) {
+        keysToCheck.push(k);
+      }
+    }
+  } catch {
+    return;
+  }
+
+  const now = Date.now();
+
+  for (const key of keysToCheck) {
+    let raw: string | null = null;
+
+    try {
+      raw = window.localStorage.getItem(key);
+    } catch {
+      continue;
+    }
+
+    if (raw === null) continue;
+
+    let envelope: Envelope<unknown>;
+
+    try {
+      envelope = JSON.parse(raw) as Envelope<unknown>;
+    } catch {
+      // Malformed JSON — remove.
+      tryRemove(key);
+      continue;
+    }
+
+    // Malformed shape — remove.
+    if (
+      envelope === null ||
+      typeof envelope !== 'object' ||
+      typeof envelope.expiresAt !== 'number' ||
+      typeof envelope.version !== 'string' ||
+      !(
+        (envelope as any).userId === null ||
+        typeof (envelope as any).userId === 'string'
+      )
+    ) {
+      tryRemove(key);
+      continue;
+    }
+
+    // Version mismatch (e.g. legacy v2 entries) — remove.
+    if (envelope.version !== version) {
+      tryRemove(key);
+      continue;
+    }
+
+    // Expired — remove.
+    if (now > envelope.expiresAt) {
+      tryRemove(key);
+      continue;
+    }
+
+    // Valid entry, potentially belonging to a different user — leave intact.
+    // User-level isolation is already provided by the key (distinct keys per
+    // user per puzzle), so no userId check is needed here.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workstation-specific constants and key builders
+// ---------------------------------------------------------------------------
+
+export const WORKSTATION_KEY_PREFIX = 'escapecircuit.workstation.state.';
+export const WORKSTATION_CACHE_VERSION = 'v3';
+export const WORKSTATION_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+export function workstationKeyForUser(
+  puzzleId: string,
+  userId: string,
+): string {
+  return `${WORKSTATION_KEY_PREFIX}${WORKSTATION_CACHE_VERSION}:user:${userId}:${puzzleId}`;
+}
+
+export function workstationKeyForAnon(puzzleId: string): string {
+  return `${WORKSTATION_KEY_PREFIX}${WORKSTATION_CACHE_VERSION}:anon:${puzzleId}`;
+}


### PR DESCRIPTION
# Puzzle Solution Mid-Solving Save

## Description
This PR persists the user's in-progress workstation board (placed components + wires) to `localStorage` so a refresh, accidental tab-close, or navigation doesn't lose their work. Everything runs client-side under a TTL envelope with keys scoped to both the puzzle and the signed-in user.

It includes:
- New generic TTL-envelope `localStorage` utility with version tagging and an expired-key sweep on app mount
- New auth-aware `useWorkstationDraft` hook that derives the active storage key from login state (authenticated / anonymous / loading / error)
- Workstation component rewired to hydrate, save, and flush drafts via the hook instead of an ad-hoc `localStorage.setItem` call
- Post-solve suppression so the cleared draft can't be resurrected by a stray flush during the win animation

## Related Issues
- #231

## Key Changes

### 1. TTL Cache Utility
- New `src/lib/cache-storage.ts` with `setWithTTL` / `getWithTTL` / `removeWithTTL` / `sweepExpired` helpers
- Envelope shape: `{ value, expiresAt, version, userId }` — mismatched version or expired entries are transparently evicted on read
- Key builders: `workstationKeyForUser(userId, puzzleId)` → `escapecircuit.workstation.state.v3:user:<id>:<puzzleId>`, and `workstationKeyForAnon(puzzleId)` → `…:anon:<puzzleId>`
- SSR-safe (guards `typeof window`), throw-free (swallows quota / JSON errors), no dependencies

Files:
- `apps/nextjs-app/src/lib/cache-storage.ts`

### 2. Auth-Aware Draft Hook
- New `src/features/puzzles/hooks/use-workstation-draft.ts` exposes `{ authReady, storageKey, loadDraft, saveDraft, clearDraft, flushNow }`
- Four-state auth derivation from `useUser()` + the auth cookie: `loading` | `authenticated(userId)` | `anonymous` | `error`
- In the `error` state (cookie present but query failed) the hook returns a null `storageKey` and refuses to write — protects against overwriting a real user's draft with anon data
- Callbacks are stable via refs so consumer effects don't churn on every auth tick
- Uses a local structural draft shape to avoid importing from the `app/` route layer (respects `import/no-restricted-paths`)

Files:
- `apps/nextjs-app/src/features/puzzles/hooks/use-workstation-draft.ts`

### 3. Workstation Wiring
- Replaced the ad-hoc `STATE_KEY` + inline `localStorage.setItem/getItem` logic in `puzzle-workstation.tsx` with three effects keyed on the hook's `storageKey`:
  - **Load** — rehydrates when the scope flips (puzzle change, login, logout); synchronously syncs `placedRef`/`wiresRef` so a concurrent-render flush can't write prior-scope state under the new key
  - **Save** — writes on every `placed`/`wires` change, gated by `hydratedKeyRef` to prevent saves before hydration
  - **Flush** — `pagehide` + `visibilitychange: hidden` listeners to catch tab-close / tab-switch
- Added a `solvedRef` synchronous gate flipped immediately before `clearDraft()` in `checkSolution`'s solved branch; both save and flush early-return when set, so a tab-close during the win animation can't re-create the cleared draft. "Solve Again" resets it.
- Removed the old `STATE_KEY` constant and legacy v2 prefix entirely

Files:
- `apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx`

### 4. App Mount Sweep
- One-shot `sweepExpired` call in `AppProvider` evicts stale v2/expired entries on app load so old drafts don't linger indefinitely

Files:
- `apps/nextjs-app/src/app/provider.tsx`

## Behavioral Notes
- No backend/API/DB changes — feature is 100% client-side
- No migration: the old v2 key (`escapecircuit.workstation.state.v2:<puzzleId>`) is superseded by v3 and left behind; the sweep cleans it up on next app mount
- Per-browser, per-device (no cross-device sync by design)
- Drafts TTL-expire (30 days) and are scoped so one user's draft never leaks to another on a shared browser
- Post-solve clears the draft so a solved puzzle doesn't rehydrate as "in progress" next visit

## Checklist
- [x] `npm run check-types` passes
- [x] `npm run lint` clean on all changed/new files (pre-existing baseline errors unrelated to this PR were not touched)
- [x] `npm run build` passes
- [x] Manual browser smoke test: build board → refresh → restored
- [x] Solve correctly → refresh → board empty (post-solve clear)
- [x] Tab-switch during win animation → refresh → board empty (solvedRef gate)
- [x] Two-user browser: A draft → logout → B draft → logout → A intact (user-scoped keys)
- [x] DevTools Local Storage keys look like `escapecircuit.workstation.state.v3:user:<id>:<puzzleId>` or `…:anon:<puzzleId>`