### PR TITLE
url fixes

### DIFF
--- a/apps/nextjs-app/src/app/app/[...notFound]/page.tsx
+++ b/apps/nextjs-app/src/app/app/[...notFound]/page.tsx
@@ -1,16 +1,21 @@
 'use client';
 
+import Cookies from 'js-cookie';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { paths } from '@/config/paths';
+import { AUTH_TOKEN_COOKIE_NAME } from '@/utils/auth-constants';
 
 export default function NotFoundPage() {
   const router = useRouter();
 
   useEffect(() => {
-    // Redirect to puzzles page for any undefined route
-    router.replace(paths.app.puzzles.getHref());
+    const destination = Cookies.get(AUTH_TOKEN_COOKIE_NAME)
+      ? paths.app.puzzles.getHref()
+      : paths.home.getHref();
+
+    router.replace(destination);
   }, [router]);
 
   return null;

--- a/apps/nextjs-app/src/app/app/_components/access-gate.tsx
+++ b/apps/nextjs-app/src/app/app/_components/access-gate.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { Spinner } from '@/components/ui/spinner';
+import { paths } from '@/config/paths';
+import { useUser } from '@/lib/auth';
+
+const normalizeRole = (role: string | undefined) => (role || '').toLowerCase();
+
+type AccessGateProps = {
+  allowedRoles: Array<'admin' | 'creator'>;
+  children: ReactNode;
+};
+
+export const AccessGate = ({ allowedRoles, children }: AccessGateProps) => {
+  const user = useUser();
+  const router = useRouter();
+
+  const normalizedRole = normalizeRole(user.data?.role);
+  const hasAccess = !!user.data && allowedRoles.includes(normalizedRole as 'admin' | 'creator');
+
+  useEffect(() => {
+    if (user.status === 'success' && user.data && !hasAccess) {
+      router.replace(paths.app.puzzles.getHref());
+    }
+  }, [hasAccess, router, user.data, user.status]);
+
+  if (user.status !== 'success') {
+    return <Spinner className="m-4" />;
+  }
+
+  if (!user.data) {
+    return <Spinner className="m-4" />;
+  }
+
+  if (!hasAccess) {
+    return null;
+  }
+
+  return children;
+};

--- a/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
+++ b/apps/nextjs-app/src/app/app/_components/dashboard-layout.tsx
@@ -416,7 +416,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     },
     userRole === 'admin' && {
       name: 'Admin',
-      to: paths.app.users.getHref(),
+      to: paths.app.admin.root.getHref(),
       icon: Shield,
     },
   ].filter(Boolean) as SideNavigationItem[];

--- a/apps/nextjs-app/src/app/app/admin/layout.tsx
+++ b/apps/nextjs-app/src/app/app/admin/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AccessGate } from '../_components/access-gate';
+
+const AdminLayout = ({ children }: { children: ReactNode }) => {
+  return <AccessGate allowedRoles={['admin']}>{children}</AccessGate>;
+};
+
+export default AdminLayout;

--- a/apps/nextjs-app/src/app/app/admin/page.tsx
+++ b/apps/nextjs-app/src/app/app/admin/page.tsx
@@ -1,0 +1,19 @@
+import { AdminGuard } from '../users/_components/admin-guard';
+import { AdminPanel } from '../users/_components/admin-panel';
+
+export const metadata = {
+  title: 'Admin Panel',
+  description: 'Admin Panel - Manage users, puzzles, and view audit log',
+};
+
+const AdminPage = () => {
+  return (
+    <AdminGuard>
+      <div className="text-foreground">
+        <AdminPanel />
+      </div>
+    </AdminGuard>
+  );
+};
+
+export default AdminPage;

--- a/apps/nextjs-app/src/app/app/arsenal/creator/layout.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AccessGate } from '../../_components/access-gate';
+
+const CreatorArsenalLayout = ({ children }: { children: ReactNode }) => {
+  return <AccessGate allowedRoles={['creator', 'admin']}>{children}</AccessGate>;
+};
+
+export default CreatorArsenalLayout;

--- a/apps/nextjs-app/src/app/app/create-puzzle/layout.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AccessGate } from '../_components/access-gate';
+
+const CreatePuzzleLayout = ({ children }: { children: ReactNode }) => {
+  return <AccessGate allowedRoles={['creator', 'admin']}>{children}</AccessGate>;
+};
+
+export default CreatePuzzleLayout;

--- a/apps/nextjs-app/src/app/app/my-puzzles/_components/my-puzzles.tsx
+++ b/apps/nextjs-app/src/app/app/my-puzzles/_components/my-puzzles.tsx
@@ -236,7 +236,7 @@ export const MyPuzzles = ({ tutorialSlot }: MyPuzzlesProps = {}) => {
           </Link>
           {user.data?.role === 'admin' && (
             <Link
-              href="/app/admin/upload-puzzle"
+              href={paths.app.admin.uploadPuzzle.getHref()}
               className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-5 py-2.5 text-[13px] font-semibold text-foreground transition-colors hover:border-primary/40 hover:bg-secondary"
             >
               <Upload className="size-4" />

--- a/apps/nextjs-app/src/app/app/my-puzzles/layout.tsx
+++ b/apps/nextjs-app/src/app/app/my-puzzles/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AccessGate } from '../_components/access-gate';
+
+const MyPuzzlesLayout = ({ children }: { children: ReactNode }) => {
+  return <AccessGate allowedRoles={['creator', 'admin']}>{children}</AccessGate>;
+};
+
+export default MyPuzzlesLayout;

--- a/apps/nextjs-app/src/app/app/notifications/layout.tsx
+++ b/apps/nextjs-app/src/app/app/notifications/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+import { AccessGate } from '../_components/access-gate';
+
+const NotificationsLayout = ({ children }: { children: ReactNode }) => {
+  return <AccessGate allowedRoles={['creator', 'admin']}>{children}</AccessGate>;
+};
+
+export default NotificationsLayout;

--- a/apps/nextjs-app/src/app/app/users/page.tsx
+++ b/apps/nextjs-app/src/app/app/users/page.tsx
@@ -1,5 +1,6 @@
-import { AdminGuard } from './_components/admin-guard';
-import { Users } from './_components/users';
+import { redirect } from 'next/navigation';
+
+import { paths } from '@/config/paths';
 
 export const metadata = {
   title: 'Admin Panel',
@@ -7,13 +8,7 @@ export const metadata = {
 };
 
 const UsersPage = () => {
-  return (
-    <AdminGuard>
-      <div className="text-foreground">
-        <Users />
-      </div>
-    </AdminGuard>
-  );
+  redirect(paths.app.admin.root.getHref());
 };
 
 export default UsersPage;

--- a/apps/nextjs-app/src/app/not-found.tsx
+++ b/apps/nextjs-app/src/app/not-found.tsx
@@ -1,16 +1,24 @@
-import { Link } from '@/components/ui/link';
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Cookies from 'js-cookie';
+
 import { paths } from '@/config/paths';
+import { AUTH_TOKEN_COOKIE_NAME } from '@/utils/auth-constants';
 
 const NotFoundPage = () => {
-  return (
-    <div className="mt-52 flex flex-col items-center font-semibold">
-      <h1>404 - Not Found</h1>
-      <p>Sorry, the page you are looking for does not exist.</p>
-      <Link href={paths.home.getHref()} replace>
-        Go to Home
-      </Link>
-    </div>
-  );
+  const router = useRouter();
+
+  useEffect(() => {
+    const destination = Cookies.get(AUTH_TOKEN_COOKIE_NAME)
+      ? paths.app.puzzles.getHref()
+      : paths.home.getHref();
+
+    router.replace(destination);
+  }, [router]);
+
+  return null;
 };
 
 export default NotFoundPage;

--- a/apps/nextjs-app/src/config/paths.ts
+++ b/apps/nextjs-app/src/config/paths.ts
@@ -36,6 +36,14 @@ export const paths = {
     myPuzzles: {
       getHref: () => '/app/my-puzzles',
     },
+    admin: {
+      root: {
+        getHref: () => '/app/admin',
+      },
+      uploadPuzzle: {
+        getHref: () => '/app/admin/upload-puzzle',
+      },
+    },
     arsenal: {
       root: {
         getHref: () => '/app/arsenal',

--- a/apps/nextjs-app/src/middleware.ts
+++ b/apps/nextjs-app/src/middleware.ts
@@ -52,7 +52,6 @@ export function middleware(request: NextRequest) {
   // submit cleanly; the home page has working "Log in" / "Register" CTAs.
   if (!isPublicRoute && !hasAuthToken) {
     const homeUrl = new URL('/', request.url);
-    homeUrl.searchParams.set('reason', 'unauthorized');
     return NextResponse.redirect(homeUrl);
   }
 


### PR DESCRIPTION
This pull request introduces a new role-based access control system for the Next.js app, centralizing authorization logic with an `AccessGate` component. Several layouts now enforce role restrictions, and navigation/routes have been updated to reflect the new admin section structure. NotFound and unauthorized routes now redirect users based on authentication status. Key changes are grouped as follows:

**Role-based Access Control:**

* Added a reusable `AccessGate` component to enforce allowed roles for pages and layouts, displaying a spinner while loading and redirecting unauthorized users. (`apps/nextjs-app/src/app/app/_components/access-gate.tsx`)
* Wrapped sensitive layouts (`admin`, `my-puzzles`, `create-puzzle`, `arsenal/creator`, `notifications`) with `AccessGate` to restrict access to admins and/or creators as appropriate. [[1]](diffhunk://#diff-1e6ac8a7162c587e2ce3ba8daf78af4646979ba7412c0fb5b3d2616266902744R1-R9) [[2]](diffhunk://#diff-61eaf6c9953e34c706a3520e8182379012bfb990a894568c0a9841e27ccdeccfR1-R9) [[3]](diffhunk://#diff-c6072dd6a5634798cd558fa7f24bb4bfd8659eb427af9349534e14d58eed4471R1-R9) [[4]](diffhunk://#diff-345056dac13dbd48d07f504b6eed2542b8be3e7cde685705778e9f9c8d445d23R1-R9) [[5]](diffhunk://#diff-df714ab42353473d7a45f84dd0eeadcf2c8989fb7bae359d9bb9814a9c989f43R1-R9)

**Admin Section & Navigation Updates:**

* Refactored admin navigation and route paths, introducing `paths.app.admin.root.getHref()` and `paths.app.admin.uploadPuzzle.getHref()`, and updated all references accordingly. (`apps/nextjs-app/src/config/paths.ts`, `dashboard-layout.tsx`, `my-puzzles.tsx`) [[1]](diffhunk://#diff-b63090f130a565e7911b7347e52e3bb6dcefb670e47f410d0c606df34368b4c3R39-R46) [[2]](diffhunk://#diff-32e17850ba048e9eecba82baa012da697db80f2312a834c37b24287a80c8615dL419-R419) [[3]](diffhunk://#diff-d67fb1b068400f9f50b00c4aa20969fbae69e9ad42f74b9c44169e05dee6f894L239-R239)
* Moved admin panel rendering to `/app/admin/page.tsx` and redirected `/app/users` to the new admin root. (`admin/page.tsx`, `users/page.tsx`) [[1]](diffhunk://#diff-e6d4e086a4028bb5e591e74d85f776b093a8431347d3bf9b4b3e577bb3343f92R1-R19) [[2]](diffhunk://#diff-90d928a30242fe3b8d29bfecf633a1fe0702c6fe2d9515b0377d4d492e5289e3L1-R11)

**NotFound and Unauthorized Redirects:**

* Updated NotFound pages to automatically redirect users to the puzzles page if authenticated, or to the home page if not. (`not-found.tsx`, `app/[...notFound]/page.tsx`) ([apps/nextjs-app/src/app/not-found.tsxL1-R21](diffhunk://#diff-88868201b4b2d2818210f770816fa6e23a0b6cb36083322a295e3cfd04500688L1-R21), [apps/nextjs-app/src/app/app/[...notFound]/page.tsxR3-R18](diffhunk://#diff-840425d9a9b6a663a803d21ef21a557c74b2aef4c81f122c79c6a45c51b4729bR3-R18))
* Removed the `unauthorized` search param from middleware redirects for cleaner URLs. (`middleware.ts`)