### PR TITLE
Add Rate button to puzzles list and fix rating metrics

### DIFF
--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-action-cluster.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-action-cluster.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { BookOpen, MessageSquare, MoreHorizontal, Trophy } from 'lucide-react';
+import {
+  BookOpen,
+  MessageSquare,
+  MoreHorizontal,
+  Star,
+  Trophy,
+} from 'lucide-react';
 
 import {
   DropdownMenu,
@@ -16,6 +22,7 @@ interface PuzzleActionClusterProps {
   onInstructions: () => void;
   onComment: () => void;
   onLeaderboard: () => void;
+  onRate: () => void;
   /** Not used here — Save lives in the parent (puzzle-card / puzzle-row). */
   onSave?: () => void;
   variant: 'card' | 'row';
@@ -24,13 +31,35 @@ interface PuzzleActionClusterProps {
 const iconButtonClass =
   'inline-flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
 
+const buildRateTooltip = (
+  canRate: boolean,
+  hasRated: boolean,
+  minAttemptSeconds?: number,
+) => {
+  if (!canRate) {
+    return minAttemptSeconds != null
+      ? `Solve or spend ${minAttemptSeconds} sec to rate`
+      : 'Solve or spend the configured minimum time to rate';
+  }
+  return hasRated ? 'Update your rating' : 'Rate this puzzle';
+};
+
 export const PuzzleActionCluster = ({
   puzzle,
   onInstructions,
   onComment,
   onLeaderboard,
+  onRate,
   variant,
 }: PuzzleActionClusterProps) => {
+  const canRate = !!puzzle.can_rate;
+  const hasRated = !!puzzle.user_rating;
+  const rateTooltip = buildRateTooltip(
+    canRate,
+    hasRated,
+    puzzle.rating_min_attempt_seconds,
+  );
+
   if (variant === 'card') {
     return (
       <div className="relative z-10 flex items-center gap-1">
@@ -62,6 +91,28 @@ export const PuzzleActionCluster = ({
           onClick={onLeaderboard}
         >
           <Trophy className="size-4" aria-hidden />
+        </button>
+
+        <button
+          type="button"
+          className={cn(
+            iconButtonClass,
+            'transition-transform',
+            canRate && 'hover:scale-110 hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-950/40 dark:hover:text-amber-400',
+            hasRated && 'text-amber-500',
+            !canRate && 'opacity-50 hover:bg-transparent hover:text-muted-foreground cursor-not-allowed',
+          )}
+          aria-label={hasRated ? 'Update rating' : 'Rate puzzle'}
+          aria-disabled={!canRate || undefined}
+          title={rateTooltip}
+          onClick={() => {
+            if (canRate) onRate();
+          }}
+        >
+          <Star
+            className={cn('size-4', hasRated && 'fill-amber-400 text-amber-500')}
+            aria-hidden
+          />
         </button>
       </div>
     );
@@ -106,6 +157,31 @@ export const PuzzleActionCluster = ({
           >
             <Trophy className="size-4" aria-hidden />
             Leaderboard
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            className={cn(
+              'flex cursor-pointer items-center gap-2',
+              !canRate && 'cursor-not-allowed opacity-50',
+            )}
+            disabled={!canRate}
+            title={rateTooltip}
+            onSelect={(e) => {
+              if (!canRate) {
+                e.preventDefault();
+                return;
+              }
+              onRate();
+            }}
+          >
+            <Star
+              className={cn(
+                'size-4',
+                hasRated ? 'fill-amber-400 text-amber-500' : '',
+              )}
+              aria-hidden
+            />
+            {hasRated ? 'Update Rating' : 'Rate Puzzle'}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-card.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-card.tsx
@@ -171,6 +171,7 @@ export const PuzzleCard = ({
           onInstructions={() => onInstructions(puzzle.id)}
           onComment={() => onComment(puzzle.id)}
           onLeaderboard={() => onLeaderboard(puzzle.id)}
+          onRate={() => onRate(puzzle.id)}
           variant="card"
         />
 

--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-row.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-row.tsx
@@ -151,6 +151,7 @@ export const PuzzleRow = ({
         onInstructions={() => onInstructions(puzzle.id)}
         onComment={() => onComment(puzzle.id)}
         onLeaderboard={() => onLeaderboard(puzzle.id)}
+        onRate={() => onRate(puzzle.id)}
         variant="row"
       />
 

--- a/apps/nextjs-app/src/middleware.ts
+++ b/apps/nextjs-app/src/middleware.ts
@@ -38,14 +38,14 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(appUrl);
   }
 
-  // If trying to access a protected route without a token, redirect to login
+  // If trying to access a protected route without a token, send the user to
+  // the public home page (not the login form). The login form, when reached
+  // through a redirect with a `redirectTo` query, has historically failed to
+  // submit cleanly; the home page has working "Log in" / "Register" CTAs.
   if (!isPublicRoute && !hasAuthToken) {
-    const loginUrl = new URL('/auth/login', request.url);
-    // Add redirectTo parameter to return user to original page after login
-    loginUrl.searchParams.set('redirectTo', pathname);
-    // Add reason parameter for notification
-    loginUrl.searchParams.set('reason', 'unauthorized');
-    return NextResponse.redirect(loginUrl);
+    const homeUrl = new URL('/', request.url);
+    homeUrl.searchParams.set('reason', 'unauthorized');
+    return NextResponse.redirect(homeUrl);
   }
 
   return NextResponse.next();

--- a/src/Backend/APILayer/PuzzleController.py
+++ b/src/Backend/APILayer/PuzzleController.py
@@ -298,6 +298,18 @@ def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingS
         if isinstance(rating_distribution, dict):
             puzzle_payload["rating_distribution"] = rating_distribution
 
+        # Frontend rating chips read from a nested `rating_metrics` object —
+        # mirror the flat fields into that shape so they render after a rating.
+        puzzle_payload["rating_metrics"] = {
+            "count": metrics.get("count", 0),
+            "avg_difficulty": metrics.get("avg_difficulty"),
+            "weighted_difficulty": metrics.get("weighted_difficulty"),
+            "avg_fun": metrics.get("avg_fun"),
+            "avg_clearness": metrics.get("avg_clearness"),
+            "rating_distribution": rating_distribution,
+            "experienced_metrics": metrics.get("experienced_metrics"),
+        }
+
 
     @router.get("")
     def browse(


### PR DESCRIPTION
## Summary
- Add a Star Rate button next to the Leaderboard in `PuzzleActionCluster` (card + row variants); filled amber once rated, disabled with tooltip otherwise.
- Backend now exposes aggregated metrics under the nested `rating_metrics` key on each puzzle payload so the existing rating chips actually render values after a rating.
- Middleware redirects unauthenticated users to `/` (home) instead of `/auth/login?redirectTo=...&reason=unauthorized`, which previously left the login form in a state that wouldn't submit.

## Test plan
- [ ] Open `/app/puzzles` — every puzzle card/row has a star button next to the trophy.
- [ ] Star is disabled with tooltip ("Solve or spend N sec to rate") on puzzles where `can_rate` is false.
- [ ] Click star on a ratable puzzle → existing rating dialog opens; submit difficulty/fun/clearness; chips on the card refresh to the submitted values; star turns amber and tooltip flips to "Update your rating".
- [ ] Visit any `/app/...` URL while logged out → land on `/`, then log in via the home page CTA.