### PR TITLE
235 UI improvements to solving page and arsenal pieces

### DIFF
--- a/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
@@ -23,6 +23,16 @@ import {
   type SelectedComponentState,
 } from '@/app/app/puzzles/[id]/_components/workstation-grid';
 import { WorkstationMenu } from '@/app/app/puzzles/[id]/_components/workstation-menu';
+import {
+  LogicNode,
+  type LogicNodeDefinition,
+  type LogicNodePort,
+  type LogicNodeVisualStyle,
+} from '@/app/app/puzzles/[id]/_components/node';
+import {
+  DEFAULT_PIECE_VISUAL_STYLE,
+  extractVisualStyleFromComponentLike,
+} from '@/app/app/puzzles/[id]/_components/piece-visual-style';
 import dynamic from 'next/dynamic';
 const CircuitDebugger = dynamic(
   () => import('@/components/circuit-debugger').then(mod => ({ default: mod.CircuitDebugger })),
@@ -44,6 +54,61 @@ type SaveState =
   | { open: false }
   | { open: true; saving: boolean; error?: string };
 
+const buildPiecePreviewNode = ({
+  label,
+  numInputs,
+  numOutputs,
+  visualStyle,
+}: {
+  label: string;
+  numInputs: number;
+  numOutputs: number;
+  visualStyle?: LogicNodeVisualStyle;
+}): LogicNodeDefinition => {
+  const safeInputs = Math.max(0, Math.floor(numInputs));
+  const safeOutputs = Math.max(0, Math.floor(numOutputs));
+  const height = Math.max(1, safeInputs, safeOutputs);
+  const width = 3;
+
+  const ports: LogicNodePort[] = [];
+  for (let i = 0; i < safeInputs; i += 1) {
+    ports.push({
+      id: `in${i}`,
+      kind: 'input',
+      offset: { row: Math.min(i, height - 1), col: 0 },
+    });
+  }
+  for (let i = 0; i < safeOutputs; i += 1) {
+    ports.push({
+      id: `out${i}`,
+      kind: 'output',
+      offset: { row: Math.min(i, height - 1), col: width - 1 },
+    });
+  }
+
+  if (safeInputs !== safeOutputs && safeInputs > 0 && safeOutputs > 0) {
+    const lowerKind: 'input' | 'output' = safeInputs < safeOutputs ? 'input' : 'output';
+    const lowerPorts = ports
+      .filter((port) => port.kind === lowerKind)
+      .sort((a, b) => a.offset.row - b.offset.row);
+
+    lowerPorts.forEach((port, index) => {
+      const distributedRow = -0.5 + ((index + 1) * height) / (lowerPorts.length + 1);
+      port.offset = {
+        row: distributedRow,
+        col: port.offset.col,
+      };
+    });
+  }
+
+  return {
+    label: label.trim() || 'Unnamed Piece',
+    size: { w: width, h: height },
+    ports,
+    visualStyle,
+  };
+};
+
 export default function ArsenalCreatorPage() {
   const router = useRouter();
   const { addNotification } = useNotifications();
@@ -52,6 +117,9 @@ export default function ArsenalCreatorPage() {
   const [numOutputs, setNumOutputs] = useState(1);
   const [pieceName, setPieceName] = useState('');
   const [pieceDescription, setPieceDescription] = useState('');
+  const [pieceVisualStyle, setPieceVisualStyle] = useState<Required<LogicNodeVisualStyle>>(
+    DEFAULT_PIECE_VISUAL_STYLE,
+  );
   const [showNameDialog, setShowNameDialog] = useState(false);
   const [showDebugger, setShowDebugger] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>({ open: false });
@@ -68,20 +136,45 @@ export default function ArsenalCreatorPage() {
   const saveArsenalMutation = useSaveArsenalPiece();
   const { data: myArsenalData } = useMyArsenal();
 
+  const hasCustomPieceVisualStyle = useMemo(() => {
+    return (
+      pieceVisualStyle.accentColor.toLowerCase() !==
+        DEFAULT_PIECE_VISUAL_STYLE.accentColor.toLowerCase() ||
+      pieceVisualStyle.roundness !== DEFAULT_PIECE_VISUAL_STYLE.roundness ||
+      pieceVisualStyle.borderStyle !== DEFAULT_PIECE_VISUAL_STYLE.borderStyle ||
+      pieceVisualStyle.edgeAddon !== DEFAULT_PIECE_VISUAL_STYLE.edgeAddon ||
+      pieceVisualStyle.surfaceStyle !== DEFAULT_PIECE_VISUAL_STYLE.surfaceStyle
+    );
+  }, [pieceVisualStyle]);
+
+  const saveDialogPreviewNode = useMemo(() => {
+    return buildPiecePreviewNode({
+      label: pieceName,
+      numInputs,
+      numOutputs,
+      visualStyle: hasCustomPieceVisualStyle ? pieceVisualStyle : undefined,
+    });
+  }, [pieceName, numInputs, numOutputs, hasCustomPieceVisualStyle, pieceVisualStyle]);
+
   // Convert arsenal pieces to CircuitComponent format
   const arsenalComponents = useMemo(() => {
     if (!myArsenalData) return [];
-    return myArsenalData.map((piece) => ({
-      id: String(piece.id),
-      type: piece.name,
-      cost: piece.cost,
-      pins: (piece as any).num_inputs + (piece as any).num_outputs,
-      basic_gates: piece.basic_gates,
-      truth_table: piece.truth_table,
-      is_arsenal: piece.is_arsenal,
-      num_inputs: (piece as any).num_inputs ?? 0,
-      num_outputs: (piece as any).num_outputs ?? 0,
-    } as CircuitComponent));
+    return myArsenalData.map((piece) => {
+      const visualStyle = extractVisualStyleFromComponentLike(piece);
+
+      return {
+        id: String(piece.id),
+        type: piece.name,
+        cost: piece.cost,
+        pins: (piece as any).num_inputs + (piece as any).num_outputs,
+        basic_gates: piece.basic_gates,
+        truth_table: piece.truth_table,
+        is_arsenal: piece.is_arsenal,
+        num_inputs: (piece as any).num_inputs ?? 0,
+        num_outputs: (piece as any).num_outputs ?? 0,
+        visual_style: visualStyle,
+      } as CircuitComponent;
+    });
   }, [myArsenalData]);
   const inputs = useMemo(() => {
     return Array.from({ length: numInputs }, (_, i) => `in${i}`);
@@ -214,6 +307,7 @@ export default function ArsenalCreatorPage() {
     for (const [id, def] of componentCatalog.entries()) {
       const hc = hardcoded[def.type];
       const isArsenal = (def as any).is_arsenal === true;
+      const visualStyle = extractVisualStyleFromComponentLike(def);
       
       let size: { w: number; h: number };
       let ports: Array<{ id: string; kind: 'input' | 'output'; offset: { row: number; col: number } }>;
@@ -257,6 +351,7 @@ export default function ArsenalCreatorPage() {
         cost: def.cost,
         size,
         ports,
+        visualStyle,
       });
     }
     return Object.fromEntries(Array.from(ui.entries())) as Record<
@@ -327,17 +422,23 @@ export default function ArsenalCreatorPage() {
     try {
       const { gates, usedArsenalPieceIds } = extractGatesAndArsenal();
 
+      const structurePayload: Record<string, unknown> = {
+        numInputs,
+        numOutputs,
+        placed,
+        wires,
+      };
+
+      if (hasCustomPieceVisualStyle) {
+        structurePayload.visualStyle = pieceVisualStyle;
+      }
+
       const savePayload = {
         name: pieceName.trim(),
         description: pieceDescription.trim(),
         num_inputs: numInputs,
         num_outputs: numOutputs,
-        structure_json: JSON.stringify({
-          numInputs,
-          numOutputs,
-          placed,
-          wires,
-        }),
+        structure_json: JSON.stringify(structurePayload),
         basic_gates: JSON.stringify(gates),
         truth_table: {},
         used_arsenal_pieces: usedArsenalPieceIds,
@@ -353,6 +454,7 @@ export default function ArsenalCreatorPage() {
 
       setShowNameDialog(false);
       setPieceDescription('');
+      setPieceVisualStyle(DEFAULT_PIECE_VISUAL_STYLE);
       setSaveState({ open: false });
       router.push(paths.app.arsenal.root.getHref());
     } catch (error: any) {
@@ -497,6 +599,124 @@ export default function ArsenalCreatorPage() {
               {!pieceDescription.trim() && (
                 <p className="text-[11px] text-red-600 mt-1">A description is required for Arsenal components.</p>
               )}
+            </div>
+
+            <div className="rounded-lg border border-border/70 bg-secondary/30 p-3">
+              <p className="mb-2 text-[13px] font-medium text-foreground">Piece Preview</p>
+              <div className="rounded-md border border-border/60 bg-background/80 p-4">
+                <div className="flex items-center justify-center">
+                  <LogicNode node={saveDialogPreviewNode} cellPx={22} portPx={8} />
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-[11px] text-foreground/80">
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Name:</span> {saveDialogPreviewNode.label}
+                  </div>
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Inputs:</span> {numInputs}
+                  </div>
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Outputs:</span> {numOutputs}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border/70 bg-secondary/30 p-3">
+              <p className="mb-2 text-[13px] font-medium text-foreground">Piece Look</p>
+              <div className="grid grid-cols-2 gap-2 text-[12px]">
+                <label className="flex flex-col gap-1 text-muted-foreground">
+                  Accent
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="color"
+                      value={pieceVisualStyle.accentColor}
+                      onChange={(e: any) =>
+                        setPieceVisualStyle((prev) => ({
+                          ...prev,
+                          accentColor: e.target.value,
+                        }))
+                      }
+                      className="h-8 w-10 cursor-pointer rounded border border-border bg-card p-1"
+                    />
+                    <span className="font-mono text-[11px] text-foreground">{pieceVisualStyle.accentColor}</span>
+                  </div>
+                </label>
+
+                <label className="flex flex-col gap-1 text-muted-foreground">
+                  Roundness
+                  <input
+                    type="range"
+                    min={0}
+                    max={10}
+                    step={1}
+                    value={pieceVisualStyle.roundness}
+                    onChange={(e: any) =>
+                      setPieceVisualStyle((prev) => ({
+                        ...prev,
+                        roundness: Number(e.target.value),
+                      }))
+                    }
+                    className="h-8"
+                  />
+                  <span className="text-[11px] text-foreground/75">{pieceVisualStyle.roundness} / 10</span>
+                </label>
+
+                <label className="flex flex-col gap-1 text-muted-foreground">
+                  Border
+                  <select
+                    value={pieceVisualStyle.borderStyle}
+                    onChange={(e: any) =>
+                      setPieceVisualStyle((prev) => ({
+                        ...prev,
+                        borderStyle: e.target.value,
+                      }))
+                    }
+                    className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                  >
+                    <option value="solid">Solid</option>
+                    <option value="double">Double</option>
+                    <option value="etched">Etched</option>
+                  </select>
+                </label>
+
+                <label className="flex flex-col gap-1 text-muted-foreground">
+                  Edge Add-on
+                  <select
+                    value={pieceVisualStyle.edgeAddon}
+                    onChange={(e: any) =>
+                      setPieceVisualStyle((prev) => ({
+                        ...prev,
+                        edgeAddon: e.target.value,
+                      }))
+                    }
+                    className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                  >
+                    <option value="none">None</option>
+                    <option value="chip-legs">Chip Legs</option>
+                  </select>
+                </label>
+
+                <label className="col-span-2 flex flex-col gap-1 text-muted-foreground">
+                  Surface
+                  <select
+                    value={pieceVisualStyle.surfaceStyle}
+                    onChange={(e: any) =>
+                      setPieceVisualStyle((prev) => ({
+                        ...prev,
+                        surfaceStyle: e.target.value,
+                      }))
+                    }
+                    className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                  >
+                    <option value="flat">Flat</option>
+                    <option value="brushed">Brushed</option>
+                    <option value="gradient">Gradient</option>
+                    <option value="matte">Matte</option>
+                    <option value="glass">Glass</option>
+                    <option value="carbon">Carbon</option>
+                  </select>
+                </label>
+              </div>
             </div>
 
             <div className="bg-secondary/50 p-3 rounded-lg text-[13px] space-y-1">

--- a/apps/nextjs-app/src/app/app/arsenal/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/page.tsx
@@ -19,11 +19,22 @@ import {
   useMyArsenal,
   useDeleteArsenalPiece,
   useRenameArsenalPiece,
+  useUpdateArsenalPiece,
   ArsenalPiece,
 } from '@/features/arsenal/api';
 import { InfoPopup } from '@/components/ui/info-popup';
 import { WorkstationGrid } from '@/app/app/puzzles/[id]/_components/workstation-grid';
 import type { PlacedGridComponent, ComponentDef } from '@/app/app/puzzles/[id]/_components/workstation-grid';
+import {
+  LogicNode,
+  type LogicNodeDefinition,
+  type LogicNodePort,
+  type LogicNodeVisualStyle,
+} from '@/app/app/puzzles/[id]/_components/node';
+import {
+  DEFAULT_PIECE_VISUAL_STYLE,
+  extractVisualStyleFromComponentLike,
+} from '@/app/app/puzzles/[id]/_components/piece-visual-style';
 import type { Wire } from '@/types/api';
 import { PageTourLauncher } from '@/components/ui/page-tour-launcher';
 import { arsenalTourSteps } from '@/config/tourSteps';
@@ -50,6 +61,87 @@ const calculateLevelFromXp = (xp: number): number => {
   return Math.floor(Math.sqrt(safeXp / 100)) + 1;
 };
 
+const buildPiecePreviewNode = ({
+  label,
+  numInputs,
+  numOutputs,
+  visualStyle,
+}: {
+  label: string;
+  numInputs: number;
+  numOutputs: number;
+  visualStyle?: LogicNodeVisualStyle;
+}): LogicNodeDefinition => {
+  const safeInputs = Math.max(0, Math.floor(numInputs));
+  const safeOutputs = Math.max(0, Math.floor(numOutputs));
+  const height = Math.max(1, safeInputs, safeOutputs);
+  const width = 3;
+
+  const ports: LogicNodePort[] = [];
+  for (let i = 0; i < safeInputs; i += 1) {
+    ports.push({
+      id: `in${i}`,
+      kind: 'input',
+      offset: { row: Math.min(i, height - 1), col: 0 },
+    });
+  }
+  for (let i = 0; i < safeOutputs; i += 1) {
+    ports.push({
+      id: `out${i}`,
+      kind: 'output',
+      offset: { row: Math.min(i, height - 1), col: width - 1 },
+    });
+  }
+
+  if (safeInputs !== safeOutputs && safeInputs > 0 && safeOutputs > 0) {
+    const lowerKind: 'input' | 'output' = safeInputs < safeOutputs ? 'input' : 'output';
+    const lowerPorts = ports
+      .filter((port) => port.kind === lowerKind)
+      .sort((a, b) => a.offset.row - b.offset.row);
+
+    lowerPorts.forEach((port, index) => {
+      const distributedRow = -0.5 + ((index + 1) * height) / (lowerPorts.length + 1);
+      port.offset = {
+        row: distributedRow,
+        col: port.offset.col,
+      };
+    });
+  }
+
+  return {
+    label: label.trim() || 'Unnamed Piece',
+    size: { w: width, h: height },
+    ports,
+    visualStyle,
+  };
+};
+
+const getPiecePortCounts = (piece: ArsenalPiece | null): { numInputs: number; numOutputs: number } => {
+  if (!piece) return { numInputs: 1, numOutputs: 1 };
+
+  const fromFields = {
+    numInputs: Number(piece.num_inputs),
+    numOutputs: Number(piece.num_outputs),
+  };
+
+  if (Number.isFinite(fromFields.numInputs) && Number.isFinite(fromFields.numOutputs)) {
+    return {
+      numInputs: Math.max(0, Math.floor(fromFields.numInputs)),
+      numOutputs: Math.max(0, Math.floor(fromFields.numOutputs)),
+    };
+  }
+
+  try {
+    const structure = JSON.parse(piece.structure_json || '{}');
+    return {
+      numInputs: Math.max(0, Math.floor(Number(structure.numInputs ?? structure.num_inputs ?? 0))),
+      numOutputs: Math.max(0, Math.floor(Number(structure.numOutputs ?? structure.num_outputs ?? 0))),
+    };
+  } catch {
+    return { numInputs: 1, numOutputs: 1 };
+  }
+};
+
 export default function ArsenalPage() {
   const router = useRouter();
   const user = useUser();
@@ -57,13 +149,19 @@ export default function ArsenalPage() {
   const { data: arsenal, isLoading } = useMyArsenal();
   const deleteArsenalMutation = useDeleteArsenalPiece();
   const renameArsenalMutation = useRenameArsenalPiece();
+  const updateArsenalPieceMutation = useUpdateArsenalPiece();
 
   const [selectedPiece, setSelectedPiece] = useState<ArsenalPiece | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [showDesignDialog, setShowDesignDialog] = useState(false);
   const [newName, setNewName] = useState('');
   const [showTruthTable, setShowTruthTable] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const [designUseClassic, setDesignUseClassic] = useState(true);
+  const [designStyle, setDesignStyle] = useState<Required<LogicNodeVisualStyle>>(
+    DEFAULT_PIECE_VISUAL_STYLE,
+  );
   const [deletingPieceId, setDeletingPieceId] = useState<number | null>(null);
 
   const handleDelete = async (piece: ArsenalPiece) => {
@@ -93,6 +191,22 @@ export default function ArsenalPage() {
     setShowRenameDialog(true);
   };
 
+  const handleDesign = (piece: ArsenalPiece) => {
+    setSelectedPiece(piece);
+    const existingStyle = extractVisualStyleFromComponentLike(piece);
+    if (existingStyle) {
+      setDesignUseClassic(false);
+      setDesignStyle({
+        ...DEFAULT_PIECE_VISUAL_STYLE,
+        ...existingStyle,
+      });
+    } else {
+      setDesignUseClassic(true);
+      setDesignStyle(DEFAULT_PIECE_VISUAL_STYLE);
+    }
+    setShowDesignDialog(true);
+  };
+
   const confirmRename = async () => {
     if (!selectedPiece || !newName.trim()) return;
     try {
@@ -110,6 +224,39 @@ export default function ArsenalPage() {
       setNewName('');
     } catch (error: any) {
       // Error notification handled automatically by API client
+    }
+  };
+
+  const confirmDesign = async () => {
+    if (!selectedPiece) return;
+
+    const pieceId = Number(selectedPiece.id);
+    if (!Number.isFinite(pieceId)) {
+      addNotification({
+        type: 'error',
+        title: 'Error',
+        message: 'Invalid piece id.',
+      });
+      return;
+    }
+
+    try {
+      await updateArsenalPieceMutation.mutateAsync({
+        pieceId,
+        visualStyle: designUseClassic ? {} : designStyle,
+      });
+
+      addNotification({
+        type: 'success',
+        title: 'Success',
+        message: designUseClassic
+          ? 'Piece design reset to classic look'
+          : 'Piece design updated',
+      });
+
+      setShowDesignDialog(false);
+    } catch (error: any) {
+      // Error notification handled by API client
     }
   };
 
@@ -149,6 +296,13 @@ export default function ArsenalPage() {
   }
 
   const pieces = arsenal || [];
+  const { numInputs: designPreviewInputs, numOutputs: designPreviewOutputs } = getPiecePortCounts(selectedPiece);
+  const designPreviewNode = buildPiecePreviewNode({
+    label: selectedPiece?.name ?? '',
+    numInputs: designPreviewInputs,
+    numOutputs: designPreviewOutputs,
+    visualStyle: designUseClassic ? undefined : designStyle,
+  });
   const role = String(user.data?.role || '').toLowerCase();
   const isAdmin = role === 'admin';
   const level = calculateLevelFromXp(Number(user.data?.xp || 0));
@@ -251,6 +405,13 @@ export default function ArsenalPage() {
                       <Button
                         variant="ghost"
                         size="sm"
+                        onClick={() => handleDesign(piece)}
+                      >
+                        Design
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         onClick={() => handleRename(piece)}
                       >
                         Rename
@@ -304,6 +465,158 @@ export default function ArsenalPage() {
             </Button>
             <Button onClick={confirmRename} disabled={!newName.trim()}>
               Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Design Dialog */}
+      <Dialog open={showDesignDialog} onOpenChange={setShowDesignDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Piece Design</DialogTitle>
+            <DialogDescription>
+              Customize this arsenal piece look. Changes apply wherever this piece is used.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <label className="flex items-center justify-between rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-[13px]">
+              <span className="font-medium text-foreground">Use classic default look</span>
+              <input
+                type="checkbox"
+                checked={designUseClassic}
+                onChange={(e) => setDesignUseClassic(e.target.checked)}
+                className="size-4 rounded border-border"
+              />
+            </label>
+
+            {!designUseClassic ? (
+              <div className="rounded-lg border border-border/70 bg-secondary/30 p-3">
+                <div className="grid grid-cols-2 gap-2 text-[12px]">
+                  <label className="flex flex-col gap-1 text-muted-foreground">
+                    Accent
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="color"
+                        value={designStyle.accentColor}
+                        onChange={(e: any) =>
+                          setDesignStyle((prev) => ({
+                            ...prev,
+                            accentColor: e.target.value,
+                          }))
+                        }
+                        className="h-8 w-10 cursor-pointer rounded border border-border bg-card p-1"
+                      />
+                      <span className="font-mono text-[11px] text-foreground">{designStyle.accentColor}</span>
+                    </div>
+                  </label>
+
+                  <label className="flex flex-col gap-1 text-muted-foreground">
+                    Roundness
+                    <input
+                      type="range"
+                      min={0}
+                      max={10}
+                      step={1}
+                      value={designStyle.roundness}
+                      onChange={(e: any) =>
+                        setDesignStyle((prev) => ({
+                          ...prev,
+                          roundness: Number(e.target.value),
+                        }))
+                      }
+                      className="h-8"
+                    />
+                    <span className="text-[11px] text-foreground/75">{designStyle.roundness} / 10</span>
+                  </label>
+
+                  <label className="flex flex-col gap-1 text-muted-foreground">
+                    Border
+                    <select
+                      value={designStyle.borderStyle}
+                      onChange={(e: any) =>
+                        setDesignStyle((prev) => ({
+                          ...prev,
+                          borderStyle: e.target.value,
+                        }))
+                      }
+                      className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                    >
+                      <option value="solid">Solid</option>
+                      <option value="double">Double</option>
+                      <option value="etched">Etched</option>
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1 text-muted-foreground">
+                    Edge Add-on
+                    <select
+                      value={designStyle.edgeAddon}
+                      onChange={(e: any) =>
+                        setDesignStyle((prev) => ({
+                          ...prev,
+                          edgeAddon: e.target.value,
+                        }))
+                      }
+                      className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                    >
+                      <option value="none">None</option>
+                      <option value="chip-legs">Chip Legs</option>
+                    </select>
+                  </label>
+
+                  <label className="col-span-2 flex flex-col gap-1 text-muted-foreground">
+                    Surface
+                    <select
+                      value={designStyle.surfaceStyle}
+                      onChange={(e: any) =>
+                        setDesignStyle((prev) => ({
+                          ...prev,
+                          surfaceStyle: e.target.value,
+                        }))
+                      }
+                      className="rounded border border-border bg-card px-2 py-1 text-foreground"
+                    >
+                      <option value="flat">Flat</option>
+                      <option value="brushed">Brushed</option>
+                      <option value="gradient">Gradient</option>
+                      <option value="matte">Matte</option>
+                      <option value="glass">Glass</option>
+                      <option value="carbon">Carbon</option>
+                    </select>
+                  </label>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="rounded-lg border border-border/70 bg-secondary/30 p-3">
+              <p className="mb-2 text-[13px] font-medium text-foreground">Piece Preview</p>
+              <div className="rounded-md border border-border/60 bg-background/80 p-4">
+                <div className="flex items-center justify-center">
+                  <LogicNode node={designPreviewNode} cellPx={22} portPx={8} />
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-[11px] text-foreground/80">
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Name:</span> {designPreviewNode.label}
+                  </div>
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Inputs:</span> {designPreviewInputs}
+                  </div>
+                  <div className="rounded border border-border/50 bg-card px-2 py-1">
+                    <span className="text-foreground/60">Outputs:</span> {designPreviewOutputs}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDesignDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmDesign} disabled={updateArsenalPieceMutation.isPending}>
+              {updateArsenalPieceMutation.isPending ? 'Saving...' : 'Save Design'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -457,6 +770,7 @@ function CircuitPreview({ piece }: { piece: ArsenalPiece }) {
           cost: arsenalPiece.cost,
           size,
           ports,
+          visualStyle: extractVisualStyleFromComponentLike(arsenalPiece),
         };
       } else {
         // Fallback for unknown components

--- a/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
@@ -30,6 +30,7 @@ import {
   type PlacedGridComponent,
   type SelectedComponentState,
 } from "@/app/app/puzzles/[id]/_components/workstation-grid";
+import { extractVisualStyleFromComponentLike } from "@/app/app/puzzles/[id]/_components/piece-visual-style";
 import type { Wire } from "@/types/api";
 import { cn } from "@/utils/cn";
 import { PageTourLauncher } from "@/components/ui/page-tour-launcher";
@@ -546,6 +547,7 @@ export default function CreatePuzzleForm() {
     
     const result = filtered.map(piece => {
       const pieceMeta = piece as any;
+      const visualStyle = extractVisualStyleFromComponentLike(piece);
       // Parse structure to extract num_inputs and num_outputs
       let num_inputs = 1;
       let num_outputs = 1;
@@ -575,6 +577,7 @@ export default function CreatePuzzleForm() {
         structure_json: pieceMeta.structure_json,
         isArsenal: true,
         basic_gates: piece.basic_gates,
+        visual_style: visualStyle,
       };
     });
     
@@ -1054,6 +1057,7 @@ export default function CreatePuzzleForm() {
         cost: piece.cost,
         size: { w: 3, h: Math.max(piece.num_inputs, piece.num_outputs) },
         ports: ports,
+        visualStyle: extractVisualStyleFromComponentLike(piece),
       };
     }
 
@@ -1086,6 +1090,7 @@ export default function CreatePuzzleForm() {
         cost: piece.cost,
         size: { w: 3, h: Math.max(piece.num_inputs, piece.num_outputs) },
         ports: ports,
+        visualStyle: extractVisualStyleFromComponentLike(piece),
       };
     }
 

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/node.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/node.tsx
@@ -8,10 +8,32 @@ export type LogicNodePort = {
   offset: { row: number; col: number };
 };
 
+export type LogicNodeBorderStyle = 'solid' | 'double' | 'etched';
+
+export type LogicNodeEdgeAddon = 'none' | 'chip-legs';
+
+export type LogicNodeSurfaceStyle =
+  | 'flat'
+  | 'brushed'
+  | 'gradient'
+  | 'matte'
+  | 'glass'
+  | 'carbon';
+
+export type LogicNodeVisualStyle = {
+  accentColor?: string;
+  // Bounded in UI and renderer to keep shapes readable across gate sizes.
+  roundness?: number;
+  borderStyle?: LogicNodeBorderStyle;
+  edgeAddon?: LogicNodeEdgeAddon;
+  surfaceStyle?: LogicNodeSurfaceStyle;
+};
+
 export type LogicNodeDefinition = {
   label: string;
   size: { w: number; h: number };
   ports: LogicNodePort[];
+  visualStyle?: LogicNodeVisualStyle;
 };
 
 type LogicNodeProps = HTMLAttributes<HTMLDivElement> & {
@@ -22,6 +44,152 @@ type LogicNodeProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 const BASIC_GATES = ['AND', 'OR', 'NOT', 'NAND', 'NOR', 'XOR', 'XNOR'];
+
+const DEFAULT_VISUAL_STYLE: Required<LogicNodeVisualStyle> = {
+  accentColor: '#3b82f6',
+  roundness: 4,
+  borderStyle: 'solid',
+  edgeAddon: 'none',
+  surfaceStyle: 'gradient',
+};
+
+const LEGACY_PRESET_OVERRIDES: Record<string, Partial<Required<LogicNodeVisualStyle>>> = {
+  'clean-lab': {
+    accentColor: '#3b82f6',
+    roundness: 4,
+    borderStyle: 'solid',
+    edgeAddon: 'none',
+    surfaceStyle: 'gradient',
+  },
+  'retro-chip': {
+    accentColor: '#f59e0b',
+    roundness: 2,
+    borderStyle: 'double',
+    edgeAddon: 'chip-legs',
+    surfaceStyle: 'brushed',
+  },
+  blueprint: {
+    accentColor: '#22d3ee',
+    roundness: 2,
+    borderStyle: 'etched',
+    edgeAddon: 'none',
+    surfaceStyle: 'flat',
+  },
+  playful: {
+    accentColor: '#10b981',
+    roundness: 8,
+    borderStyle: 'solid',
+    edgeAddon: 'none',
+    surfaceStyle: 'gradient',
+  },
+};
+
+const BORDER_STYLES: LogicNodeBorderStyle[] = ['solid', 'double', 'etched'];
+const EDGE_ADDONS: LogicNodeEdgeAddon[] = ['none', 'chip-legs'];
+const SURFACE_STYLES: LogicNodeSurfaceStyle[] = [
+  'flat',
+  'brushed',
+  'gradient',
+  'matte',
+  'glass',
+  'carbon',
+];
+
+const clampRoundness = (value: number) => Math.max(0, Math.min(10, Math.round(value)));
+
+const isHexColor = (value: string) => /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value);
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const normalized = hex.replace('#', '');
+  const full = normalized.length === 3
+    ? normalized.split('').map((c) => c + c).join('')
+    : normalized;
+
+  const r = Number.parseInt(full.slice(0, 2), 16);
+  const g = Number.parseInt(full.slice(2, 4), 16);
+  const b = Number.parseInt(full.slice(4, 6), 16);
+
+  if ([r, g, b].some((n) => Number.isNaN(n))) {
+    return `rgba(59,130,246,${alpha})`;
+  }
+
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const resolveVisualStyle = (
+  visualStyle?: LogicNodeVisualStyle,
+): Required<LogicNodeVisualStyle> => {
+  const legacyPreset = (visualStyle as { preset?: string } | undefined)?.preset;
+  const base = {
+    ...DEFAULT_VISUAL_STYLE,
+    ...(legacyPreset && LEGACY_PRESET_OVERRIDES[legacyPreset]
+      ? LEGACY_PRESET_OVERRIDES[legacyPreset]
+      : {}),
+  };
+
+  const accentColor = visualStyle?.accentColor;
+  const legacyCornerStyle = (visualStyle as { cornerStyle?: string } | undefined)?.cornerStyle;
+  const legacyBorderStyle = (visualStyle as { borderStyle?: string } | undefined)?.borderStyle;
+  const legacyEdgeAddonRaw = (
+    visualStyle as { edgeAddon?: string; edge_addon?: string } | undefined
+  )?.edgeAddon;
+  const legacyEdgeAddonAltRaw = (
+    visualStyle as { edgeAddon?: string; edge_addon?: string } | undefined
+  )?.edge_addon;
+
+  const legacyRoundness =
+    legacyCornerStyle === 'sharp'
+      ? 0
+      : legacyCornerStyle === 'capsule'
+        ? 10
+        : legacyCornerStyle === 'rounded'
+          ? 4
+          : undefined;
+
+  const requestedRoundness =
+    typeof visualStyle?.roundness === 'number'
+      ? visualStyle.roundness
+      : legacyRoundness;
+
+  const borderStyle =
+    typeof visualStyle?.borderStyle === 'string'
+      ? visualStyle.borderStyle
+      : undefined;
+
+  const resolvedBorderStyle =
+    borderStyle && BORDER_STYLES.includes(borderStyle as LogicNodeBorderStyle)
+      ? (borderStyle as LogicNodeBorderStyle)
+      : legacyBorderStyle === 'chip'
+        ? 'double'
+        : base.borderStyle;
+
+  const edgeAddonRaw = visualStyle?.edgeAddon ?? legacyEdgeAddonRaw ?? legacyEdgeAddonAltRaw;
+  const resolvedEdgeAddon =
+    edgeAddonRaw === 'chip'
+      ? 'chip-legs'
+      : edgeAddonRaw && EDGE_ADDONS.includes(edgeAddonRaw as LogicNodeEdgeAddon)
+        ? (edgeAddonRaw as LogicNodeEdgeAddon)
+        : legacyBorderStyle === 'chip'
+          ? 'chip-legs'
+          : base.edgeAddon;
+
+  const surfaceStyle = visualStyle?.surfaceStyle;
+  const resolvedSurfaceStyle =
+    surfaceStyle && SURFACE_STYLES.includes(surfaceStyle)
+      ? surfaceStyle
+      : base.surfaceStyle;
+
+  return {
+    accentColor: accentColor && isHexColor(accentColor) ? accentColor : base.accentColor,
+    roundness:
+      typeof requestedRoundness === 'number'
+        ? clampRoundness(requestedRoundness)
+        : base.roundness,
+    borderStyle: resolvedBorderStyle,
+    edgeAddon: resolvedEdgeAddon,
+    surfaceStyle: resolvedSurfaceStyle,
+  };
+};
 
 /**
  * Generate SVG schematic symbol for a logic gate.
@@ -188,6 +356,80 @@ export const LogicNode = ({
     ? node.label.slice(gateType.length + 1)
     : '';
 
+  const rawVisualStyle = node.visualStyle as
+    | (LogicNodeVisualStyle & {
+        preset?: string;
+        cornerStyle?: string;
+        borderStyle?: string;
+      })
+    | undefined;
+
+  const hasCustomVisualStyle = Boolean(
+    rawVisualStyle &&
+    (
+      rawVisualStyle.preset ||
+      rawVisualStyle.cornerStyle ||
+      rawVisualStyle.accentColor ||
+      typeof rawVisualStyle.roundness === 'number' ||
+      rawVisualStyle.borderStyle ||
+      rawVisualStyle.edgeAddon ||
+      rawVisualStyle.surfaceStyle
+    ),
+  );
+  const resolvedVisualStyle = hasCustomVisualStyle
+    ? resolveVisualStyle(node.visualStyle)
+    : null;
+  const accentColorStrong = resolvedVisualStyle
+    ? hexToRgba(resolvedVisualStyle.accentColor, 0.48)
+    : '';
+  const accentColorSoft = resolvedVisualStyle
+    ? hexToRgba(resolvedVisualStyle.accentColor, 0.22)
+    : '';
+  const accentColorGlow = resolvedVisualStyle
+    ? hexToRgba(resolvedVisualStyle.accentColor, 0.28)
+    : '';
+
+  const shellRoundness = resolvedVisualStyle?.roundness ?? DEFAULT_VISUAL_STYLE.roundness;
+  const shellRadiusPx = 2 + shellRoundness * 1.2;
+  const shellRadius = `${shellRadiusPx}px`;
+
+  const shellSurfaceClass = resolvedVisualStyle
+    ? resolvedVisualStyle.surfaceStyle === 'gradient'
+      ? 'bg-gradient-to-b from-card via-card to-muted/30'
+      : resolvedVisualStyle.surfaceStyle === 'matte'
+        ? 'bg-muted/35'
+        : resolvedVisualStyle.surfaceStyle === 'glass'
+          ? 'bg-background/75'
+          : 'bg-card'
+    : 'bg-gradient-to-b from-card via-card to-muted/30';
+
+  const shellBorderWidthClass =
+    resolvedVisualStyle?.borderStyle === 'double' ? 'border-2' : 'border';
+
+  const brushedPattern =
+    'repeating-linear-gradient(135deg, rgba(255,255,255,0.07) 0px, rgba(255,255,255,0.07) 2px, rgba(0,0,0,0) 2px, rgba(0,0,0,0) 6px)';
+  const carbonPattern =
+    'repeating-linear-gradient(45deg, rgba(255,255,255,0.06) 0px, rgba(255,255,255,0.06) 2px, rgba(0,0,0,0) 2px, rgba(0,0,0,0) 6px), repeating-linear-gradient(-45deg, rgba(0,0,0,0.08) 0px, rgba(0,0,0,0.08) 2px, rgba(0,0,0,0) 2px, rgba(0,0,0,0) 6px)';
+  const mattePattern =
+    'radial-gradient(circle at 2px 2px, rgba(255,255,255,0.08) 0.6px, rgba(0,0,0,0) 0.8px)';
+  const showChipLegs = resolvedVisualStyle?.edgeAddon === 'chip-legs';
+  const chipLegsHorizontal = `repeating-linear-gradient(90deg,
+    rgba(0,0,0,0) 0px,
+    rgba(0,0,0,0) 4px,
+    ${accentColorStrong} 4px,
+    ${accentColorStrong} 7px,
+    rgba(0,0,0,0) 7px,
+    rgba(0,0,0,0) 11px
+  )`;
+  const chipLegsVertical = `repeating-linear-gradient(180deg,
+    rgba(0,0,0,0) 0px,
+    rgba(0,0,0,0) 4px,
+    ${accentColorStrong} 4px,
+    ${accentColorStrong} 7px,
+    rgba(0,0,0,0) 7px,
+    rgba(0,0,0,0) 11px
+  )`;
+
   return (
     <div
       className={cn(
@@ -228,7 +470,111 @@ export const LogicNode = ({
         </div>
       ) : (
         <div className="pointer-events-none absolute inset-0">
-          <div className="absolute inset-[1px] rounded-[5px] border border-border/70 bg-gradient-to-b from-card via-card to-muted/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]" />
+          {showChipLegs ? (
+            <>
+              <div
+                className="absolute inset-x-[6px] -top-[2px] h-[2px] opacity-95"
+                style={{ backgroundImage: chipLegsHorizontal }}
+              />
+              <div
+                className="absolute inset-x-[6px] -bottom-[2px] h-[2px] opacity-95"
+                style={{ backgroundImage: chipLegsHorizontal }}
+              />
+              <div
+                className="absolute inset-y-[6px] -left-[2px] w-[2px] opacity-90"
+                style={{ backgroundImage: chipLegsVertical }}
+              />
+              <div
+                className="absolute inset-y-[6px] -right-[2px] w-[2px] opacity-90"
+                style={{ backgroundImage: chipLegsVertical }}
+              />
+            </>
+          ) : null}
+
+          {resolvedVisualStyle ? (
+            <div
+              className={cn(
+                'absolute inset-[1px] overflow-hidden',
+                shellBorderWidthClass,
+                shellSurfaceClass,
+                resolvedVisualStyle.borderStyle === 'etched'
+                  ? 'shadow-[inset_0_1px_0_rgba(255,255,255,0.28),inset_0_-1px_0_rgba(0,0,0,0.2)]'
+                  : 'shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+              )}
+              style={{
+                borderRadius: shellRadius,
+                borderColor: accentColorStrong,
+                boxShadow:
+                  resolvedVisualStyle.borderStyle === 'double'
+                    ? `inset 0 1px 0 rgba(255,255,255,0.14), 0 0 0 1px ${accentColorSoft}`
+                    : undefined,
+              }}
+            >
+              {resolvedVisualStyle.surfaceStyle === 'brushed' ? (
+                <div
+                  className="absolute inset-0"
+                  style={{
+                    backgroundImage: brushedPattern,
+                    opacity: 0.55,
+                  }}
+                />
+              ) : null}
+              {resolvedVisualStyle.surfaceStyle === 'carbon' ? (
+                <div
+                  className="absolute inset-0"
+                  style={{
+                    backgroundImage: carbonPattern,
+                    opacity: 0.55,
+                  }}
+                />
+              ) : null}
+              {resolvedVisualStyle.surfaceStyle === 'matte' ? (
+                <div
+                  className="absolute inset-0"
+                  style={{
+                    backgroundImage: mattePattern,
+                    backgroundSize: '4px 4px',
+                    opacity: 0.35,
+                  }}
+                />
+              ) : null}
+              {resolvedVisualStyle.surfaceStyle === 'gradient' ? (
+                <div
+                  className="absolute inset-0"
+                  style={{
+                    background: `linear-gradient(180deg, ${accentColorSoft} 0%, rgba(0,0,0,0) 60%)`,
+                  }}
+                />
+              ) : null}
+              {resolvedVisualStyle.surfaceStyle === 'glass' ? (
+                <>
+                  <div
+                    className="absolute inset-0"
+                    style={{
+                      background: 'linear-gradient(180deg, rgba(255,255,255,0.28) 0%, rgba(255,255,255,0.05) 32%, rgba(0,0,0,0.04) 100%)',
+                    }}
+                  />
+                  <div
+                    className="absolute -left-[20%] top-[8%] h-[35%] w-[70%] -rotate-12"
+                    style={{
+                      background: 'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.35) 60%, rgba(255,255,255,0) 100%)',
+                      opacity: 0.5,
+                    }}
+                  />
+                </>
+              ) : null}
+              <div
+                className="absolute left-0 top-0 h-full w-[3px]"
+                style={{
+                  borderTopLeftRadius: shellRadius,
+                  borderBottomLeftRadius: shellRadius,
+                  background: `linear-gradient(180deg, ${accentColorStrong} 0%, ${accentColorGlow} 100%)`,
+                }}
+              />
+            </div>
+          ) : (
+            <div className="absolute inset-[1px] rounded-[5px] border border-border/70 bg-gradient-to-b from-card via-card to-muted/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]" />
+          )}
           <div className="absolute inset-x-1 inset-y-0 flex items-center justify-center">
             <span className="max-w-full truncate px-2 text-[9px] font-semibold tracking-wide text-foreground">
               {node.label}

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/node.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/node.tsx
@@ -150,6 +150,22 @@ const getGateSVG = (label: string) => {
         </svg>
       );
     }
+    case 'DFF': {
+      // 3x1 gate: D flip-flop symbol with clock notch and Q output
+      return (
+        <svg viewBox="0 0 54 18" className="w-full h-full">
+          {/* Body */}
+          <rect x="10" y="1.5" width="26" height="15" rx="2.5" {...commonProps} />
+          {/* Clock notch */}
+          <path d="M 10 9 L 14 6.3 L 14 11.7 Z" {...commonProps} />
+          {/* Output lead */}
+          <line x1="36" y1="9" x2="45" y2="9" {...commonProps} />
+          {/* Labels */}
+          <text x="18" y="11" fill="currentColor" fontSize="5.5" fontWeight="700">D</text>
+          <text x="28" y="11" fill="currentColor" fontSize="5.5" fontWeight="700">Q</text>
+        </svg>
+      );
+    }
     default:
       return null;
   }
@@ -167,6 +183,10 @@ export const LogicNode = ({
   // Extract gate type (e.g., "AND" from "AND 1" or just "AND")
   const gateType = node.label.split(' ')[0];
   const isBasicGate = BASIC_GATES.includes(gateType);
+  const isDffGate = gateType === 'DFF';
+  const gateInstanceLabel = node.label.startsWith(`${gateType} `)
+    ? node.label.slice(gateType.length + 1)
+    : '';
 
   return (
     <div
@@ -193,14 +213,27 @@ export const LogicNode = ({
             gateType === 'XNOR' && 'translate-x-[2px]', 
             gateType === 'NOT' && 'absolute left-1/4 top-1/2 -translate-y-1/2'
           )}>
-            {node.label.includes(' ') ? node.label.split(' ')[1] : ''}
+            {gateInstanceLabel}
+          </span>
+        </div>
+      ) : isDffGate ? (
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute inset-[1px] rounded-sm bg-gradient-to-b from-card to-card/70" />
+          <div className="absolute inset-0">
+            {getGateSVG('DFF')}
+          </div>
+          <span className="absolute right-1 top-0.5 select-none rounded border border-border/60 bg-background/80 px-1 text-[6px] font-semibold leading-none text-muted-foreground">
+            {gateInstanceLabel}
           </span>
         </div>
       ) : (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <span className="select-none text-[9px] font-semibold tracking-wide text-foreground">
-            {node.label}
-          </span>
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute inset-[1px] rounded-[5px] border border-border/70 bg-gradient-to-b from-card via-card to-muted/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]" />
+          <div className="absolute inset-x-1 inset-y-0 flex items-center justify-center">
+            <span className="max-w-full truncate px-2 text-[9px] font-semibold tracking-wide text-foreground">
+              {node.label}
+            </span>
+          </div>
         </div>
       )}
 

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/piece-visual-style.ts
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/piece-visual-style.ts
@@ -1,0 +1,179 @@
+import type { LogicNodeVisualStyle } from './node';
+
+const LEGACY_PRESETS = new Set(['clean-lab', 'retro-chip', 'blueprint', 'playful']);
+const LEGACY_CORNER_STYLES = new Set(['rounded', 'sharp', 'capsule']);
+const BORDER_STYLES = new Set(['solid', 'double', 'etched']);
+const EDGE_ADDONS = new Set(['none', 'chip-legs', 'chip']);
+const SURFACE_STYLES = new Set(['flat', 'brushed', 'gradient', 'matte', 'glass', 'carbon']);
+
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const MIN_ROUNDNESS = 0;
+const MAX_ROUNDNESS = 10;
+
+const LEGACY_PRESET_DEFAULTS: Record<string, Required<LogicNodeVisualStyle>> = {
+  'clean-lab': {
+    accentColor: '#3b82f6',
+    roundness: 4,
+    borderStyle: 'solid',
+    edgeAddon: 'none',
+    surfaceStyle: 'gradient',
+  },
+  'retro-chip': {
+    accentColor: '#f59e0b',
+    roundness: 2,
+    borderStyle: 'double',
+    edgeAddon: 'chip-legs',
+    surfaceStyle: 'brushed',
+  },
+  blueprint: {
+    accentColor: '#22d3ee',
+    roundness: 2,
+    borderStyle: 'etched',
+    edgeAddon: 'none',
+    surfaceStyle: 'flat',
+  },
+  playful: {
+    accentColor: '#10b981',
+    roundness: 8,
+    borderStyle: 'solid',
+    edgeAddon: 'none',
+    surfaceStyle: 'gradient',
+  },
+};
+
+export const DEFAULT_PIECE_VISUAL_STYLE: Required<LogicNodeVisualStyle> = {
+  accentColor: '#3b82f6',
+  roundness: 4,
+  borderStyle: 'solid',
+  edgeAddon: 'none',
+  surfaceStyle: 'gradient',
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+};
+
+const asString = (value: unknown): string | undefined => {
+  return typeof value === 'string' ? value : undefined;
+};
+
+const asNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+const clampRoundness = (value: number) =>
+  Math.max(MIN_ROUNDNESS, Math.min(MAX_ROUNDNESS, Math.round(value)));
+
+const resolveLegacyCornerToRoundness = (cornerStyle: string): number | undefined => {
+  if (cornerStyle === 'sharp') return 0;
+  if (cornerStyle === 'capsule') return MAX_ROUNDNESS;
+  if (cornerStyle === 'rounded') return 4;
+  return undefined;
+};
+
+export const normalizeLogicNodeVisualStyle = (
+  raw: unknown,
+): LogicNodeVisualStyle | undefined => {
+  const rec = asRecord(raw);
+  if (!rec) return undefined;
+
+  const presetRaw = asString(rec.preset);
+  const accentRaw = asString(rec.accentColor ?? rec.accent_color);
+  const roundnessRaw = asNumber(rec.roundness ?? rec.cornerRadius ?? rec.corner_radius);
+  const legacyCornerRaw = asString(rec.cornerStyle ?? rec.corner_style);
+  const borderRaw = asString(rec.borderStyle ?? rec.border_style);
+  const edgeAddonRaw = asString(rec.edgeAddon ?? rec.edge_addon);
+  const surfaceRaw = asString(rec.surfaceStyle ?? rec.surface_style);
+
+  const style: LogicNodeVisualStyle = {
+    ...(presetRaw && LEGACY_PRESETS.has(presetRaw)
+      ? LEGACY_PRESET_DEFAULTS[presetRaw]
+      : {}),
+  };
+
+  if (accentRaw && HEX_COLOR_RE.test(accentRaw)) {
+    style.accentColor = accentRaw;
+  }
+  if (typeof roundnessRaw === 'number') {
+    style.roundness = clampRoundness(roundnessRaw);
+  } else if (legacyCornerRaw && LEGACY_CORNER_STYLES.has(legacyCornerRaw)) {
+    const legacyRoundness = resolveLegacyCornerToRoundness(legacyCornerRaw);
+    if (typeof legacyRoundness === 'number') {
+      style.roundness = legacyRoundness;
+    }
+  }
+  if (borderRaw === 'chip') {
+    style.edgeAddon = 'chip-legs';
+    style.borderStyle = style.borderStyle ?? 'double';
+  } else if (borderRaw && BORDER_STYLES.has(borderRaw)) {
+    style.borderStyle = borderRaw as LogicNodeVisualStyle['borderStyle'];
+  }
+
+  if (edgeAddonRaw && EDGE_ADDONS.has(edgeAddonRaw)) {
+    style.edgeAddon = edgeAddonRaw === 'chip' ? 'chip-legs' : (edgeAddonRaw as LogicNodeVisualStyle['edgeAddon']);
+  }
+
+  if (surfaceRaw && SURFACE_STYLES.has(surfaceRaw)) {
+    style.surfaceStyle = surfaceRaw as LogicNodeVisualStyle['surfaceStyle'];
+  }
+
+  if (
+    style.accentColor ||
+    typeof style.roundness === 'number' ||
+    style.borderStyle ||
+    style.edgeAddon ||
+    style.surfaceStyle
+  ) {
+    return style;
+  }
+
+  return undefined;
+};
+
+export const extractVisualStyleFromStructureJson = (
+  structureJson: unknown,
+): LogicNodeVisualStyle | undefined => {
+  if (typeof structureJson !== 'string' || !structureJson.trim()) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(structureJson);
+    const rec = asRecord(parsed);
+    if (!rec) return undefined;
+
+    return (
+      normalizeLogicNodeVisualStyle(rec.visualStyle) ??
+      normalizeLogicNodeVisualStyle(rec.visual_style)
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+export const extractVisualStyleFromComponentLike = (
+  component: unknown,
+): LogicNodeVisualStyle | undefined => {
+  const rec = asRecord(component);
+  if (!rec) return undefined;
+
+  const direct =
+    normalizeLogicNodeVisualStyle(rec.visualStyle) ??
+    normalizeLogicNodeVisualStyle(rec.visual_style);
+  if (direct) return direct;
+
+  const solutionRec = asRecord(rec.solution);
+  const fromSolution = solutionRec
+    ? normalizeLogicNodeVisualStyle(solutionRec.visualStyle) ??
+      normalizeLogicNodeVisualStyle(solutionRec.visual_style)
+    : undefined;
+  if (fromSolution) return fromSolution;
+
+  return extractVisualStyleFromStructureJson(rec.structure_json);
+};

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -35,6 +35,7 @@ import {
   type PlacedGridComponent,
   type SelectedComponentState,
 } from './workstation-grid';
+import { extractVisualStyleFromComponentLike } from './piece-visual-style';
 import { WorkstationMenu } from './workstation-menu';
 import { WorkstationTimer } from './workstation-timer';
 const CircuitDebugger = dynamic(
@@ -723,6 +724,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     for (const [id, def] of componentCatalog.entries()) {
       // Arsenal pieces have custom sizing: width 4, height = max(inputs, outputs)
       const isArsenal = (def as any).is_arsenal === true;
+      const visualStyle = extractVisualStyleFromComponentLike(def);
       
       let size: { w: number; h: number };
       let ports: ComponentDef['ports'];
@@ -783,6 +785,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
         cost: def.cost,
         size,
         ports,
+        visualStyle,
       });
     }
     return Object.fromEntries(Array.from(ui.entries())) as Record<

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -1989,6 +1989,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
           onDebuggerSequenceChange={onInlineSequenceChange}
           onInspectComponent={setInspectingPlacedId}
           arsenalComponentDisplayModes={arsenalComponentDisplayModes}
+          disableZoomPersistence
         />
         </div>
 
@@ -2293,6 +2294,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                   boardRows={puzzle.board_rows ?? 15}
                   boardCols={puzzle.board_cols ?? 30}
                   onInspectComponent={setInspectingSandboxPlacedId}
+                  disableZoomPersistence
                 />
               </div>
             </div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -87,6 +87,60 @@ const rotatedSize = (size: { w: number; h: number }, rotation: 0 | 90) => {
   return rotation === 0 ? size : { w: size.h, h: size.w };
 };
 
+const getVisualPortOffsets = (
+  def: ComponentDef,
+  rotation: 0 | 90,
+): Map<string, HoleCoord> => {
+  const result = new Map<string, HoleCoord>();
+
+  for (const port of def.ports) {
+    result.set(port.id, rotateOffset(port.offset, def.size, rotation));
+  }
+
+  const grouped: Record<PortKind, Array<{ port: PortDef; index: number }>> = {
+    input: [],
+    output: [],
+  };
+
+  def.ports.forEach((port, index) => {
+    grouped[port.kind].push({ port, index });
+  });
+
+  const inputCount = grouped.input.length;
+  const outputCount = grouped.output.length;
+
+  if (inputCount === outputCount || inputCount === 0 || outputCount === 0) {
+    return result;
+  }
+
+  const lowerKind: PortKind = inputCount < outputCount ? 'input' : 'output';
+  const lowerPorts = grouped[lowerKind].sort(
+    (a, b) =>
+      a.port.offset.row - b.port.offset.row ||
+      a.port.offset.col - b.port.offset.col ||
+      a.index - b.index,
+  );
+
+  const componentHeight = Math.max(1, def.size.h);
+
+  lowerPorts.forEach(({ port }, index) => {
+    const distributedRow =
+      -0.5 +
+      ((index + 1) * componentHeight) / (lowerPorts.length + 1);
+
+    result.set(
+      port.id,
+      rotateOffset(
+        { row: distributedRow, col: port.offset.col },
+        def.size,
+        rotation,
+      ),
+    );
+  });
+
+  return result;
+};
+
 const inRect = (
   p: HoleCoord,
   origin: HoleCoord,
@@ -707,6 +761,16 @@ export const WorkstationGrid = ({
     return map;
   }, [placed]);
 
+  const visualPortOffsetsByPlacedId = useMemo(() => {
+    const map = new Map<string, Map<string, HoleCoord>>();
+    for (const p of placed) {
+      const def = catalog[p.componentId];
+      if (!def) continue;
+      map.set(p.id, getVisualPortOffsets(def, p.rotation));
+    }
+    return map;
+  }, [catalog, placed]);
+
   const portIndexByPortId = useMemo(() => {
     const map = new Map<string, Map<string, number>>();
     for (const [id, def] of Object.entries(catalog)) {
@@ -923,6 +987,20 @@ export const WorkstationGrid = ({
     if (port.ownerId.startsWith('IO:OUT:')) {
       return ioLayout.outputs[port.ownerId] ?? { x: 0, y: 0 };
     }
+
+    const placedInst = placedById[port.ownerId];
+    const visualOffsets = visualPortOffsetsByPlacedId.get(port.ownerId);
+    const visualOffset = visualOffsets?.get(port.portId);
+
+    if (placedInst && visualOffset) {
+      const visualHole = {
+        row: placedInst.origin.row + visualOffset.row,
+        col: placedInst.origin.col + visualOffset.col,
+      };
+      const pt = worldToScreen(visualHole);
+      return { x: pt.x + (CELL_PX * zoom) / 2, y: pt.y + (CELL_PX * zoom) / 2 };
+    }
+
     if (!port.hole) return { x: 0, y: 0 };
     const pt = worldToScreen(port.hole);
     // center of hole
@@ -2033,11 +2111,18 @@ export const WorkstationGrid = ({
               ...def,
               label: totalCount > 1 ? `${def.label} ${componentNumber}` : def.label,
             };
+            const visualPortOffsets = visualPortOffsetsByPlacedId.get(p.id);
 
             return (
               <LogicNode
                 key={p.id}
-                node={defWithNumber}
+                node={{
+                  ...defWithNumber,
+                  ports: def.ports.map((port) => ({
+                    ...port,
+                    offset: visualPortOffsets?.get(port.id) ?? port.offset,
+                  })),
+                }}
                 className={cn(
                   'absolute transition-[box-shadow,transform,border-color] duration-300',
                   bootSequenceActive && 'animate-in fade-in zoom-in-75',
@@ -2252,8 +2337,9 @@ export const WorkstationGrid = ({
                 {/* Port markers */}
                 {def.ports.map((port, portIndex) => {
                   const rot = rotateOffset(port.offset, def.size, p.rotation);
-                  const pl = rot.col * CELL_PX;
-                  const pt = rot.row * CELL_PX;
+                  const visualOffset = visualPortOffsets?.get(port.id) ?? rot;
+                  const pl = visualOffset.col * CELL_PX;
+                  const pt = visualOffset.row * CELL_PX;
 
                   const effective: PortAddress = {
                     ownerId: p.id,

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -59,6 +59,7 @@ export type SelectedComponentState =
 const DEFAULT_GRID_ROWS = 15;
 const DEFAULT_GRID_COLS = 30;
 const CELL_PX = 18;
+const PUZZLE_IO_Y_OFFSET_PX = 20;
 
 // Visual Feature: Dynamic Wire Coloring
 const WIRE_COLORS = ['#3b82f6', '#ef4444', '#10b981', '#a855f7', '#f97316']; 
@@ -836,6 +837,33 @@ export const WorkstationGrid = ({
     return occ;
   }, [allPorts]);
 
+  const staleLogicalPortHoleKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    for (const p of placed) {
+      const def = catalog[p.componentId];
+      if (!def) continue;
+
+      const visualOffsets = visualPortOffsetsByPlacedId.get(p.id);
+      if (!visualOffsets) continue;
+
+      for (const port of def.ports) {
+        const logicalOffset = rotateOffset(port.offset, def.size, p.rotation);
+        const visualOffset = visualOffsets.get(port.id) ?? logicalOffset;
+
+        if (
+          visualOffset.row !== logicalOffset.row ||
+          visualOffset.col !== logicalOffset.col
+        ) {
+          const key = `r${p.origin.row + logicalOffset.row}c${p.origin.col + logicalOffset.col}`;
+          keys.add(key);
+        }
+      }
+    }
+
+    return keys;
+  }, [catalog, placed, visualPortOffsetsByPlacedId]);
+
   const worldToScreen = (hole: HoleCoord) => {
     const x = pan.x + hole.col * CELL_PX * zoom;
     const y = pan.y + hole.row * CELL_PX * zoom;
@@ -982,10 +1010,12 @@ export const WorkstationGrid = ({
 
   const getPortScreenPoint = (port: PortAddress, ioLayout: IOLayout) => {
     if (port.ownerId.startsWith('IO:IN:')) {
-      return ioLayout.inputs[port.ownerId] ?? { x: 0, y: 0 };
+      const pt = ioLayout.inputs[port.ownerId] ?? { x: 0, y: 0 };
+      return { x: pt.x, y: pt.y + PUZZLE_IO_Y_OFFSET_PX };
     }
     if (port.ownerId.startsWith('IO:OUT:')) {
-      return ioLayout.outputs[port.ownerId] ?? { x: 0, y: 0 };
+      const pt = ioLayout.outputs[port.ownerId] ?? { x: 0, y: 0 };
+      return { x: pt.x, y: pt.y + PUZZLE_IO_Y_OFFSET_PX };
     }
 
     const placedInst = placedById[port.ownerId];
@@ -2030,6 +2060,7 @@ export const WorkstationGrid = ({
                   const key = `r${r}c${c}`;
                   const occ = occupiedHoles.get(key);
                   const portOcc = occupiedPortHoles.get(key);
+                  const showPortOcc = Boolean(portOcc) && !staleLogicalPortHoleKeys.has(key);
 
                   const left = c * CELL_PX;
                   const top = r * CELL_PX;
@@ -2050,7 +2081,7 @@ export const WorkstationGrid = ({
                       <button
                         className={cn(
                           'rounded-full transition-colors',
-                          portOcc
+                          showPortOcc
                             ? 'size-3 bg-blue-400'
                             : occ
                               ? 'size-3 bg-muted-foreground/50'
@@ -2423,9 +2454,16 @@ export const WorkstationGrid = ({
                   ? selectedComponent.rotation
                   : 0;
               const size = rotatedSize(def.size, rotation);
+              const previewVisualPortOffsets = getVisualPortOffsets(def, rotation);
               return (
                 <LogicNode
-                  node={def}
+                  node={{
+                    ...def,
+                    ports: def.ports.map((port) => ({
+                      ...port,
+                      offset: previewVisualPortOffsets.get(port.id) ?? port.offset,
+                    })),
+                  }}
                   className="absolute z-40 opacity-50 ring-2 ring-blue-500 pointer-events-none"
                   style={{
                     left: dropPreview.col * 18,
@@ -2487,7 +2525,7 @@ export const WorkstationGrid = ({
                   style={{
                     left: pt.x,
                     top: pt.y,
-                    transform: 'translate(-100%, calc(-50% + 20px))',
+                    transform: `translate(-100%, calc(-50% + ${PUZZLE_IO_Y_OFFSET_PX}px))`,
                     animationDelay: `${Math.min(inputIndex, 8) * 110}ms`,
                     animationFillMode: 'both',
                   }}
@@ -2557,7 +2595,7 @@ export const WorkstationGrid = ({
                   style={{
                     left: pt.x,
                     top: pt.y,
-                    transform: 'translate(0%, calc(-50% + 20px))',
+                    transform: `translate(0%, calc(-50% + ${PUZZLE_IO_Y_OFFSET_PX}px))`,
                   }}
                   onPointerDown={(e) => {
                     e.stopPropagation();

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -146,6 +146,7 @@ export const WorkstationGrid = ({
   onInspectComponent,
   isEditMode = false,
   viewportClassName,
+  disableZoomPersistence = false,
 }: {
   puzzleId: string;
   inputs: string[];
@@ -178,6 +179,7 @@ export const WorkstationGrid = ({
   arsenalComponentDisplayModes?: Record<string, 'circuit' | 'description'>;
   isEditMode?: boolean;
   viewportClassName?: string;
+  disableZoomPersistence?: boolean;
 }) => {
   const gridRows = Math.max(1, boardRows ?? DEFAULT_GRID_ROWS);
   const gridCols = Math.max(1, boardCols ?? DEFAULT_GRID_COLS);
@@ -544,9 +546,12 @@ export const WorkstationGrid = ({
   const previousWireIdsRef = useRef<string[]>(wires.map((wire) => wire.id));
 
   const STORAGE_KEY = `escapecircuit.workstation.grid.v1:${puzzleId}`;
+  const shouldPersistZoom = !disableZoomPersistence;
 
   // Load/save view state.
   useEffect(() => {
+    if (!shouldPersistZoom) return;
+
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
       let hasSavedZoom = false;
@@ -576,15 +581,17 @@ export const WorkstationGrid = ({
       // ignore
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [STORAGE_KEY, gridCols, gridRows]);
+  }, [STORAGE_KEY, gridCols, gridRows, shouldPersistZoom]);
 
   useEffect(() => {
+    if (!shouldPersistZoom) return;
+
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ zoom }));
     } catch {
       // ignore
     }
-  }, [STORAGE_KEY, zoom]);
+  }, [STORAGE_KEY, zoom, shouldPersistZoom]);
 
   useEffect(() => {
     const previousPlacedIds = previousPlacedIdsRef.current;
@@ -654,7 +661,7 @@ export const WorkstationGrid = ({
       return { x: panX, y: panY };
     };
 
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = shouldPersistZoom ? window.localStorage.getItem(STORAGE_KEY) : null;
     if (!raw) {
       const fit = updateFit();
       setZoom(fit);
@@ -678,7 +685,7 @@ export const WorkstationGrid = ({
 
     return () => ro.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [STORAGE_KEY, gridCols, gridRows]);
+  }, [STORAGE_KEY, gridCols, gridRows, shouldPersistZoom]);
 
   const componentRects = useMemo(() => {
     return placed

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -15,7 +15,7 @@ import { useAudio } from '@/hooks/useAudio';
 import { useSettings } from '@/context/settings-context';
 import type { Wire } from '@/types/api';
 import { cn } from '@/utils/cn';
-import { LogicNode } from './node';
+import { LogicNode, type LogicNodeVisualStyle } from './node';
 
 export type HoleCoord = { row: number; col: number };
 
@@ -34,6 +34,7 @@ export type ComponentDef = {
   cost: number;
   size: { w: number; h: number };
   ports: PortDef[];
+  visualStyle?: LogicNodeVisualStyle;
 };
 
 export type PlacedGridComponent = {

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-menu.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-menu.tsx
@@ -2,8 +2,6 @@
 
 import { Info } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { flushSync } from 'react-dom';
-import { createRoot } from 'react-dom/client';
 
 import {
   Dialog,
@@ -298,33 +296,10 @@ const DraggableItem = ({
         <div
           draggable
           onDragStart={(e) => {
-            const dragPreview = document.createElement('div');
-            dragPreview.style.position = 'fixed';
-            dragPreview.style.left = '-10000px';
-            dragPreview.style.top = '-10000px';
-            dragPreview.style.pointerEvents = 'none';
-            dragPreview.style.zIndex = '-1';
-            document.body.appendChild(dragPreview);
-
-            const root = createRoot(dragPreview);
-            flushSync(() => {
-              root.render(
-                <LogicNode
-                  node={node}
-                  className="border-border opacity-80 shadow-xl"
-                />,
-              );
-            });
-
-            e.dataTransfer.setDragImage(
-              dragPreview,
-              (node.size.w * 18) / 2,
-              (node.size.h * 18) / 2,
-            );
-            window.requestAnimationFrame(() => {
-              root.unmount();
-              dragPreview.remove();
-            });
+            const transparentDragImage = document.createElement('canvas');
+            transparentDragImage.width = 1;
+            transparentDragImage.height = 1;
+            e.dataTransfer.setDragImage(transparentDragImage, 0, 0);
             e.dataTransfer.setData(
               'application/x-escapecircuit-component',
               component.id,

--- a/apps/nextjs-app/src/features/arsenal/api/index.ts
+++ b/apps/nextjs-app/src/features/arsenal/api/index.ts
@@ -3,15 +3,26 @@ import { queryOptions, useQuery, useMutation, useQueryClient } from '@tanstack/r
 import { api } from '@/lib/api-client';
 import { QueryConfig } from '@/lib/react-query';
 
+export interface ArsenalPieceVisualStyle {
+  accentColor?: string;
+  roundness?: number;
+  borderStyle?: 'solid' | 'double' | 'etched';
+  edgeAddon?: 'none' | 'chip-legs';
+  surfaceStyle?: 'flat' | 'brushed' | 'gradient' | 'matte' | 'glass' | 'carbon';
+}
+
 export interface ArsenalPiece {
   id: string | number;
   name: string;
   cost: number;
   is_arsenal: boolean;
+  num_inputs?: number;
+  num_outputs?: number;
   basic_gates: string; // JSON string
   truth_table: string; // JSON string
   structure_json: string;
   description?: string; // Description of the Arsenal piece
+  visual_style?: ArsenalPieceVisualStyle;
 }
 
 export interface SaveArsenalPiecePayload {
@@ -64,6 +75,21 @@ export const renameArsenalPiece = (
   return api.put(`/arsenal/${pieceId}`, { new_name: newName });
 };
 
+export const updateArsenalPiece = ({
+  pieceId,
+  newName,
+  visualStyle,
+}: {
+  pieceId: number;
+  newName?: string;
+  visualStyle?: ArsenalPieceVisualStyle | null;
+}): Promise<ArsenalPiece> => {
+  const payload: Record<string, unknown> = {};
+  if (typeof newName === 'string') payload.new_name = newName;
+  if (visualStyle !== undefined) payload.visual_style = visualStyle ?? {};
+  return api.put(`/arsenal/${pieceId}`, payload);
+};
+
 export const useDeleteArsenalPiece = () => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -79,6 +105,16 @@ export const useRenameArsenalPiece = () => {
   return useMutation({
     mutationFn: ({ pieceId, newName }: { pieceId: number; newName: string }) =>
       renameArsenalPiece(pieceId, newName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['arsenal'] });
+    },
+  });
+};
+
+export const useUpdateArsenalPiece = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateArsenalPiece,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['arsenal'] });
     },

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -199,6 +199,13 @@ export type CircuitComponent = {
   is_arsenal?: boolean;
   used_basic_types?: string[];  // Array of basic gate types used in the component
   solution?: Record<string, any>;  // Component's internal structure/implementation
+  visual_style?: {
+    accentColor?: string;
+    roundness?: number;
+    borderStyle?: 'solid' | 'double' | 'etched';
+    edgeAddon?: 'none' | 'chip-legs';
+    surfaceStyle?: 'flat' | 'brushed' | 'gradient' | 'matte' | 'glass' | 'carbon';
+  };
   hide_internal_structure?: boolean;  // Whether internal structure should be hidden from player
   description?: string;  // Component description shown in inspection dialog
 };

--- a/src/Backend/APILayer/ArsenalController.py
+++ b/src/Backend/APILayer/ArsenalController.py
@@ -19,8 +19,9 @@ class SaveArsenalPieceReq(BaseModel):
     used_arsenal_pieces: List[int] = []  # IDs of other arsenal pieces used as components
 
 
-class RenameArsenalPieceReq(BaseModel):
-    new_name: str
+class UpdateArsenalPieceReq(BaseModel):
+    new_name: Optional[str] = None
+    visual_style: Optional[Dict[str, Any]] = None
 
 
 class SimulateReq(BaseModel):
@@ -58,10 +59,15 @@ def build_arsenal_router(arsenal_service: ArsenalService, solving_service: Solvi
             raise HTTPException(status_code=code, detail=str(e))
 
     @router.put("/{piece_id}")
-    def rename_piece(piece_id: int, req: RenameArsenalPieceReq, token: str = Depends(verify_token)):
-        """Rename an arsenal piece"""
+    def update_piece(piece_id: int, req: UpdateArsenalPieceReq, token: str = Depends(verify_token)):
+        """Update an arsenal piece (name and/or visual style)."""
         try:
-            return arsenal_service.rename_arsenal_piece(token, piece_id, req.new_name)
+            return arsenal_service.update_arsenal_piece(
+                token,
+                piece_id,
+                new_name=req.new_name,
+                visual_style=req.visual_style,
+            )
         except ValidationError as e:
             code = 403 if "forbidden" in str(e).lower() else 400
             raise HTTPException(status_code=code, detail=str(e))

--- a/src/Backend/ServiceLayer/ArsenalService.py
+++ b/src/Backend/ServiceLayer/ArsenalService.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import re
 from typing import Any, Dict, List, Set
 
 from Backend.DomainLayer.Circuit import Circuit
@@ -38,6 +39,43 @@ class ArsenalService:
     MAX_OUTPUTS = ARSENAL_MAX_OUTPUTS
     MIN_INPUTS = ARSENAL_MIN_INPUTS
     MIN_OUTPUTS = ARSENAL_MIN_OUTPUTS
+    _LEGACY_CORNER_STYLES = {"rounded", "sharp", "capsule"}
+    _BORDER_STYLES = {"solid", "double", "etched"}
+    _EDGE_ADDONS = {"none", "chip-legs", "chip"}
+    _SURFACE_STYLES = {"flat", "brushed", "gradient", "matte", "glass", "carbon"}
+    _HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+    _MIN_ROUNDNESS = 0
+    _MAX_ROUNDNESS = 10
+    _LEGACY_PRESET_STYLES: Dict[str, Dict[str, Any]] = {
+        "clean-lab": {
+            "accentColor": "#3b82f6",
+            "roundness": 4,
+            "borderStyle": "solid",
+            "edgeAddon": "none",
+            "surfaceStyle": "gradient",
+        },
+        "retro-chip": {
+            "accentColor": "#f59e0b",
+            "roundness": 2,
+            "borderStyle": "double",
+            "edgeAddon": "chip-legs",
+            "surfaceStyle": "brushed",
+        },
+        "blueprint": {
+            "accentColor": "#22d3ee",
+            "roundness": 2,
+            "borderStyle": "etched",
+            "edgeAddon": "none",
+            "surfaceStyle": "flat",
+        },
+        "playful": {
+            "accentColor": "#10b981",
+            "roundness": 8,
+            "borderStyle": "solid",
+            "edgeAddon": "none",
+            "surfaceStyle": "gradient",
+        },
+    }
 
     def __init__(
         self,
@@ -183,13 +221,96 @@ class ArsenalService:
             raise ValidationError("not an arsenal piece")
         return piece.to_dict()
 
-    def rename_arsenal_piece(self, session_token: str, piece_id: int, new_name: str) -> dict:
-        """Rename an arsenal piece (must be unique per user)"""
+    def _normalize_visual_style(self, visual_style: Any) -> dict:
+        if visual_style is None:
+            return {}
+        if not isinstance(visual_style, dict):
+            raise ValidationError("visual_style must be an object")
+
+        normalized: Dict[str, Any] = {}
+
+        preset = visual_style.get("preset")
+        if preset is not None:
+            if not isinstance(preset, str):
+                raise ValidationError("visual_style.preset is invalid")
+            if preset in self._LEGACY_PRESET_STYLES:
+                normalized.update(self._LEGACY_PRESET_STYLES[preset])
+            else:
+                raise ValidationError("visual_style.preset is invalid")
+
+        accent = visual_style.get("accentColor", visual_style.get("accent_color"))
+        if accent is not None:
+            if not isinstance(accent, str) or not self._HEX_COLOR_RE.match(accent):
+                raise ValidationError("visual_style.accentColor must be a valid hex color")
+            normalized["accentColor"] = accent
+
+        roundness = visual_style.get(
+            "roundness",
+            visual_style.get("cornerRadius", visual_style.get("corner_radius")),
+        )
+        if roundness is not None:
+            if isinstance(roundness, bool) or not isinstance(roundness, (int, float)):
+                raise ValidationError("visual_style.roundness must be a number")
+
+            normalized_roundness = int(round(roundness))
+            if not (self._MIN_ROUNDNESS <= normalized_roundness <= self._MAX_ROUNDNESS):
+                raise ValidationError(
+                    f"visual_style.roundness must be between {self._MIN_ROUNDNESS} and {self._MAX_ROUNDNESS}"
+                )
+            normalized["roundness"] = normalized_roundness
+        else:
+            legacy_corner = visual_style.get("cornerStyle", visual_style.get("corner_style"))
+            if legacy_corner is not None:
+                if (
+                    not isinstance(legacy_corner, str)
+                    or legacy_corner not in self._LEGACY_CORNER_STYLES
+                ):
+                    raise ValidationError("visual_style.cornerStyle is invalid")
+
+                normalized["roundness"] = {
+                    "sharp": 0,
+                    "rounded": 4,
+                    "capsule": 10,
+                }[legacy_corner]
+
+        border = visual_style.get("borderStyle", visual_style.get("border_style"))
+        if border is not None:
+            if not isinstance(border, str):
+                raise ValidationError("visual_style.borderStyle is invalid")
+
+            if border == "chip":
+                normalized["edgeAddon"] = "chip-legs"
+                normalized["borderStyle"] = normalized.get("borderStyle", "double")
+            elif border in self._BORDER_STYLES:
+                normalized["borderStyle"] = border
+            else:
+                raise ValidationError("visual_style.borderStyle is invalid")
+
+        edge_addon = visual_style.get("edgeAddon", visual_style.get("edge_addon"))
+        if edge_addon is not None:
+            if not isinstance(edge_addon, str) or edge_addon not in self._EDGE_ADDONS:
+                raise ValidationError("visual_style.edgeAddon is invalid")
+
+            normalized["edgeAddon"] = "chip-legs" if edge_addon == "chip" else edge_addon
+
+        surface = visual_style.get("surfaceStyle", visual_style.get("surface_style"))
+        if surface is not None:
+            if not isinstance(surface, str) or surface not in self._SURFACE_STYLES:
+                raise ValidationError("visual_style.surfaceStyle is invalid")
+            normalized["surfaceStyle"] = surface
+
+        return normalized
+
+    def update_arsenal_piece(
+        self,
+        session_token: str,
+        piece_id: int,
+        new_name: str | None = None,
+        visual_style: Dict[str, Any] | None = None,
+    ) -> dict:
+        """Update an arsenal piece name and/or visual style."""
         user_id = self.auth.require_user_id(session_token)
-        new_name = (new_name or "").strip()
-        if not new_name:
-            raise ValidationError("new name is required")
-        
+
         piece = self.repo.get_by_id(piece_id)
         if not piece:
             raise ValidationError("arsenal piece not found")
@@ -197,14 +318,48 @@ class ArsenalService:
             raise ValidationError("forbidden")
         if not piece.is_arsenal:
             raise ValidationError("not an arsenal piece")
-        
-        piece.name = new_name
+
+        has_changes = False
+
+        if new_name is not None:
+            normalized_name = (new_name or "").strip()
+            if not normalized_name:
+                raise ValidationError("new name is required")
+            piece.name = normalized_name
+            has_changes = True
+
+        if visual_style is not None:
+            normalized_style = self._normalize_visual_style(visual_style)
+            try:
+                structure = json.loads(piece.structure_json) if piece.structure_json else {}
+            except (json.JSONDecodeError, ValueError):
+                structure = {}
+
+            if not isinstance(structure, dict):
+                structure = {}
+
+            if normalized_style:
+                structure["visualStyle"] = normalized_style
+            else:
+                structure.pop("visualStyle", None)
+                structure.pop("visual_style", None)
+
+            piece.structure_json = json.dumps(structure)
+            has_changes = True
+
+        if not has_changes:
+            raise ValidationError("no updates provided")
+
         try:
             self.repo.update(piece)
         except sqlite3.IntegrityError:
             raise ValidationError("arsenal piece name already exists for this user")
-        
+
         return piece.to_dict()
+
+    def rename_arsenal_piece(self, session_token: str, piece_id: int, new_name: str) -> dict:
+        """Rename an arsenal piece (must be unique per user)."""
+        return self.update_arsenal_piece(session_token, piece_id, new_name=new_name)
 
     def delete_arsenal_piece(self, session_token: str, piece_id: int) -> dict:
         """Delete an arsenal piece"""


### PR DESCRIPTION
This pull request introduces a customizable visual style system for user-created "arsenal pieces" in the app, allowing users to personalize the appearance of their logic components. The changes add a new UI for editing visual styles (such as color, roundness, border, etc.), update the data model and payloads to support saving and loading these styles, and provide real-time previews of the customizations. Additionally, users can now reset to the classic look or update the design of existing pieces.

The most important changes are:

**Custom Visual Style Support for Arsenal Pieces**
- Added a visual style editor UI to the arsenal piece creator (`page.tsx`) that lets users set accent color, roundness, border style, edge add-on, and surface style, with a live preview of the piece (`LogicNode`).
- The arsenal piece creation and update payloads now include the visual style in `structure_json` only if the user has customized it, ensuring backward compatibility. [[1]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1R425-R441) [[2]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1R457)

**Data Model and API Integration**
- Arsenal pieces now extract and pass visual style information throughout the UI and data layer, including when displaying, saving, and updating pieces. [[1]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1L84-R177) [[2]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1R310) [[3]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1R354) [[4]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R22-R37) [[5]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R64-R164)
- Added support for updating an existing piece’s visual style via a new "Design" dialog and the `useUpdateArsenalPiece` mutation. [[1]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R194-R209) [[2]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R230-R262) [[3]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R405-R411)

**Reusable Logic and Utilities**
- Introduced and reused a `buildPiecePreviewNode` utility for creating piece previews with the correct port layout and visual style, ensuring consistency between preview and actual component rendering. [[1]](diffhunk://#diff-bb06b18792528f3dbef4d9a49aec8c2dfa5426415f15d2092b3789740f4401b1R57-R111) [[2]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R64-R164) [[3]](diffhunk://#diff-410cbf27771f59ccc58f983918274002ee2dea76ecb85f287cf947cf988c76e3R299-R305)

**UI/UX Improvements**
- The arsenal page now features a "Design" button for each piece, opening a dialog to edit or reset its look, with instant preview and feedback on save.
- After saving or updating a piece, the visual style state is reset to the default to avoid leaking customizations between pieces.

These changes make arsenal pieces visually customizable, improving user engagement and ownership of their creations.