### PR TITLE
Penalize clue/help requests with time deduction

### DIFF
--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/clue-button.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/clue-button.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Lightbulb } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmationDialog } from '@/components/ui/dialog/confirmation-dialog';
+import { useNotifications } from '@/components/ui/notifications';
+import {
+  useRequestClue,
+  type RequestClueResponse,
+} from '@/features/puzzles/api/request-clue';
+
+export type RevealedClue = {
+  index: number;
+  text: string;
+  penalty: number;
+};
+
+export type ClueButtonProps = {
+  puzzleId: string | number;
+  attemptId: number | null;
+  totalClues: number;
+  cluePenaltySeconds: number;
+  hasCountdown?: boolean;
+  revealedClues: RevealedClue[];
+  onClueRevealed: (clue: RevealedClue) => void;
+};
+
+export const ClueButton = ({
+  puzzleId,
+  attemptId,
+  totalClues,
+  cluePenaltySeconds,
+  hasCountdown = false,
+  revealedClues,
+  onClueRevealed,
+}: ClueButtonProps) => {
+  const { addNotification } = useNotifications();
+  const requestClue = useRequestClue();
+  const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
+  const [confirmDoneTick, setConfirmDoneTick] = useState(0);
+
+  if (totalClues <= 0) return null;
+
+  const used = revealedClues.length;
+  const allUsed = used >= totalClues;
+  const disabled =
+    attemptId === null ||
+    requestClue.isPending ||
+    pendingRequestId !== null ||
+    allUsed;
+
+  const handleConfirm = async () => {
+    if (attemptId === null) return;
+    const requestId =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setPendingRequestId(requestId);
+    try {
+      const response: RequestClueResponse = await requestClue.mutateAsync({
+        puzzleId,
+        attemptId,
+        requestId,
+      });
+      // `replayed` only means the server has already charged this request_id
+      // (e.g. our previous POST succeeded but its response was lost). The local
+      // UI may still be missing this clue, so hydrate it if absent. Only the
+      // user-facing toast is gated on "fresh" so a retry doesn't double-fire it.
+      const newClue: RevealedClue = {
+        index: response.clue_index,
+        text: response.clue_text,
+        penalty: response.penalty_seconds,
+      };
+      const alreadyShown = revealedClues.some((c) => c.index === newClue.index);
+      if (!alreadyShown) {
+        onClueRevealed(newClue);
+      }
+      if (!response.replayed && !alreadyShown) {
+        const message = hasCountdown
+          ? `−${response.penalty_seconds}s on your countdown and +${response.penalty_seconds}s on your time taken. Total clue penalty: ${response.total_penalty_so_far}s.`
+          : `+${response.penalty_seconds}s added to your time taken. Total clue penalty: ${response.total_penalty_so_far}s.`;
+        addNotification({
+          type: 'warning',
+          title: 'Clue revealed — penalty applied',
+          message,
+        });
+      }
+      setConfirmDoneTick((t) => t + 1);
+    } catch (err) {
+      addNotification({
+        type: 'error',
+        title: 'Could not reveal clue',
+        message: err instanceof Error ? err.message : 'Please try again.',
+      });
+      setConfirmDoneTick((t) => t + 1);
+    } finally {
+      setPendingRequestId(null);
+    }
+  };
+
+  const nextNumber = used + 1;
+  const dialogBody = allUsed
+    ? 'No more clues left for this puzzle.'
+    : hasCountdown
+      ? `This will subtract ${cluePenaltySeconds}s from your live countdown AND add ${cluePenaltySeconds}s to your recorded time taken (medals & leaderboard). (Clue ${nextNumber} of ${totalClues} — penalty stacks on each clue.)`
+      : `This will add ${cluePenaltySeconds}s to your time taken. (Clue ${nextNumber} of ${totalClues} — penalty stacks on each clue.)`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ConfirmationDialog
+        title="Reveal next clue?"
+        body={dialogBody}
+        cancelButtonText="Cancel"
+        icon="danger"
+        isDone={confirmDoneTick > 0}
+        triggerButton={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            className="gap-1.5"
+          >
+            <Lightbulb className="size-4" aria-hidden />
+            <span>
+              {allUsed ? 'All clues used' : `Clues (${used}/${totalClues})`}
+            </span>
+          </Button>
+        }
+        confirmButton={
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={disabled || allUsed}
+            onClick={handleConfirm}
+          >
+            {requestClue.isPending
+              ? 'Revealing…'
+              : `Reveal clue (+${cluePenaltySeconds}s)`}
+          </Button>
+        }
+      />
+
+      {revealedClues.length > 0 ? (
+        <div className="rounded-md border border-amber-200/70 bg-amber-50/60 p-2 text-xs text-amber-900">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
+            Revealed clues
+          </div>
+          <ol className="list-decimal space-y-1 pl-4">
+            {revealedClues
+              .slice()
+              .sort((a, b) => a.index - b.index)
+              .map((c) => (
+                <li key={c.index}>
+                  <span>{c.text}</span>
+                  <span className="ml-1 text-[10px] text-amber-700">
+                    (+{c.penalty}s)
+                  </span>
+                </li>
+              ))}
+          </ol>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import React from 'react';
-import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 const Confetti = dynamic(() => import('react-confetti'), { ssr: false });
 
 import { Button } from '@/components/ui/button';
-import { useAudio } from '@/hooks/useAudio';
-import { useSettings } from '@/context/settings-context';
 import {
   Dialog,
   DialogContent,
@@ -18,26 +21,31 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { InfoPopup } from '@/components/ui/info-popup';
 import { useNotifications } from '@/components/ui/notifications';
 import { paths } from '@/config/paths';
+import { useSettings } from '@/context/settings-context';
 import { usePuzzle } from '@/features/puzzles/api/get-puzzle';
 import { startPuzzleAttempt } from '@/features/puzzles/api/start-attempt';
-import { CreatorCommentDialog } from '@/features/puzzles/components/creator-comment-dialog';
 import { validateSolution } from '@/features/puzzles/api/validate-solution';
-import { useUser } from '@/lib/auth';
+import { CreatorCommentDialog } from '@/features/puzzles/components/creator-comment-dialog';
+import { useAudio } from '@/hooks/useAudio';
 import { api } from '@/lib/api-client';
+import { useUser } from '@/lib/auth';
 import { CircuitComponent, CircuitSolution, Wire } from '@/types/api';
 import { cn } from '@/utils/cn';
 
+import { ClueButton, type RevealedClue } from './clue-button';
+import { extractVisualStyleFromComponentLike } from './piece-visual-style';
 import {
   WorkstationGrid,
   type ComponentDef,
   type PlacedGridComponent,
   type SelectedComponentState,
 } from './workstation-grid';
-import { extractVisualStyleFromComponentLike } from './piece-visual-style';
 import { WorkstationMenu } from './workstation-menu';
 import { WorkstationTimer } from './workstation-timer';
+
 const CircuitDebugger = dynamic(
   () =>
     import('@/components/circuit-debugger').then((mod) => ({
@@ -55,8 +63,8 @@ const CircuitDebugger = dynamic(
 import { PuzzleXPBar } from '@/components/ui/puzzle-xp-bar';
 import { PuzzleLeaderboard } from '@/features/puzzles/components/puzzle-leaderboard';
 import { RatingDialog } from '@/features/ratings/components/rating-dialog';
-import { InfoPopup } from '@/components/ui/info-popup';
 import { ZigzagBugCanvas } from '@/components/ui/zigzag-bug-canvas';
+
 import {
   Bug,
   ChevronDown,
@@ -68,6 +76,7 @@ import {
   CircuitBoard,
   Medal,
 } from 'lucide-react';
+
 import { PageTourLauncher } from '@/components/ui/page-tour-launcher';
 import { workstationTourSteps } from '@/config/tourSteps';
 import { useWorkstationDraft } from '@/features/puzzles/hooks/use-workstation-draft';
@@ -285,6 +294,15 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     string | null
   >(null);
 
+  // Clue-penalty state (server is the source of truth — these mirror what /attempts/start
+  // and /clue tell us, so a refresh hydrates back to a consistent UI).
+  const [attemptId, setAttemptId] = useState<number | null>(null);
+  const [cluesRevealed, setCluesRevealed] = useState<RevealedClue[]>([]);
+  const cluePenaltySeconds = cluesRevealed.reduce(
+    (sum, c) => sum + c.penalty,
+    0,
+  );
+
   // Sync isSolved from API data (so page refresh preserves solved state)
   useEffect(() => {
     if (puzzle?.is_solved) {
@@ -351,7 +369,29 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     const startAttempt = async () => {
       try {
         if (!puzzle?.id) return;
-        await startPuzzleAttempt({ puzzleId: puzzle.id });
+        const response = await startPuzzleAttempt({ puzzleId: puzzle.id });
+        if (cancelled) return;
+        setAttemptId(typeof response.id === 'number' ? response.id : null);
+        // Hydrate raw timer from server's started_at so a refresh doesn't reset
+        // the user's elapsed time.
+        if (response.started_at) {
+          const parsed = Date.parse(response.started_at);
+          if (Number.isFinite(parsed)) {
+            startTime.current = parsed;
+          }
+        }
+        // Restore clues already paid for so the user doesn't lose access to them.
+        if (Array.isArray(response.revealed_clues)) {
+          setCluesRevealed(
+            response.revealed_clues.map((c) => ({
+              index: c.index,
+              text: c.text,
+              penalty: c.penalty_seconds,
+            })),
+          );
+        } else {
+          setCluesRevealed([]);
+        }
       } catch {
         // Best-effort only: rating still falls back to client elapsed on submit.
       }
@@ -1571,6 +1611,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
         puzzleId: puzzle.id,
         solution: buildSolution(),
         timeTaken,
+        attemptId,
       });
 
       setIsPowerSurge(false);
@@ -1605,11 +1646,9 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
         open: true,
         solved: res.solved,
         message: res.solved
-          ? Boolean(
-              (res as any).is_first_solve ??
-              (res as any).first_solve ??
-              (res.xp_earned ?? 0) > 0,
-            )
+          ? ((res as any).is_first_solve ??
+            (res as any).first_solve ??
+            (res.xp_earned ?? 0) > 0)
             ? res.message || 'You earned XP!'
             : 'Correct! You rebuilt it.'
           : res.message,
@@ -1689,8 +1728,10 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   const onSolveAgain = () => {
     const shouldResetBoard = postCheck.open && postCheck.solved;
 
-    // For "Try again" after a failed check, keep the user's board.
-    // For "Solve again" after success, start from a clean board.
+    // For "Try again" after a failed check, keep the user's board AND the
+    // accumulated clue penalty / attempt id — the student keeps working in the
+    // same attempt. For "Solve again" after success, start a fresh attempt:
+    // the previous one was closed server-side and clue requests must restart.
     if (shouldResetBoard) {
       clearDraft();
       setPlaced([]);
@@ -1699,6 +1740,34 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
       // Re-enable save/flush for the fresh attempt.
       solvedRef.current = false;
       startTime.current = Date.now();
+      // Tear down the old attempt's state and request a new one.
+      setAttemptId(null);
+      setCluesRevealed([]);
+      if (puzzle?.id) {
+        startPuzzleAttempt({ puzzleId: puzzle.id })
+          .then((response) => {
+            setAttemptId(typeof response.id === 'number' ? response.id : null);
+            if (response.started_at) {
+              const parsed = Date.parse(response.started_at);
+              if (Number.isFinite(parsed)) {
+                startTime.current = parsed;
+              }
+            }
+            if (Array.isArray(response.revealed_clues)) {
+              setCluesRevealed(
+                response.revealed_clues.map((c) => ({
+                  index: c.index,
+                  text: c.text,
+                  penalty: c.penalty_seconds,
+                })),
+              );
+            }
+          })
+          .catch(() => {
+            // Best-effort: validate path will still work via the back-compat
+            // open-attempt fallback when attempt_id is null.
+          });
+      }
     }
 
     // Always reset interaction/UI state
@@ -1921,10 +1990,54 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <WorkstationTimer
+                elapsedSeconds={elapsedSeconds}
+                extraSeconds={cluePenaltySeconds}
                 timeLimitSeconds={
                   puzzle.timeLimit ?? (puzzle as any).time_limit_seconds
                 }
               />
+              {(() => {
+                const limit =
+                  puzzle.timeLimit ?? (puzzle as any).time_limit_seconds;
+                const hasCountdown = typeof limit === 'number' && limit > 0;
+                if (hasCountdown && cluePenaltySeconds > 0) {
+                  return (
+                    <div
+                      className="rounded-lg border border-red-200/60 bg-red-50/50 px-3 py-1.5 text-[13px] font-medium text-red-700 backdrop-blur-sm"
+                      title="Added to your recorded time on submit (medals & leaderboard). The countdown is not affected."
+                    >
+                      <span className="mr-1 opacity-70">
+                        Time-taken penalty:
+                      </span>
+                      <span className="font-semibold tabular-nums tracking-tight">
+                        +{cluePenaltySeconds}s
+                      </span>
+                    </div>
+                  );
+                }
+                return null;
+              })()}
+              {puzzle.has_clues && (puzzle.clue_count ?? 0) > 0 ? (
+                <ClueButton
+                  puzzleId={puzzle.id}
+                  attemptId={attemptId}
+                  totalClues={puzzle.clue_count ?? 0}
+                  cluePenaltySeconds={puzzle.clue_penalty_seconds ?? 30}
+                  hasCountdown={(() => {
+                    const limit =
+                      puzzle.timeLimit ?? (puzzle as any).time_limit_seconds;
+                    return typeof limit === 'number' && limit > 0;
+                  })()}
+                  revealedClues={cluesRevealed}
+                  onClueRevealed={(clue) =>
+                    setCluesRevealed((prev) =>
+                      prev.some((c) => c.index === clue.index)
+                        ? prev
+                        : [...prev, clue],
+                    )
+                  }
+                />
+              ) : null}
               {!isInlineDebugger ? (
                 <div className="relative">
                   <Button
@@ -2032,16 +2145,16 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
               {budgetLimit}
               {creatorBudget !== null && (
                 <>
-                  <span className="text-muted-foreground ml-2">
+                  <span className="ml-2 text-muted-foreground">
                     Creator Cost:
                   </span>{' '}
                   {creatorBudget}
                 </>
               )}
-              <span className="text-muted-foreground ml-2">Cost:</span>{' '}
+              <span className="ml-2 text-muted-foreground">Cost:</span>{' '}
               {currentCost}
               <InfoPopup>
-                <p className="font-medium text-foreground mb-1">
+                <p className="mb-1 font-medium text-foreground">
                   Circuit Cost Limits
                 </p>
                 <p>
@@ -2265,22 +2378,22 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       return (
                         <li
                           key={w.id}
-                          className="group flex items-center justify-between gap-2 rounded-md border border-border/60 bg-secondary/40 px-2.5 py-2 transition-all hover:bg-secondary/70 hover:border-border"
+                          className="group flex items-center justify-between gap-2 rounded-md border border-border/60 bg-secondary/40 px-2.5 py-2 transition-all hover:border-border hover:bg-secondary/70"
                         >
-                          <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                          <div className="flex min-w-0 flex-1 items-center gap-1.5">
                             {/* From Badge */}
-                            <div className="flex-shrink-0 inline-flex items-center rounded-md border border-blue-600/80 bg-blue-600 px-2 py-1 text-[10px] font-semibold text-white shadow-sm">
+                            <div className="inline-flex shrink-0 items-center rounded-md border border-blue-600/80 bg-blue-600 px-2 py-1 text-[10px] font-semibold text-white shadow-sm">
                               {fromLabel}
                             </div>
 
                             {/* Arrow Icon */}
                             <ArrowRight
                               size={12}
-                              className="text-muted-foreground flex-shrink-0"
+                              className="shrink-0 text-muted-foreground"
                             />
 
                             {/* To Badge */}
-                            <div className="flex-shrink-0 inline-flex items-center rounded-md border border-yellow-600/80 bg-yellow-600 px-2 py-1 text-[10px] font-semibold text-white shadow-sm">
+                            <div className="inline-flex shrink-0 items-center rounded-md border border-yellow-600/80 bg-yellow-600 px-2 py-1 text-[10px] font-semibold text-white shadow-sm">
                               {toLabel}
                             </div>
                           </div>
@@ -2288,7 +2401,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                           {/* Delete Button */}
                           <button
                             type="button"
-                            className="hidden rounded-sm p-0.5 text-muted-foreground transition-all group-hover:flex items-center justify-center hover:scale-110 hover:bg-red-100 dark:hover:bg-red-950/40 hover:text-red-700 dark:hover:text-red-300"
+                            className="hidden items-center justify-center rounded-sm p-0.5 text-muted-foreground transition-all hover:scale-110 hover:bg-red-100 hover:text-red-700 group-hover:flex dark:hover:bg-red-950/40 dark:hover:text-red-300"
                             onClick={() =>
                               setWires((prev) =>
                                 prev.filter((x) => x.id !== w.id),
@@ -2365,7 +2478,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
 
                     <div className="space-y-3">
                       <div>
-                        <label className="text-[11px] font-medium text-foreground block mb-2">
+                        <label className="mb-2 block text-[11px] font-medium text-foreground">
                           Inputs
                         </label>
                         <select
@@ -2373,7 +2486,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                           onChange={(e) =>
                             setSandboxNumInputs(parseInt(e.target.value))
                           }
-                          className="w-full border border-border rounded-lg bg-card text-foreground px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-ring"
+                          className="w-full rounded-lg border border-border bg-card px-2 py-1.5 text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                         >
                           {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
                             <option key={n} value={n}>
@@ -2384,7 +2497,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       </div>
 
                       <div>
-                        <label className="text-[11px] font-medium text-foreground block mb-2">
+                        <label className="mb-2 block text-[11px] font-medium text-foreground">
                           Outputs
                         </label>
                         <select
@@ -2392,7 +2505,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                           onChange={(e) =>
                             setSandboxNumOutputs(parseInt(e.target.value))
                           }
-                          className="w-full border border-border rounded-lg bg-transparent px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-ring"
+                          className="w-full rounded-lg border border-border bg-transparent px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-ring"
                         >
                           {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
                             <option key={n} value={n}>
@@ -2445,7 +2558,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       size="sm"
                       variant="outline"
                       onClick={() => setShowSandboxDebugger(true)}
-                      className="w-full mt-3"
+                      className="mt-3 w-full"
                     >
                       Debug
                     </Button>
@@ -2579,13 +2692,13 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       }}
                     />
                   ) : (
-                    <div className="text-muted-foreground text-[13px]">
+                    <div className="text-[13px] text-muted-foreground">
                       Loading instructions...
                     </div>
                   )}
                 </>
               ) : (
-                <div className="text-muted-foreground text-[13px]">
+                <div className="text-[13px] text-muted-foreground">
                   No instructions provided.
                 </div>
               )}
@@ -2727,7 +2840,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                         You have reached the maximum XP for this puzzle.
                       </p>
                     )}
-                  <p className="font-medium text-foreground mt-4">
+                  <p className="mt-4 font-medium text-foreground">
                     Congrats! Your solution passed all test cases.
                   </p>
                 </div>
@@ -2966,7 +3079,7 @@ const InspectionDialog = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+      <DialogContent className="max-h-[85vh] max-w-3xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <svg
@@ -2996,7 +3109,7 @@ const InspectionDialog = ({
               <h3 className="mb-2 text-[13px] font-semibold text-foreground">
                 Description
               </h3>
-              <p className="text-[13px] text-foreground whitespace-pre-wrap leading-relaxed font-normal">
+              <p className="whitespace-pre-wrap text-[13px] font-normal leading-relaxed text-foreground">
                 {mappedDescriptionContent}
               </p>
             </div>
@@ -3033,7 +3146,7 @@ const InspectionDialog = ({
               </div>
 
               {/* Port details table */}
-              <div className="mt-4 rounded-md border border-border/40 overflow-hidden">
+              <div className="mt-4 overflow-hidden rounded-md border border-border/40">
                 <table className="w-full text-[12px]">
                   <thead className="bg-secondary">
                     <tr>
@@ -3083,7 +3196,7 @@ const InspectionDialog = ({
               </h3>
 
               {isHidden ? (
-                <div className="rounded-md bg-amber-50 border border-amber-200 p-3">
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
                   <p className="inline-flex items-start gap-2 text-[12px] font-medium text-amber-900">
                     <CircleAlert
                       className="mt-0.5 size-4 shrink-0"
@@ -3100,14 +3213,14 @@ const InspectionDialog = ({
                   {/* Show basic gates list */}
                   {hasUsedBasicTypes && (
                     <div>
-                      <p className="text-[12px] font-medium text-foreground mb-2">
+                      <p className="mb-2 text-[12px] font-medium text-foreground">
                         Gates Used:
                       </p>
-                      <div className="pl-3 space-y-1">
+                      <div className="space-y-1 pl-3">
                         {((catalogEntry as any).used_basic_types || []).map(
                           (gate: string) => (
                             <div key={gate} className="flex items-center gap-2">
-                              <span className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500"></span>
+                              <span className="inline-block size-1.5 rounded-full bg-blue-500"></span>
                               <span className="text-[12px] text-muted-foreground">
                                 {gate}
                               </span>
@@ -3123,17 +3236,17 @@ const InspectionDialog = ({
                     parsedSolution &&
                     (parsedSolution.placed.length > 0 ||
                       parsedSolution.wires.length > 0) && (
-                      <div className="mt-4 pt-4 border-t border-cyan-200">
-                        <p className="text-[12px] font-medium text-foreground mb-2">
+                      <div className="mt-4 border-t border-cyan-200 pt-4">
+                        <p className="mb-2 text-[12px] font-medium text-foreground">
                           Circuit Preview:
                         </p>
                         <div
-                          className="relative w-full bg-slate-50 rounded border border-slate-200 overflow-auto"
+                          className="relative w-full overflow-auto rounded border border-slate-200 bg-slate-50"
                           style={{ minHeight: '200px', maxHeight: '300px' }}
                         >
                           {/* Mini grid canvas */}
                           <svg
-                            className="absolute inset-0 pointer-events-none"
+                            className="pointer-events-none absolute inset-0"
                             width="100%"
                             height="100%"
                             style={{ minWidth: '100%', minHeight: '100%' }}
@@ -3196,7 +3309,7 @@ const InspectionDialog = ({
 
                           {/* Render mini gates */}
                           <div
-                            className="absolute inset-0 pointer-events-none"
+                            className="pointer-events-none absolute inset-0"
                             style={{ perspective: '1000px' }}
                           >
                             {(parsedSolution.placed || []).map(
@@ -3217,7 +3330,7 @@ const InspectionDialog = ({
                                 return (
                                   <div
                                     key={placed.id}
-                                    className="absolute border border-border bg-card rounded text-[9px] font-bold text-foreground flex items-center justify-center pointer-events-none"
+                                    className="pointer-events-none absolute flex items-center justify-center rounded border border-border bg-card text-[9px] font-bold text-foreground"
                                     style={{
                                       left: `${left}px`,
                                       top: `${top}px`,
@@ -3235,7 +3348,7 @@ const InspectionDialog = ({
                             )}
                           </div>
                         </div>
-                        <p className="text-[11px] text-muted-foreground mt-2 italic">
+                        <p className="mt-2 text-[11px] italic text-muted-foreground">
                           This component contains{' '}
                           {parsedSolution.placed?.length || 0} gate(s) connected
                           by {parsedSolution.wires?.length || 0} wire(s).
@@ -3244,7 +3357,7 @@ const InspectionDialog = ({
                     )}
                 </div>
               ) : (
-                <div className="rounded-md bg-slate-50 border border-slate-200 p-3">
+                <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
                   <p className="text-[12px] text-muted-foreground">
                     No internal structure information available.
                   </p>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-timer.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-timer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 const formatTime = (seconds: number) => {
   const abs = Math.abs(seconds);
@@ -9,55 +9,73 @@ const formatTime = (seconds: number) => {
   return `${m}:${String(s).padStart(2, '0')}`;
 };
 
+/**
+ * The clue penalty is added to displayed elapsed time in both modes — for the
+ * countdown case it shrinks the visible remaining time, for the no-limit case
+ * it inflates the visible elapsed. In the no-limit case we also append a
+ * compact "+Ns" pill inside the timer so the user can see how much of the
+ * displayed time is penalty. For the countdown case the breakdown is
+ * surfaced separately by `puzzle-workstation` (a dedicated "Time-taken
+ * penalty" pill alongside the timer) — that pill makes it explicit that the
+ * same penalty is also recorded on the leaderboard.
+ */
 export const WorkstationTimer = ({
+  elapsedSeconds,
+  extraSeconds = 0,
   timeLimitSeconds,
 }: {
+  elapsedSeconds: number;
+  extraSeconds?: number;
   timeLimitSeconds?: number | null;
 }) => {
-  const [elapsed, setElapsed] = useState(0);
-
-  useEffect(() => {
-    const startedAt = Date.now();
-    const interval = window.setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
-    }, 250);
-
-    return () => window.clearInterval(interval);
-  }, []);
-
+  const penalty = Math.max(0, Math.floor(extraSeconds || 0));
+  const displayElapsed = Math.max(0, Math.floor(elapsedSeconds || 0)) + penalty;
   const hasLimit = typeof timeLimitSeconds === 'number' && timeLimitSeconds > 0;
-  // If no limit, we can treat remaining as infinite or calculate differently.
-  // For logic preservation, we define remaining based on limit if exists.
-  const remaining = hasLimit ? (timeLimitSeconds as number) - elapsed : 0;
 
   const { label, colorClass } = useMemo(() => {
-    if (!hasLimit) return { label: null, colorClass: '' };
-
-    // Overtime
-    if (remaining <= 0) {
-      return { 
-        label: `+${formatTime(remaining)}`, 
-        colorClass: 'bg-red-50/50 text-red-700 border-red-200/60'
+    if (!hasLimit) {
+      return {
+        label: formatTime(displayElapsed),
+        colorClass: 'bg-slate-50/50 text-slate-700 border-slate-200/60',
       };
     }
 
-    // Normal countdown
-    const percentage = remaining / (timeLimitSeconds as number);
-    let color = 'bg-emerald-50/50 text-emerald-700 border-emerald-200/60'; // Default Green ( > 10%)
+    const remaining = (timeLimitSeconds as number) - displayElapsed;
 
+    if (remaining <= 0) {
+      return {
+        label: `+${formatTime(remaining)}`,
+        colorClass: 'bg-red-50/50 text-red-700 border-red-200/60',
+      };
+    }
+
+    const percentage = remaining / (timeLimitSeconds as number);
+    let color = 'bg-emerald-50/50 text-emerald-700 border-emerald-200/60';
     if (percentage <= 0.1) {
-      color = 'bg-amber-50/50 text-amber-700 border-amber-200/60'; // Yellow ( <= 10%)
+      color = 'bg-amber-50/50 text-amber-700 border-amber-200/60';
     }
 
     return { label: formatTime(remaining), colorClass: color };
-  }, [hasLimit, remaining, timeLimitSeconds]);
-
-  if (!label) return null;
+  }, [hasLimit, displayElapsed, timeLimitSeconds]);
 
   return (
-    <div className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium backdrop-blur-sm transition-colors duration-300 ${colorClass}`}>
-      <span className="opacity-60 mr-1">Time:</span>
-      <span className="font-semibold tabular-nums tracking-tight">{label}</span>
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-3 py-1.5 text-[13px] font-medium backdrop-blur-sm transition-colors duration-300 ${colorClass}`}
+    >
+      <span>
+        <span className="mr-1 opacity-60">Time:</span>
+        <span className="font-semibold tabular-nums tracking-tight">
+          {label}
+        </span>
+      </span>
+      {!hasLimit && penalty > 0 ? (
+        <span
+          className="rounded bg-red-100/80 px-1.5 py-0.5 text-[11px] font-semibold text-red-700"
+          title="Penalty added for clues"
+        >
+          +{penalty}s
+        </span>
+      ) : null}
     </div>
   );
 };

--- a/apps/nextjs-app/src/features/puzzles/api/request-clue.ts
+++ b/apps/nextjs-app/src/features/puzzles/api/request-clue.ts
@@ -1,0 +1,39 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { api } from '@/lib/api-client';
+
+export type RequestClueRequest = {
+  puzzleId: string | number;
+  attemptId: number;
+  requestId: string;
+};
+
+export type RequestClueResponse = {
+  clue_index: number;
+  clue_text: string;
+  penalty_seconds: number;
+  total_clues: number;
+  clues_used_so_far: number;
+  total_penalty_so_far: number;
+  replayed: boolean;
+};
+
+export const requestClue = ({
+  puzzleId,
+  attemptId,
+  requestId,
+}: RequestClueRequest): Promise<RequestClueResponse> => {
+  return api.post(
+    `/puzzles/${puzzleId}/clue`,
+    {
+      attempt_id: attemptId,
+      request_id: requestId,
+    },
+    { suppressErrorNotification: true },
+  );
+};
+
+export const useRequestClue = () =>
+  useMutation({
+    mutationFn: requestClue,
+  });

--- a/apps/nextjs-app/src/features/puzzles/api/start-attempt.ts
+++ b/apps/nextjs-app/src/features/puzzles/api/start-attempt.ts
@@ -1,10 +1,18 @@
 import { api } from '@/lib/api-client';
 
+export type RevealedClue = {
+  index: number;
+  text: string;
+  penalty_seconds: number;
+};
+
 export type StartAttemptResponse = {
   id: number;
   puzzle_id: number;
   user_id: number;
   started_at?: string;
+  revealed_clues?: RevealedClue[];
+  total_clue_penalty_seconds?: number;
 };
 
 export const startPuzzleAttempt = ({

--- a/apps/nextjs-app/src/features/puzzles/api/validate-solution.ts
+++ b/apps/nextjs-app/src/features/puzzles/api/validate-solution.ts
@@ -4,6 +4,8 @@ import { CircuitSolution } from '@/types/api';
 export type ValidateSolutionRequest = {
   solution: CircuitSolution;
   time_taken?: number;
+  time_taken_raw?: number;
+  attempt_id?: number;
 };
 
 export type ValidateSolutionResponse = {
@@ -21,13 +23,24 @@ export const validateSolution = ({
   puzzleId,
   solution,
   timeTaken,
+  attemptId,
 }: {
   puzzleId: string;
   solution: CircuitSolution;
   timeTaken?: number;
+  attemptId?: number | null;
 }): Promise<ValidateSolutionResponse> => {
-  return api.post(`/puzzles/${puzzleId}/validate`, {
-    solution,
-    time_taken: timeTaken ?? 0,
-  }, { suppressErrorNotification: true });
+  return api.post(
+    `/puzzles/${puzzleId}/validate`,
+    {
+      solution,
+      // Send under the new field name; server treats time_taken_raw as the source of truth
+      // and adds persisted clue penalty server-side. Legacy time_taken is kept for callers
+      // that haven't migrated yet.
+      time_taken: timeTaken ?? 0,
+      time_taken_raw: timeTaken ?? 0,
+      attempt_id: attemptId ?? undefined,
+    },
+    { suppressErrorNotification: true },
+  );
 };

--- a/apps/nextjs-app/src/types/api.ts
+++ b/apps/nextjs-app/src/types/api.ts
@@ -170,6 +170,11 @@ export type Puzzle = Entity<{
   best_medal?: number; // 0=none, 1=bronze, 2=silver, 3=gold
   is_saved?: boolean; // Whether user has saved this puzzle
 
+  // Clue metadata (text intentionally NOT exposed — fetched via POST /puzzles/{id}/clue)
+  has_clues?: boolean;
+  clue_count?: number;
+  clue_penalty_seconds?: number;
+
   // Difficulty ratings (injected by backend)
   avg_difficulty?: number;
   // User's rating (injected by browse endpoint if user already rated)

--- a/riddles/riddle_01_binary_adder/riddle_01_binary_adder_config.json
+++ b/riddles/riddle_01_binary_adder/riddle_01_binary_adder_config.json
@@ -13,7 +13,12 @@
     "min_cycles": null,
     "max_cycles": null,
     "allow_arsenal": true,
-    "riddle_base_name": "riddle_01_binary_adder"
+    "riddle_base_name": "riddle_01_binary_adder",
+    "clues": [
+      "S is the parity of A, B, and C_in — think XOR.",
+      "C_out is high whenever at least two of A, B, C_in are high — that's a majority function.",
+      "A 3-input XOR for S, plus AND/OR for the majority on C_out, fits the budget."
+    ]
   },
   "test_cases": [
     {

--- a/riddles/riddle_03_sequential_adder/riddle_03_sequential_adder_config.json
+++ b/riddles/riddle_03_sequential_adder/riddle_03_sequential_adder_config.json
@@ -33,7 +33,12 @@
     "min_cycles": 3,
     "max_cycles": 3,
     "allow_arsenal": true,
-    "riddle_base_name": "riddle_03_sequential_adder"
+    "riddle_base_name": "riddle_03_sequential_adder",
+    "clues": [
+      "Use the two DFF outputs (D1, D2) as your previous-bit memory — that's the carry from the prior cycle.",
+      "OUT each cycle is X XOR carry_in. The new carry is the majority of X and carry_in.",
+      "Two DFFs are enough: one for the saved carry, one optional for input parity tracking."
+    ]
   },
   "test_cases": [
     {

--- a/src/Backend/APILayer/PuzzleController.py
+++ b/src/Backend/APILayer/PuzzleController.py
@@ -13,6 +13,7 @@ from Backend.ServiceLayer.SolvingService import SolvingService
 from Backend.ServiceLayer.RatingService import RatingService
 from Backend.ServiceLayer.AdminService import AdminService
 from Backend.ServiceLayer.logicEngineService import logicEngineService
+from Backend.ServiceLayer.CluesService import CluesService, CluePuzzleHasNoClues, ClueAttemptInvalid, CluesAllConsumed
 from Backend.APILayer.auth_utils import verify_token
 from Backend.PersistantLayer._db import connect
 from insert_riddles import insert_riddle
@@ -88,6 +89,13 @@ class SolveReq(BaseModel):
 class ValidateSolutionReq(BaseModel):
     solution: Dict[str, Any]
     time_taken: int = 0
+    time_taken_raw: Optional[int] = None
+    attempt_id: Optional[int] = None
+
+
+class RequestClueReq(BaseModel):
+    attempt_id: int
+    request_id: Optional[str] = None
 
 
 class SimulateReq(BaseModel):
@@ -236,7 +244,7 @@ def _validate_uploaded_puzzle_payload(conn, config_data: dict, instructions_text
     return puzzle_config
 
 
-def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingService, rating_service: RatingService | None = None, admin_service: AdminService | None = None) -> APIRouter:
+def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingService, rating_service: RatingService | None = None, admin_service: AdminService | None = None, clues_service: CluesService | None = None) -> APIRouter:
     router = APIRouter(prefix="/puzzles", tags=["puzzles"])
 
     def _inject_rating_metrics(puzzle_payload: dict) -> None:
@@ -588,7 +596,35 @@ def build_puzzle_router(puzzle_service: PuzzleService, solving_service: SolvingS
     @router.post("/{puzzle_id}/validate")
     def validate(puzzle_id: int, req: ValidateSolutionReq, token: str = Depends(verify_token)):
         try:
-            return solving_service.validate_solution(token, puzzle_id, req.solution, time_taken=req.time_taken)
+            # Prefer time_taken_raw (new contract); fall back to legacy time_taken.
+            raw_time = req.time_taken_raw if req.time_taken_raw is not None else req.time_taken
+            return solving_service.validate_solution(
+                token,
+                puzzle_id,
+                req.solution,
+                time_taken=raw_time,
+                attempt_id=req.attempt_id,
+            )
+        except ValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    @router.post("/{puzzle_id}/clue")
+    def request_clue(puzzle_id: int, req: RequestClueReq, token: str = Depends(verify_token)):
+        if clues_service is None:
+            raise HTTPException(status_code=503, detail="clue service not available")
+        try:
+            return clues_service.request_clue(
+                token=token,
+                puzzle_id=puzzle_id,
+                attempt_id=req.attempt_id,
+                request_id=req.request_id,
+            )
+        except CluePuzzleHasNoClues as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except CluesAllConsumed as e:
+            raise HTTPException(status_code=410, detail=str(e))
+        except ClueAttemptInvalid as e:
+            raise HTTPException(status_code=403, detail=str(e))
         except ValidationError as e:
             raise HTTPException(status_code=400, detail=str(e))
 

--- a/src/Backend/DomainLayer/CluePenalty.py
+++ b/src/Backend/DomainLayer/CluePenalty.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING
+
+from .Enums import PuzzleDifficulty
+
+if TYPE_CHECKING:
+    from .Puzzle import Puzzle
+
+
+DEFAULT_CLUE_PENALTY_BY_DIFFICULTY = {
+    PuzzleDifficulty.EASY: 15,
+    PuzzleDifficulty.MEDIUM: 30,
+    PuzzleDifficulty.HARD: 60,
+}
+
+FALLBACK_CLUE_PENALTY_SECONDS = 30
+
+
+def resolve_clue_penalty(puzzle: "Puzzle") -> int:
+    override = getattr(puzzle, "clue_penalty_seconds", None)
+    if override is not None and override > 0:
+        return int(override)
+    difficulty = getattr(puzzle, "difficulty", None)
+    if difficulty in DEFAULT_CLUE_PENALTY_BY_DIFFICULTY:
+        return DEFAULT_CLUE_PENALTY_BY_DIFFICULTY[difficulty]
+    return FALLBACK_CLUE_PENALTY_SECONDS

--- a/src/Backend/DomainLayer/Puzzle.py
+++ b/src/Backend/DomainLayer/Puzzle.py
@@ -41,6 +41,10 @@ class Puzzle:
     # Initial board configuration: JSON string containing locked placed components and wires
     initial_board_json: Optional[str] = None
 
+    # Optional progressive clues for in-puzzle hints. Stored server-side; never echoed to clients via to_dict().
+    clues: Optional[List[str]] = None
+    clue_penalty_seconds: Optional[int] = None
+
     rating_count: int = 0
     is_hall_of_fame: bool = False
     avg_difficulty: float = 0.0
@@ -91,6 +95,9 @@ class Puzzle:
             self.status = PuzzleStatus.UNPUBLISHED
 
     def to_dict(self) -> dict:
+        from .CluePenalty import resolve_clue_penalty
+
+        clue_count = len(self.clues) if self.clues else 0
         return {
             "id": str(self.id), # Frontend often expects string IDs or handles both
             "name": self.name,
@@ -136,6 +143,10 @@ class Puzzle:
             "avg_clearness": self.avg_clearness,
             "created_at": self.created_at.isoformat(),
             "createdAt": int(self.created_at.timestamp() * 1000), # Frontend expects timestamp (ms)
+            # Clue metadata: text is intentionally redacted; only counts and resolved penalty are exposed.
+            "has_clues": clue_count > 0,
+            "clue_count": clue_count,
+            "clue_penalty_seconds": resolve_clue_penalty(self),
         }
 
     @staticmethod
@@ -176,6 +187,8 @@ class Puzzle:
             allowed_arsenal_component_ids=d.get("allowed_arsenal_component_ids") or d.get("allowedArsenalComponentIds"),
             arsenal_component_display_modes=d.get("arsenal_component_display_modes") or d.get("arsenalComponentDisplayModes"),
             initial_board_json=initial_board_json,
+            clues=list(d["clues"]) if isinstance(d.get("clues"), list) else None,
+            clue_penalty_seconds=int(d["clue_penalty_seconds"]) if d.get("clue_penalty_seconds") is not None else None,
             rating_count=int(d.get("rating_count", 0)),
             is_hall_of_fame=bool(d.get("is_hall_of_fame", d.get("isHallOfFame", False))),
             avg_difficulty=float(d.get("avg_difficulty", 0.0)),

--- a/src/Backend/DomainLayer/SolveAttempt.py
+++ b/src/Backend/DomainLayer/SolveAttempt.py
@@ -21,6 +21,9 @@ class SolveAttempt:
     passed: Optional[bool] = None
     fail_reason: Optional[str] = None
 
+    clues_used: int = 0
+    clue_penalty_seconds: int = 0
+
     def __post_init__(self) -> None:
         self.id = ensure_non_negative_int("SolveAttempt.id", self.id)
         self.puzzle_id = ensure_non_negative_int("SolveAttempt.puzzle_id", self.puzzle_id)
@@ -54,6 +57,8 @@ class SolveAttempt:
             "submitted_at": self.submitted_at.isoformat() if self.submitted_at else None,
             "passed": self.passed,
             "fail_reason": self.fail_reason,
+            "clues_used": int(self.clues_used or 0),
+            "clue_penalty_seconds": int(self.clue_penalty_seconds or 0),
         }
 
     @staticmethod

--- a/src/Backend/PersistantLayer/CluesRepo.py
+++ b/src/Backend/PersistantLayer/CluesRepo.py
@@ -1,0 +1,167 @@
+import sqlite3
+from typing import Optional
+
+from Backend.DomainLayer.Utils import utcnow
+
+
+class CluesExhausted(Exception):
+    """Raised by record_next_clue when all configured clues for a puzzle have been consumed."""
+
+
+class CluesRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS clue_requests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                attempt_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                puzzle_id INTEGER NOT NULL,
+                clue_index INTEGER NOT NULL,
+                penalty_seconds INTEGER NOT NULL,
+                request_id TEXT,
+                requested_at TEXT NOT NULL,
+                UNIQUE(attempt_id, clue_index)
+            );
+            """
+        )
+        # Partial unique index for client-supplied idempotency keys.
+        self.conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_clue_requests_request_id
+                ON clue_requests(attempt_id, request_id)
+                WHERE request_id IS NOT NULL;
+            """
+        )
+
+    # --- reads ---
+    def count_for_attempt(self, attempt_id: int) -> int:
+        row = self.conn.execute(
+            "SELECT COUNT(*) AS c FROM clue_requests WHERE attempt_id=?",
+            (int(attempt_id),),
+        ).fetchone()
+        return int(row["c"]) if row else 0
+
+    def total_penalty_for_attempt(self, attempt_id: int) -> int:
+        row = self.conn.execute(
+            "SELECT COALESCE(SUM(penalty_seconds), 0) AS t FROM clue_requests WHERE attempt_id=?",
+            (int(attempt_id),),
+        ).fetchone()
+        return int(row["t"]) if row else 0
+
+    def list_for_attempt(self, attempt_id: int) -> list[dict]:
+        rows = self.conn.execute(
+            """
+            SELECT clue_index, penalty_seconds, request_id, requested_at
+            FROM clue_requests
+            WHERE attempt_id=?
+            ORDER BY clue_index ASC
+            """,
+            (int(attempt_id),),
+        ).fetchall()
+        return [
+            {
+                "clue_index": int(r["clue_index"]),
+                "penalty_seconds": int(r["penalty_seconds"]),
+                "request_id": r["request_id"],
+                "requested_at": r["requested_at"],
+            }
+            for r in rows
+        ]
+
+    def find_by_request_id(self, attempt_id: int, request_id: str) -> Optional[dict]:
+        if not request_id:
+            return None
+        row = self.conn.execute(
+            """
+            SELECT clue_index, penalty_seconds, request_id, requested_at
+            FROM clue_requests
+            WHERE attempt_id=? AND request_id=?
+            LIMIT 1
+            """,
+            (int(attempt_id), str(request_id)),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "clue_index": int(row["clue_index"]),
+            "penalty_seconds": int(row["penalty_seconds"]),
+            "request_id": row["request_id"],
+            "requested_at": row["requested_at"],
+        }
+
+    # --- writes ---
+    def record_next_clue(
+        self,
+        attempt_id: int,
+        user_id: int,
+        puzzle_id: int,
+        penalty_seconds: int,
+        total_clues: int,
+        request_id: Optional[str] = None,
+    ) -> dict:
+        """Record the next clue for this attempt.
+
+        Idempotency:
+          - If request_id matches an existing row for this attempt, returns the existing
+            row with replayed=True; no new clue is consumed.
+          - Otherwise inserts a new row at the next available clue_index. On UNIQUE
+            collision (concurrent reveal), retries by re-reading the count.
+        Raises CluesExhausted if all clues for the puzzle have been used.
+        """
+        if request_id:
+            existing = self.find_by_request_id(attempt_id, request_id)
+            if existing is not None:
+                return {
+                    "clue_index": existing["clue_index"],
+                    "penalty_seconds": existing["penalty_seconds"],
+                    "replayed": True,
+                }
+
+        for _ in range(2):
+            current = self.count_for_attempt(attempt_id)
+            if current >= int(total_clues):
+                raise CluesExhausted()
+            try:
+                self.conn.execute(
+                    """
+                    INSERT INTO clue_requests(attempt_id, user_id, puzzle_id, clue_index, penalty_seconds, request_id, requested_at)
+                    VALUES(?,?,?,?,?,?,?)
+                    """,
+                    (
+                        int(attempt_id),
+                        int(user_id),
+                        int(puzzle_id),
+                        int(current),
+                        int(penalty_seconds),
+                        request_id,
+                        utcnow().isoformat(),
+                    ),
+                )
+                return {
+                    "clue_index": int(current),
+                    "penalty_seconds": int(penalty_seconds),
+                    "replayed": False,
+                }
+            except sqlite3.IntegrityError:
+                # A concurrent reveal won the race for this clue_index, or a duplicate
+                # request_id slipped past the earlier lookup. Re-check on next loop.
+                if request_id:
+                    existing = self.find_by_request_id(attempt_id, request_id)
+                    if existing is not None:
+                        return {
+                            "clue_index": existing["clue_index"],
+                            "penalty_seconds": existing["penalty_seconds"],
+                            "replayed": True,
+                        }
+                continue
+        raise CluesExhausted()
+
+    def delete_for_puzzle(self, puzzle_id: int) -> None:
+        self.conn.execute("DELETE FROM clue_requests WHERE puzzle_id=?", (int(puzzle_id),))

--- a/src/Backend/PersistantLayer/PuzzleRepo.py
+++ b/src/Backend/PersistantLayer/PuzzleRepo.py
@@ -77,6 +77,10 @@ class PuzzleRepo:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN riddle_base_name TEXT;")
             if "initial_board_json" not in cols:
                 self.conn.execute("ALTER TABLE puzzles ADD COLUMN initial_board_json TEXT;")
+            if "clues_json" not in cols:
+                self.conn.execute("ALTER TABLE puzzles ADD COLUMN clues_json TEXT;")
+            if "clue_penalty_seconds" not in cols:
+                self.conn.execute("ALTER TABLE puzzles ADD COLUMN clue_penalty_seconds INTEGER;")
         except Exception:
             pass
         self.conn.execute("""
@@ -159,8 +163,8 @@ class PuzzleRepo:
                 rating_count, is_hall_of_fame, avg_difficulty, avg_fun, avg_clearness,
                 min_gate_count, total_gate_count, min_cycles, max_cycles,
                 riddle_base_name, allow_arsenal, allowed_arsenal_component_ids, arsenal_component_display_modes,
-                initial_board_json, created_at
-            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                initial_board_json, clues_json, clue_penalty_seconds, created_at
+            ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """, (
             puzzle.name,
             puzzle.creator_user_id,
@@ -187,6 +191,8 @@ class PuzzleRepo:
             json.dumps(puzzle.allowed_arsenal_component_ids) if puzzle.allowed_arsenal_component_ids else None,
             json.dumps(puzzle.arsenal_component_display_modes) if puzzle.arsenal_component_display_modes else None,
             puzzle.initial_board_json,
+            json.dumps(puzzle.clues) if puzzle.clues else None,
+            puzzle.clue_penalty_seconds,
             puzzle.created_at.isoformat(),
         ))
         puzzle.id = int(cur.lastrowid)
@@ -222,7 +228,9 @@ class PuzzleRepo:
                 allow_arsenal=?,
                 allowed_arsenal_component_ids=?,
                 arsenal_component_display_modes=?,
-                initial_board_json=?
+                initial_board_json=?,
+                clues_json=?,
+                clue_penalty_seconds=?
             WHERE id=?
         """, (
             puzzle.name,
@@ -249,6 +257,8 @@ class PuzzleRepo:
             json.dumps(puzzle.allowed_arsenal_component_ids) if puzzle.allowed_arsenal_component_ids else None,
             json.dumps(puzzle.arsenal_component_display_modes) if puzzle.arsenal_component_display_modes else None,
             puzzle.initial_board_json,
+            json.dumps(puzzle.clues) if puzzle.clues else None,
+            puzzle.clue_penalty_seconds,
             puzzle.id
         ))
 
@@ -1053,6 +1063,19 @@ class PuzzleRepo:
             initial_board_json = row["initial_board_json"]
         except (IndexError, KeyError):
             initial_board_json = None
+        # Safely read clue metadata — may be missing in old DBs
+        try:
+            clues_json = row["clues_json"]
+            clues = json.loads(clues_json) if clues_json else None
+            if not isinstance(clues, list):
+                clues = None
+        except (IndexError, KeyError, TypeError, ValueError):
+            clues = None
+        try:
+            clue_penalty_seconds = row["clue_penalty_seconds"]
+            clue_penalty_seconds = int(clue_penalty_seconds) if clue_penalty_seconds is not None else None
+        except (IndexError, KeyError, TypeError, ValueError):
+            clue_penalty_seconds = None
         return Puzzle.from_dict({
             "id": int(row["id"]),
             "name": row["name"],
@@ -1083,4 +1106,6 @@ class PuzzleRepo:
             "created_at": row["created_at"],
             "riddle_base_name": riddle_base_name,
             "initial_board_json": initial_board_json,
+            "clues": clues,
+            "clue_penalty_seconds": clue_penalty_seconds,
         })

--- a/src/Backend/PersistantLayer/SolveRepo.py
+++ b/src/Backend/PersistantLayer/SolveRepo.py
@@ -59,6 +59,8 @@ class SolveRepo:
             "xp_earned INTEGER DEFAULT 0",
             "highest_medal INTEGER DEFAULT 0",
             "solution_hash TEXT",
+            "clues_used INTEGER DEFAULT 0",
+            "clue_penalty_seconds INTEGER DEFAULT 0",
         ]:
             self._add_column_if_missing("solve_attempts", coldef)
 
@@ -115,8 +117,12 @@ class SolveRepo:
     def create_attempt(self, attempt: SolveAttempt) -> SolveAttempt:
         cur = self.conn.execute(
             """
-            INSERT INTO solve_attempts(puzzle_id, user_id, circuit_id, started_at, submitted_at, passed, fail_reason, time_used_seconds, cost_used)
-            VALUES(?,?,?,?,?,?,?,?,?)
+            INSERT INTO solve_attempts(
+                puzzle_id, user_id, circuit_id, started_at, submitted_at,
+                passed, fail_reason, time_used_seconds, cost_used,
+                clues_used, clue_penalty_seconds
+            )
+            VALUES(?,?,?,?,?,?,?,?,?,?,?)
             """,
             (
                 int(attempt.puzzle_id),
@@ -128,6 +134,8 @@ class SolveRepo:
                 attempt.fail_reason,
                 attempt.time_used_seconds,
                 attempt.cost_used,
+                int(getattr(attempt, "clues_used", 0) or 0),
+                int(getattr(attempt, "clue_penalty_seconds", 0) or 0),
             ),
         )
         attempt.id = int(cur.lastrowid)
@@ -142,7 +150,9 @@ class SolveRepo:
                 passed=?,
                 fail_reason=?,
                 time_used_seconds=?,
-                cost_used=?
+                cost_used=?,
+                clues_used=?,
+                clue_penalty_seconds=?
             WHERE id=?
             """,
             (
@@ -152,6 +162,8 @@ class SolveRepo:
                 attempt.fail_reason,
                 attempt.time_used_seconds,
                 attempt.cost_used,
+                int(getattr(attempt, "clues_used", 0) or 0),
+                int(getattr(attempt, "clue_penalty_seconds", 0) or 0),
                 int(attempt.id),
             ),
         )
@@ -341,27 +353,59 @@ class SolveRepo:
         return dict(row) if row else None
         return row
 
-    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0, cost_used: int = 0, solution_json: str = None) -> int:
+    def add_solve(self, user_id: int, puzzle_id: int, time_taken_seconds: int, xp_earned: int, medal: int = 0, cost_used: int = 0, solution_json: str = None, clues_used: int = 0, clue_penalty_seconds: int = 0) -> int:
         """Convenience: insert a passed attempt with time/xp/medal/cost metadata and return its id."""
         import hashlib
         from Backend.DomainLayer.Utils import utcnow
         now = utcnow()
-        
+
         # Compute solution hash if solution is provided
         solution_hash = None
         if solution_json:
             solution_hash = hashlib.md5(solution_json.encode()).hexdigest()
-        
+
         cur = self.conn.execute(
             """
             INSERT INTO solve_attempts(puzzle_id, user_id, started_at, submitted_at, passed,
-                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal, cost_used, solution_hash)
-            VALUES(?,?,?,?,1,?,?,?,?,?,?)
+                                       time_used_seconds, time_taken_seconds, xp_earned, highest_medal, cost_used, solution_hash,
+                                       clues_used, clue_penalty_seconds)
+            VALUES(?,?,?,?,1,?,?,?,?,?,?,?,?)
             """,
             (int(puzzle_id), int(user_id), now.isoformat(), now.isoformat(),
-             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal), int(cost_used), solution_hash),
+             int(time_taken_seconds), int(time_taken_seconds), int(xp_earned), int(medal), int(cost_used), solution_hash,
+             int(clues_used or 0), int(clue_penalty_seconds or 0)),
         )
         return int(cur.lastrowid)
+
+    def close_attempt(self, attempt_id: int) -> None:
+        """Mark an open attempt as submitted so it can no longer accumulate clue requests.
+        Used after a successful validate_solution() to prevent the closed attempt from
+        being reused by /attempts/start or /clue."""
+        from Backend.DomainLayer.Utils import utcnow
+        self.conn.execute(
+            "UPDATE solve_attempts SET submitted_at=? WHERE id=? AND submitted_at IS NULL",
+            (utcnow().isoformat(), int(attempt_id)),
+        )
+
+    def get_attempt_by_id(self, attempt_id: int) -> Optional[SolveAttempt]:
+        row = self.conn.execute(
+            "SELECT * FROM solve_attempts WHERE id=? LIMIT 1",
+            (int(attempt_id),),
+        ).fetchone()
+        if not row:
+            return None
+        return SolveAttempt.from_dict(
+            {
+                "id": int(row["id"]),
+                "puzzle_id": int(row["puzzle_id"]),
+                "user_id": int(row["user_id"]),
+                "circuit_id": row["circuit_id"],
+                "started_at": row["started_at"],
+                "submitted_at": row["submitted_at"],
+                "passed": None if row["passed"] is None else bool(int(row["passed"])),
+                "fail_reason": row["fail_reason"],
+            }
+        )
 
     def get_leaderboard(self, puzzle_id: int, limit: int = 50) -> list[dict]:
         """Return the leaderboard for a puzzle: best (fastest) passed solve per user, ranked by time."""

--- a/src/Backend/ServiceLayer/CluesService.py
+++ b/src/Backend/ServiceLayer/CluesService.py
@@ -1,0 +1,98 @@
+from typing import Any, Dict, Optional
+
+from Backend.DomainLayer.CluePenalty import resolve_clue_penalty
+from Backend.DomainLayer.Exceptions import ValidationError
+from Backend.PersistantLayer.CluesRepo import CluesRepo, CluesExhausted
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.SolveRepo import SolveRepo
+from Backend.PersistantLayer._db import transaction
+from Backend.ServiceLayer.AuthService import AuthService
+
+
+class CluePuzzleHasNoClues(ValidationError):
+    """Puzzle has no clues authored — POST /clue should 404."""
+
+
+class ClueAttemptInvalid(ValidationError):
+    """Attempt id is missing, mismatched, or already submitted."""
+
+
+class CluesAllConsumed(ValidationError):
+    """All clues for this puzzle have been revealed on this attempt — POST /clue should 410."""
+
+
+class CluesService:
+    def __init__(
+        self,
+        conn,
+        clues_repo: CluesRepo,
+        puzzle_repo: PuzzleRepo,
+        solve_repo: SolveRepo,
+        auth: AuthService,
+    ) -> None:
+        self.conn = conn
+        self.clues_repo = clues_repo
+        self.puzzle_repo = puzzle_repo
+        self.solve_repo = solve_repo
+        self.auth = auth
+
+    def request_clue(
+        self,
+        token: str,
+        puzzle_id: int,
+        attempt_id: int,
+        request_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        user_id = self.auth.require_user_id(token)
+
+        puzzle = self.puzzle_repo.get_by_id(int(puzzle_id))
+        if puzzle is None:
+            raise ValidationError("puzzle not found")
+
+        clues = list(getattr(puzzle, "clues", None) or [])
+        if not clues:
+            raise CluePuzzleHasNoClues("puzzle has no clues")
+
+        attempt = self.solve_repo.get_attempt_by_id(int(attempt_id)) if hasattr(self.solve_repo, "get_attempt_by_id") else None
+        if attempt is None:
+            raise ClueAttemptInvalid("attempt not found")
+        if int(attempt.user_id) != int(user_id):
+            raise ClueAttemptInvalid("attempt does not belong to this user")
+        if int(attempt.puzzle_id) != int(puzzle_id):
+            raise ClueAttemptInvalid("attempt does not match puzzle")
+        if attempt.submitted_at is not None:
+            raise ClueAttemptInvalid("attempt already submitted")
+
+        penalty = int(resolve_clue_penalty(puzzle))
+        total_clues = len(clues)
+
+        with transaction(self.conn):
+            try:
+                recorded = self.clues_repo.record_next_clue(
+                    attempt_id=int(attempt_id),
+                    user_id=int(user_id),
+                    puzzle_id=int(puzzle_id),
+                    penalty_seconds=penalty,
+                    total_clues=total_clues,
+                    request_id=request_id,
+                )
+            except CluesExhausted as exc:
+                raise CluesAllConsumed("all clues already revealed for this attempt") from exc
+
+        clue_index = int(recorded["clue_index"])
+        if clue_index < 0 or clue_index >= total_clues:
+            # Defensive: should never happen because record_next_clue gates on total_clues.
+            raise CluesAllConsumed("clue index out of range")
+
+        clues_used = self.clues_repo.count_for_attempt(int(attempt_id))
+        total_penalty = self.clues_repo.total_penalty_for_attempt(int(attempt_id))
+
+        return {
+            "clue_index": clue_index,
+            "clue_text": clues[clue_index],
+            "penalty_seconds": int(recorded["penalty_seconds"]),
+            "total_clues": total_clues,
+            "clues_used_so_far": int(clues_used),
+            "total_penalty_so_far": int(total_penalty),
+            "replayed": bool(recorded.get("replayed", False)),
+        }

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -10,6 +10,7 @@ from Backend.PersistantLayer.SolveRepo import SolveRepo, PuzzleProgress
 from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
 from Backend.PersistantLayer.CircuitRepo import CircuitRepo
 from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.PersistantLayer.CluesRepo import CluesRepo
 from Backend.ServiceLayer.AuthService import AuthService
 from Backend.ServiceLayer.XPService import XPService
 from Backend.ServiceLayer.logicEngineService import logicEngineService
@@ -37,6 +38,7 @@ class SolvingService:
         xp_service: XPService,
         user_repo: UserRepo | None = None,
         notification_service=None,
+        clues_repo: CluesRepo | None = None,
     ):
         self.conn = conn
         self.solve_repo = solve_repo
@@ -47,6 +49,7 @@ class SolvingService:
         self.logic_engine = logic_engine
         self.xp_service = xp_service
         self.notification_service = notification_service
+        self.clues_repo = clues_repo
 
     @property
     def engine(self):
@@ -71,15 +74,37 @@ class SolvingService:
         if p.status != PuzzleStatus.PUBLISHED and creator_id != int(user_id):
             raise ValidationError("puzzle not published")
 
-        attempt = SolveAttempt(id=1, puzzle_id=int(puzzle_id), user_id=int(user_id))
-        created_attempt = self.solve_repo.create_attempt(attempt)
-        # Persist the started attempt so later requests (e.g., rating eligibility)
-        # can read elapsed attempt time from the database.
-        self.conn.commit()
-        
-        result = created_attempt.to_dict() if hasattr(created_attempt, 'to_dict') else dict(created_attempt)
+        # Idempotency: reuse an existing open attempt so a refresh doesn't strand
+        # accumulated clue requests against a freshly created attempt id.
+        existing = self.solve_repo.get_open_attempt(int(user_id), int(puzzle_id))
+        if isinstance(existing, SolveAttempt):
+            attempt_obj = existing
+        else:
+            attempt = SolveAttempt(id=1, puzzle_id=int(puzzle_id), user_id=int(user_id))
+            attempt_obj = self.solve_repo.create_attempt(attempt)
+            self.conn.commit()
+
+        result = attempt_obj.to_dict() if hasattr(attempt_obj, 'to_dict') else dict(attempt_obj)
         if 'puzzle_id' not in result: result['puzzle_id'] = int(puzzle_id)
         if 'user_id' not in result: result['user_id'] = int(user_id)
+
+        # Hydration payload: paid-for clue text + cumulative penalty.
+        revealed_clues: list[dict] = []
+        total_penalty = 0
+        if self.clues_repo is not None and getattr(p, 'clues', None):
+            recorded = self.clues_repo.list_for_attempt(int(attempt_obj.id))
+            clue_texts = list(p.clues or [])
+            for entry in recorded:
+                idx = int(entry["clue_index"])
+                if 0 <= idx < len(clue_texts):
+                    revealed_clues.append({
+                        "index": idx,
+                        "text": clue_texts[idx],
+                        "penalty_seconds": int(entry["penalty_seconds"]),
+                    })
+                total_penalty += int(entry["penalty_seconds"])
+        result["revealed_clues"] = revealed_clues
+        result["total_clue_penalty_seconds"] = int(total_penalty)
         return result
 
     def submit_solution(self, token: str, puzzle_id: int, payload) -> Dict[str, Any]:
@@ -213,17 +238,48 @@ class SolvingService:
         }
 
     # ---------- New Validation Logic (Stateless) ----------
-    def validate_solution(self, token: str, puzzle_id: int, solution_payload: Dict[str, Any], time_taken: int = 0) -> Dict[str, Any]:
+    def validate_solution(self, token: str, puzzle_id: int, solution_payload: Dict[str, Any], time_taken: int = 0, attempt_id: Optional[int] = None) -> Dict[str, Any]:
         """
         Stateless validation of a solution attempt.
         If the solution passes, calculate medal, persist solve with delta XP, award creator XP.
+
+        Clue penalty contract (server-authoritative):
+          - `time_taken` is the raw client elapsed time. The server adds the sum of
+            persisted clue penalties for `attempt_id` (or the user's open attempt
+            if `attempt_id` is omitted) to compute the effective time used for medal
+            calculation and persisted on the solved row.
+          - On success the open attempt is closed so further clue requests fail.
         """
         print(f"[SOLVING_SERVICE] validate_solution called with puzzle_id={puzzle_id}")
         user_id = self.auth.require_user_id(token)
-        
+
         p = self.puzzle_repo.get_by_id(puzzle_id)
         if not p:
             raise ValidationError("puzzle not found")
+
+        # Resolve the attempt this validate is being recorded against.
+        # - If attempt_id is provided, validate ownership/puzzle/open-state strictly.
+        # - If absent, reuse the user's open attempt (back-compat for legacy callers
+        #   that don't track attempt ids); penalty stays 0 if there are no clue requests.
+        resolved_attempt_id: Optional[int] = None
+        if attempt_id is not None:
+            attempt_row = self.solve_repo.get_attempt_by_id(int(attempt_id)) if hasattr(self.solve_repo, 'get_attempt_by_id') else None
+            if attempt_row is None:
+                raise ValidationError("attempt not found")
+            if int(attempt_row.user_id) != int(user_id) or int(attempt_row.puzzle_id) != int(puzzle_id):
+                raise ValidationError("attempt does not belong to this user/puzzle")
+            if attempt_row.submitted_at is not None:
+                raise ValidationError("attempt already submitted")
+            resolved_attempt_id = int(attempt_row.id)
+        else:
+            existing_open = self.solve_repo.get_open_attempt(int(user_id), int(puzzle_id))
+            resolved_attempt_id = int(existing_open.id) if isinstance(existing_open, SolveAttempt) else None
+
+        persisted_clue_penalty = 0
+        persisted_clues_used = 0
+        if resolved_attempt_id is not None and self.clues_repo is not None:
+            persisted_clue_penalty = int(self.clues_repo.total_penalty_for_attempt(resolved_attempt_id))
+            persisted_clues_used = int(self.clues_repo.count_for_attempt(resolved_attempt_id))
             
         test_cases = self.puzzle_repo.list_test_cases(puzzle_id)
         if not test_cases:
@@ -275,7 +331,10 @@ class SolvingService:
         
         if passed:
             cost_used = int(solution_payload.get("totalCost", 0))
-            time_taken_s = max(0, int(time_taken))
+            time_taken_raw_s = max(0, int(time_taken))
+            # Effective time used everywhere downstream (medal, leaderboard, persisted row)
+            # is raw + persisted clue penalty. Server is the source of truth.
+            time_taken_s = time_taken_raw_s + int(persisted_clue_penalty)
 
             # --- Determine difficulty tier for XP ---
             # Use creator-set puzzle difficulty first so XP/medal rewards stay
@@ -377,9 +436,9 @@ class SolvingService:
                             "first_time_solve": False,
                         }
                 
-                attempt_id = None
+                solved_attempt_id = None
                 if hasattr(self.solve_repo, 'add_solve'):
-                    attempt_id = self.solve_repo.add_solve(
+                    solved_attempt_id = self.solve_repo.add_solve(
                         user_id=user_id,
                         puzzle_id=puzzle_id,
                         time_taken_seconds=time_taken_s,
@@ -387,7 +446,15 @@ class SolvingService:
                         medal=medal.value if isinstance(medal, Medal) else int(medal),
                         cost_used=cost_used,
                         solution_json=solution_json,
+                        clues_used=int(persisted_clues_used),
+                        clue_penalty_seconds=int(persisted_clue_penalty),
                     )
+
+                # Close the open attempt so it cannot be reused for further clue
+                # requests. The /attempts/start path will create a fresh attempt
+                # for any subsequent solve-again flow.
+                if resolved_attempt_id is not None and hasattr(self.solve_repo, 'close_attempt'):
+                    self.solve_repo.close_attempt(int(resolved_attempt_id))
 
                 if hasattr(self.solve_repo, 'upsert_progress'):
                     new_best_medal = medal.value if isinstance(medal, Medal) else int(medal)
@@ -420,9 +487,9 @@ class SolvingService:
                 xp_earned = max(0, xp_earned)
 
                 # Prefer attempt-history truth for first-time solve detection.
-                if hasattr(self.solve_repo, 'has_passed_before_attempt') and attempt_id is not None:
+                if hasattr(self.solve_repo, 'has_passed_before_attempt') and solved_attempt_id is not None:
                     try:
-                        is_first_time_solve = not self.solve_repo.has_passed_before_attempt(user_id, puzzle_id, attempt_id)
+                        is_first_time_solve = not self.solve_repo.has_passed_before_attempt(user_id, puzzle_id, solved_attempt_id)
                     except Exception:
                         pass
 
@@ -479,11 +546,15 @@ class SolvingService:
                 "medal_value": medal.value if isinstance(medal, Medal) else int(medal),
             }
         else:
-            # Record failed attempt so time accumulates for rating eligibility
+            # Record failed attempt so time accumulates for rating eligibility.
+            # NOTE: per the clue-penalty contract, this is a separate analytics row
+            # — the open attempt that owns clue_requests stays open so the student
+            # keeps their accumulated penalty when they retry without leaving.
             try:
                 from Backend.DomainLayer.Utils import utcnow
                 now = utcnow()
-                time_taken_s = max(0, int(time_taken))
+                time_taken_raw_s = max(0, int(time_taken))
+                effective_time_taken_s = time_taken_raw_s + int(persisted_clue_penalty)
                 attempt = SolveAttempt(
                     id=0,
                     puzzle_id=int(puzzle_id),
@@ -492,7 +563,9 @@ class SolvingService:
                     submitted_at=now,
                     passed=False,
                     fail_reason=fail_msg or "wrong answer",
-                    time_used_seconds=time_taken_s,
+                    time_used_seconds=effective_time_taken_s,
+                    clues_used=int(persisted_clues_used),
+                    clue_penalty_seconds=int(persisted_clue_penalty),
                 )
                 self.solve_repo.create_attempt(attempt)
                 self.conn.commit()

--- a/src/Backend/main.py
+++ b/src/Backend/main.py
@@ -14,6 +14,7 @@ from Backend.PersistantLayer.CircuitRepo import CircuitRepo
 from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
 from Backend.PersistantLayer.RatingRepo import RatingRepo
 from Backend.PersistantLayer.SolveRepo import SolveRepo
+from Backend.PersistantLayer.CluesRepo import CluesRepo
 from Backend.PersistantLayer.NotificationRepo import NotificationRepo
 from Backend.PersistantLayer.AuditLogRepo import AuditLogRepo
 from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
@@ -29,6 +30,7 @@ from Backend.ServiceLayer.CircuitService import CircuitService
 from Backend.ServiceLayer.ArsenalService import ArsenalService
 from Backend.ServiceLayer.PuzzleService import PuzzleService
 from Backend.ServiceLayer.SolvingService import SolvingService
+from Backend.ServiceLayer.CluesService import CluesService
 from Backend.ServiceLayer.RatingService import RatingService
 from Backend.ServiceLayer.logicEngineService import logicEngineService
 from Backend.ServiceLayer.NotificationService import NotificationService
@@ -66,6 +68,7 @@ def create_app() -> FastAPI:
     puzzle_repo = PuzzleRepo(conn)
     rating_repo = RatingRepo(conn)
     solve_repo = SolveRepo(conn)
+    clues_repo = CluesRepo(conn)
     notification_repo = NotificationRepo(conn)
     audit_log_repo = AuditLogRepo(conn)
     discussion_repo = DiscussionRepo(conn)
@@ -124,6 +127,16 @@ def create_app() -> FastAPI:
         xp_service,
         user_repo,
         notification_service,
+        clues_repo=clues_repo,
+    )
+
+    # Clues Service
+    clues_service = CluesService(
+        conn=conn,
+        clues_repo=clues_repo,
+        puzzle_repo=puzzle_repo,
+        solve_repo=solve_repo,
+        auth=auth_service,
     )
 
     # Puzzle Service
@@ -205,7 +218,7 @@ def create_app() -> FastAPI:
     app.include_router(build_user_router(user_service, notification_service))
     app.include_router(build_circuit_router(circuit_service))
     app.include_router(build_arsenal_router(arsenal_service, solving_service))
-    app.include_router(build_puzzle_router(puzzle_service, solving_service, rating_service, admin_service))
+    app.include_router(build_puzzle_router(puzzle_service, solving_service, rating_service, admin_service, clues_service=clues_service))
     app.include_router(build_rating_router(rating_service))
     app.include_router(build_admin_router(admin_service))
     app.include_router(build_debugger_router(logic_engine, circuit_repo))

--- a/src/insert_riddles.py
+++ b/src/insert_riddles.py
@@ -349,6 +349,10 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
     # Check if puzzle already exists by name — preserve its ID for solve_attempts
     existing = c.execute("SELECT id FROM puzzles WHERE name = ?", (puzzle_data['name'],)).fetchone()
     
+    clues_payload = puzzle_data.get('clues')
+    clues_json = json.dumps(clues_payload) if isinstance(clues_payload, list) and clues_payload else None
+    clue_penalty_seconds = puzzle_data.get('clue_penalty_seconds')
+
     if existing:
         puzzle_id = existing[0]
         # Update description/budget/creator_budget/instructions/config but keep the same ID
@@ -358,7 +362,8 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
                 default_gate_set=?, difficulty=?,
                 min_gate_count=?, total_gate_count=?, min_cycles=?, max_cycles=?,
                 board_rows=?, board_cols=?,
-                allow_arsenal=?, allowed_arsenal_component_ids=?, arsenal_component_display_modes=?, riddle_base_name=?, initial_board_json=?
+                allow_arsenal=?, allowed_arsenal_component_ids=?, arsenal_component_display_modes=?, riddle_base_name=?, initial_board_json=?,
+                clues_json=?, clue_penalty_seconds=?
             WHERE id=?
         """, (
             description,
@@ -379,6 +384,8 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             json.dumps(puzzle_data.get('arsenal_component_display_modes')) if puzzle_data.get('arsenal_component_display_modes') else None,
             puzzle_data.get('riddle_base_name'),
             initial_board_json,
+            clues_json,
+            clue_penalty_seconds,
             puzzle_id
         ))
         # Clear old test cases for this puzzle (they get re-imported below)
@@ -388,13 +395,14 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
         c.execute("""
             INSERT INTO puzzles (
                 name, creator_user_id, description, instructions, status, budget, creator_budget,
-                time_limit_seconds, difficulty, default_gate_set, rating_count, 
+                time_limit_seconds, difficulty, default_gate_set, rating_count,
                 avg_difficulty, avg_fun, avg_clearness,
                 min_gate_count, total_gate_count, min_cycles, max_cycles,
                 allow_arsenal, allowed_arsenal_component_ids, arsenal_component_display_modes,
                 board_rows, board_cols, riddle_base_name, initial_board_json,
+                clues_json, clue_penalty_seconds,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             puzzle_data['name'],
             creator_id,
@@ -418,6 +426,8 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
             puzzle_data.get('board', {}).get('cols'),
             puzzle_data.get('riddle_base_name'),
             initial_board_json,
+            clues_json,
+            clue_penalty_seconds,
             utcnow().isoformat()
         ))
         puzzle_id = c.lastrowid
@@ -644,17 +654,21 @@ def insert_puzzle_to_db(conn, config_data: dict, instructions_text: str, creator
     if existing:
         puzzle_id = existing[0]
     else:
+        clues_payload2 = puzzle_data.get('clues')
+        clues_json2 = json.dumps(clues_payload2) if isinstance(clues_payload2, list) and clues_payload2 else None
+        clue_penalty_seconds2 = puzzle_data.get('clue_penalty_seconds')
         # INSERT new puzzle
         c.execute("""
             INSERT INTO puzzles (
                 name, creator_user_id, description, instructions, status, budget, creator_budget,
-                time_limit_seconds, difficulty, default_gate_set, rating_count, 
+                time_limit_seconds, difficulty, default_gate_set, rating_count,
                 avg_difficulty, avg_fun, avg_clearness,
                 min_gate_count, total_gate_count, min_cycles, max_cycles,
                 allow_arsenal, allowed_arsenal_component_ids, arsenal_component_display_modes,
                 board_rows, board_cols, riddle_base_name,
+                clues_json, clue_penalty_seconds,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             puzzle_data['name'],
             creator_id,
@@ -677,6 +691,8 @@ def insert_puzzle_to_db(conn, config_data: dict, instructions_text: str, creator
             puzzle_data.get('board', {}).get('rows'),
             puzzle_data.get('board', {}).get('cols'),
             puzzle_data.get('riddle_base_name'),
+            clues_json2,
+            clue_penalty_seconds2,
             utcnow().isoformat()
         ))
         puzzle_id = c.lastrowid

--- a/src/tests/IntegrationTests/conftest.py
+++ b/src/tests/IntegrationTests/conftest.py
@@ -16,6 +16,7 @@ from Backend.PersistantLayer.CircuitRepo import CircuitRepo
 from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
 from Backend.PersistantLayer.RatingRepo import RatingRepo
 from Backend.PersistantLayer.SolveRepo import SolveRepo
+from Backend.PersistantLayer.CluesRepo import CluesRepo
 from Backend.PersistantLayer.NotificationRepo import NotificationRepo
 from Backend.PersistantLayer.AuditLogRepo import AuditLogRepo
 from Backend.PersistantLayer.DiscussionRepo import DiscussionRepo
@@ -31,6 +32,7 @@ from Backend.ServiceLayer.CircuitService import CircuitService
 from Backend.ServiceLayer.ArsenalService import ArsenalService
 from Backend.ServiceLayer.PuzzleService import PuzzleService
 from Backend.ServiceLayer.SolvingService import SolvingService
+from Backend.ServiceLayer.CluesService import CluesService
 from Backend.ServiceLayer.RatingService import RatingService
 from Backend.ServiceLayer.logicEngineService import logicEngineService
 from Backend.ServiceLayer.NotificationService import NotificationService
@@ -57,6 +59,7 @@ def _build_test_app(conn: sqlite3.Connection) -> FastAPI:
     puzzle_repo = PuzzleRepo(conn)
     rating_repo = RatingRepo(conn)
     solve_repo = SolveRepo(conn)
+    clues_repo = CluesRepo(conn)
     notification_repo = NotificationRepo(conn)
     audit_log_repo = AuditLogRepo(conn)
     discussion_repo = DiscussionRepo(conn)
@@ -80,6 +83,11 @@ def _build_test_app(conn: sqlite3.Connection) -> FastAPI:
     solving_service = SolvingService(
         conn, solve_repo, puzzle_repo, circuit_repo,
         auth_service, logic_engine, xp_service, user_repo, notification_service,
+        clues_repo=clues_repo,
+    )
+    clues_service = CluesService(
+        conn=conn, clues_repo=clues_repo, puzzle_repo=puzzle_repo,
+        solve_repo=solve_repo, auth=auth_service,
     )
     puzzle_service = PuzzleService(puzzle_repo, user_repo, auth_service, solve_repo, arsenal_service)
     rating_service = RatingService(rating_repo, puzzle_repo, solve_repo, auth_service, xp_service, notification_service)
@@ -108,7 +116,7 @@ def _build_test_app(conn: sqlite3.Connection) -> FastAPI:
     app.include_router(build_user_router(user_service, notification_service))
     app.include_router(build_circuit_router(circuit_service))
     app.include_router(build_arsenal_router(arsenal_service, solving_service))
-    app.include_router(build_puzzle_router(puzzle_service, solving_service, rating_service, admin_service))
+    app.include_router(build_puzzle_router(puzzle_service, solving_service, rating_service, admin_service, clues_service=clues_service))
     app.include_router(build_rating_router(rating_service))
     app.include_router(build_admin_router(admin_service))
     app.include_router(build_debugger_router(logic_engine))

--- a/src/tests/ServiceLayerTests/test_solving_service.py
+++ b/src/tests/ServiceLayerTests/test_solving_service.py
@@ -83,6 +83,9 @@ class TestSolvingServiceStartAttempt:
         puzzle = Puzzle(id=1, name="Test", creator_user_id=2, status=PuzzleStatus.PUBLISHED)
         self.mock_puzzle_repo.get_by_id.return_value = puzzle
 
+        # No prior open attempt → idempotency path falls through to create_attempt.
+        self.mock_solve_repo.get_open_attempt.return_value = None
+
         # The repo returns the attempt with id assigned by DB
 
         saved_attempt = Mock(spec=SolveAttempt)

--- a/src/tests/SystemTests/test_clue_penalty.py
+++ b/src/tests/SystemTests/test_clue_penalty.py
@@ -1,0 +1,397 @@
+import json
+
+from .conftest import (
+    auth_header,
+    create_and_publish_puzzle,
+    make_creator,
+    register_and_login,
+    validate_solution,
+    _and_solution,
+)
+
+
+def _attach_clues(conn, puzzle_id, clues, clue_penalty_seconds=None):
+    conn.execute(
+        "UPDATE puzzles SET clues_json=?, clue_penalty_seconds=? WHERE id=?",
+        (json.dumps(clues), clue_penalty_seconds, int(puzzle_id)),
+    )
+    conn.commit()
+
+
+def _start_attempt(client, token, pid):
+    resp = client.post(
+        f"/puzzles/{pid}/attempts/start",
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _request_clue(client, token, pid, attempt_id, request_id=None):
+    resp = client.post(
+        f"/puzzles/{pid}/clue",
+        json={"attempt_id": attempt_id, "request_id": request_id},
+        headers=auth_header(token),
+    )
+    return resp
+
+
+def _validate_with_attempt(client, token, pid, solution, time_taken_raw, attempt_id):
+    resp = client.post(
+        f"/puzzles/{pid}/validate",
+        json={
+            "solution": solution,
+            "time_taken_raw": time_taken_raw,
+            "attempt_id": attempt_id,
+        },
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestClueExposure:
+    def test_puzzle_payload_redacts_clue_text(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_redact_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Redact",
+            budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["secret hint A", "secret hint B"])
+
+        solver_token = register_and_login(client, "clue_redact_solver")
+        resp = client.get(f"/puzzles/{pid}", headers=auth_header(solver_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        # The text array must NOT be exposed; only metadata.
+        serialized = json.dumps(body)
+        assert "secret hint A" not in serialized
+        assert "secret hint B" not in serialized
+        assert body.get("has_clues") is True
+        assert body.get("clue_count") == 2
+        # EASY tier default is 15s.
+        assert body.get("clue_penalty_seconds") == 15
+
+
+class TestClueRequestFlow:
+    def test_request_clue_returns_text_and_records_penalty(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_request_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Request", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["alpha clue", "beta clue", "gamma clue"])
+
+        solver_token = register_and_login(client, "clue_request_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        resp = _request_clue(client, solver_token, pid, attempt_id)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["clue_index"] == 0
+        assert body["clue_text"] == "alpha clue"
+        assert body["penalty_seconds"] == 15  # EASY default
+        assert body["total_clues"] == 3
+        assert body["clues_used_so_far"] == 1
+        assert body["total_penalty_so_far"] == 15
+        assert body["replayed"] is False
+
+    def test_two_clues_inflate_recorded_time(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_inflate_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Inflate", budget=10, time_limit=300, difficulty="MEDIUM",
+        )
+        _attach_clues(conn, pid, ["c1", "c2", "c3"])
+
+        solver_token = register_and_login(client, "clue_inflate_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        # Two clues: MEDIUM tier defaults to 30s each.
+        _request_clue(client, solver_token, pid, attempt_id, "rid-1")
+        _request_clue(client, solver_token, pid, attempt_id, "rid-2")
+
+        result = _validate_with_attempt(
+            client, solver_token, pid,
+            _and_solution(), time_taken_raw=10, attempt_id=attempt_id,
+        )
+        assert result["solved"] is True
+        # Effective recorded time = 10 raw + 2 * 30 = 70
+        assert result["time_taken"] == 70
+
+        # Leaderboard reflects the inflated time. The creator self-solves during
+        # publish, so look up the solver's row specifically.
+        lb = client.get(
+            f"/puzzles/{pid}/leaderboard?type=time",
+            headers=auth_header(solver_token),
+        ).json()
+        solver_rows = [e for e in lb["data"] if e["username"] == "clue_inflate_solver"]
+        assert len(solver_rows) == 1
+        assert solver_rows[0]["best_time"] == 70
+
+    def test_idempotent_request_id_does_not_double_charge(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_idem_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Idempotency", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["one", "two"])
+
+        solver_token = register_and_login(client, "clue_idem_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        first = _request_clue(client, solver_token, pid, attempt_id, "rid-shared").json()
+        second = _request_clue(client, solver_token, pid, attempt_id, "rid-shared").json()
+
+        assert first["clue_index"] == 0
+        assert first["replayed"] is False
+        assert second["clue_index"] == 0
+        assert second["replayed"] is True
+        # Total penalty so far reflects exactly one consumed clue, not two.
+        assert second["total_penalty_so_far"] == first["penalty_seconds"]
+
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM clue_requests WHERE attempt_id=?",
+            (attempt_id,),
+        ).fetchone()
+        assert rows[0] == 1
+
+    def test_distinct_request_ids_consume_distinct_clues(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_distinct_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Distinct", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["one", "two", "three"])
+
+        solver_token = register_and_login(client, "clue_distinct_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        a = _request_clue(client, solver_token, pid, attempt_id, "rid-a").json()
+        b = _request_clue(client, solver_token, pid, attempt_id, "rid-b").json()
+
+        assert {a["clue_index"], b["clue_index"]} == {0, 1}
+        assert a["replayed"] is False and b["replayed"] is False
+
+    def test_exhaustion_returns_410(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_exhaust_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Clue Exhaust", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["only one"])
+
+        solver_token = register_and_login(client, "clue_exhaust_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        first = _request_clue(client, solver_token, pid, attempt_id, "first")
+        assert first.status_code == 200
+        second = _request_clue(client, solver_token, pid, attempt_id, "second")
+        assert second.status_code == 410, second.text
+
+    def test_no_clues_returns_404(self, client, conn):
+        creator_token = make_creator(client, conn, "clue_none_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="No Clues", budget=10, time_limit=60, difficulty="EASY",
+        )
+
+        solver_token = register_and_login(client, "clue_none_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        resp = _request_clue(client, solver_token, pid, attempt_id, "x")
+        assert resp.status_code == 404, resp.text
+
+
+class TestStartAttemptHydration:
+    def test_idempotent_start_returns_existing_attempt_with_clues(self, client, conn):
+        creator_token = make_creator(client, conn, "hydrate_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Hydrate", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["alpha", "beta", "gamma"])
+
+        solver_token = register_and_login(client, "hydrate_solver")
+        first = _start_attempt(client, solver_token, pid)
+        attempt_id = first["id"]
+
+        _request_clue(client, solver_token, pid, attempt_id, "rid-1")
+        _request_clue(client, solver_token, pid, attempt_id, "rid-2")
+
+        # Refresh: hitting /attempts/start again should not create a new attempt
+        # and should hydrate the user's revealed clue text + penalty.
+        second = _start_attempt(client, solver_token, pid)
+        assert second["id"] == attempt_id
+        assert second["started_at"] == first["started_at"]
+        assert second["total_clue_penalty_seconds"] == 30  # 2 * 15
+        revealed = second["revealed_clues"]
+        assert len(revealed) == 2
+        assert {c["index"] for c in revealed} == {0, 1}
+        assert {c["text"] for c in revealed} == {"alpha", "beta"}
+
+
+class TestSolveClosesAttempt:
+    def test_solve_closes_attempt_and_blocks_clue_requests(self, client, conn):
+        creator_token = make_creator(client, conn, "close_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Close Attempt", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["one", "two"])
+
+        solver_token = register_and_login(client, "close_solver")
+        first = _start_attempt(client, solver_token, pid)
+        first_attempt_id = first["id"]
+
+        _request_clue(client, solver_token, pid, first_attempt_id, "rid-a")
+        _validate_with_attempt(
+            client, solver_token, pid,
+            _and_solution(), time_taken_raw=5, attempt_id=first_attempt_id,
+        )
+
+        # The closed attempt now refuses new clue requests.
+        rejected = _request_clue(client, solver_token, pid, first_attempt_id, "rid-b")
+        assert rejected.status_code == 403, rejected.text
+
+        # Solve again -> fresh attempt with no revealed clues.
+        second = _start_attempt(client, solver_token, pid)
+        assert second["id"] != first_attempt_id
+        assert second["revealed_clues"] == []
+        assert second["total_clue_penalty_seconds"] == 0
+
+        ok = _request_clue(client, solver_token, pid, second["id"], "rid-c")
+        assert ok.status_code == 200
+        assert ok.json()["clue_index"] == 0
+
+
+class TestFailedAttemptKeepsClues:
+    def test_failed_attempt_row_records_clue_metadata(self, client, conn):
+        creator_token = make_creator(client, conn, "fail_meta_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Failed Row Clue Meta", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["x1", "x2"])
+
+        solver_token = register_and_login(client, "fail_meta_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        _request_clue(client, solver_token, pid, attempt_id, "rid-x1")
+        _request_clue(client, solver_token, pid, attempt_id, "rid-x2")
+
+        bad_solution = {
+            "placedComponents": [
+                {"id": "and1", "componentId": "AND"},
+                {"id": "not1", "componentId": "NOT"},
+            ],
+            "wires": [
+                {"from": {"componentId": "IO:IN:A", "pinIndex": 0},
+                 "to": {"componentId": "and1", "pinIndex": 0}},
+                {"from": {"componentId": "IO:IN:B", "pinIndex": 0},
+                 "to": {"componentId": "and1", "pinIndex": 1}},
+                {"from": {"componentId": "and1", "pinIndex": 2},
+                 "to": {"componentId": "not1", "pinIndex": 0}},
+                {"from": {"componentId": "not1", "pinIndex": 1},
+                 "to": {"componentId": "IO:OUT:out", "pinIndex": 0}},
+            ],
+            "totalCost": 2,
+        }
+        result = _validate_with_attempt(
+            client, solver_token, pid, bad_solution,
+            time_taken_raw=7, attempt_id=attempt_id,
+        )
+        assert result["solved"] is False
+
+        # The most recent failed-attempt analytics row for this user/puzzle
+        # must record both clues_used and clue_penalty_seconds (2 * 15 = 30).
+        row = conn.execute(
+            """
+            SELECT clues_used, clue_penalty_seconds, time_used_seconds, passed
+            FROM solve_attempts
+            WHERE puzzle_id=? AND passed=0
+            ORDER BY id DESC LIMIT 1
+            """,
+            (int(pid),),
+        ).fetchone()
+        assert row is not None
+        assert int(row["clues_used"]) == 2
+        assert int(row["clue_penalty_seconds"]) == 30
+        # Effective time on the failed row = raw + persisted penalty.
+        assert int(row["time_used_seconds"]) == 7 + 30
+
+    def test_failed_then_successful_solve_carries_clue_penalty(self, client, conn):
+        creator_token = make_creator(client, conn, "carry_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Carry Penalty", budget=10, time_limit=60, difficulty="EASY",
+        )
+        _attach_clues(conn, pid, ["help-one"])
+
+        solver_token = register_and_login(client, "carry_solver")
+        attempt = _start_attempt(client, solver_token, pid)
+        attempt_id = attempt["id"]
+
+        _request_clue(client, solver_token, pid, attempt_id, "rid-1")
+
+        # First submit: a wrong solution that swaps the truth table — NOT(A AND B)
+        # produces 1 for (0,0) and 0 for (1,1), failing both blackbox cases.
+        bad_solution = {
+            "placedComponents": [
+                {"id": "and1", "componentId": "AND"},
+                {"id": "not1", "componentId": "NOT"},
+            ],
+            "wires": [
+                {"from": {"componentId": "IO:IN:A", "pinIndex": 0},
+                 "to": {"componentId": "and1", "pinIndex": 0}},
+                {"from": {"componentId": "IO:IN:B", "pinIndex": 0},
+                 "to": {"componentId": "and1", "pinIndex": 1}},
+                {"from": {"componentId": "and1", "pinIndex": 2},
+                 "to": {"componentId": "not1", "pinIndex": 0}},
+                {"from": {"componentId": "not1", "pinIndex": 1},
+                 "to": {"componentId": "IO:OUT:out", "pinIndex": 0}},
+            ],
+            "totalCost": 2,
+        }
+        bad = _validate_with_attempt(
+            client, solver_token, pid, bad_solution,
+            time_taken_raw=5, attempt_id=attempt_id,
+        )
+        assert bad["solved"] is False
+
+        # Now submit the correct solution. Clue penalty is still applied.
+        good = _validate_with_attempt(
+            client, solver_token, pid, _and_solution(),
+            time_taken_raw=12, attempt_id=attempt_id,
+        )
+        assert good["solved"] is True
+        # 12 raw + 15 penalty = 27
+        assert good["time_taken"] == 27
+
+
+class TestValidateContract:
+    def test_legacy_validate_without_attempt_id_works(self, client, conn):
+        # This mirrors the behavior covered by test_retry_and_edge_case_regressions:
+        # when no attempt_id is sent, validate must not 400 — it falls back to the
+        # user's open attempt (or creates one inline) with zero clue penalty.
+        creator_token = make_creator(client, conn, "legacy_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="Legacy", budget=10, time_limit=60, difficulty="EASY",
+        )
+
+        solver_token = register_and_login(client, "legacy_solver")
+        result = validate_solution(
+            client, solver_token, pid, _and_solution(), time_taken=10,
+        )
+        assert result["solved"] is True
+        assert result["time_taken"] == 10  # no penalty applied


### PR DESCRIPTION
## What this adds

A clue/help system: stuck players can ask for hints, and every clue costs them time. Each request both subtracts time from the live timer and adds the same amount to the time recorded on the leaderboard. Closes #260.

## Cost per clue

| Difficulty | Cost      |
| ---------- | --------- |
| Easy       | **15 s**  |
| Medium     | **30 s**  |
| Hard       | **60 s**  |

Stacks per clue. Each puzzle can override its own cost via `clue_penalty_seconds` in its config.

## Two cases, depending on the puzzle's timer

**Puzzles WITH a countdown** (e.g. Binary Adder, 5 min limit):
- The countdown shrinks by the penalty the moment a clue is revealed.
- A separate red pill `Time-taken penalty: +Ns` shows up next to the timer to make the leaderboard impact explicit.
- Warning + toast: *"This will subtract 15s from your live countdown AND add 15s to your recorded time taken."*

**Puzzles WITHOUT a countdown** (just an elapsed timer, e.g. Half Adder):
- The elapsed timer jumps forward by the penalty (since elapsed = recorded time here).
- A compact `+Ns` badge sits inside the timer pill.
- Warning + toast: *"This will add 15s to your time taken."*

In both cases the player gets a confirmation dialog before being charged, a toast confirming the hit, and a panel listing the clues they've paid for.

## Behind the scenes

- **Server is authoritative on the cost** — frontend sends raw elapsed; backend adds the penalty itself.
- **Clue text is never in the puzzle payload** — only fetched on demand once the cost is recorded.
- **Refresh-safe** — reload mid-puzzle and the timer + paid clues come back exactly as they were.
- **Retry-safe** — duplicate "reveal" requests don't double-charge.
- **Failed solves keep the penalty** — clues stay attached to the open attempt; "Solve again" after success starts a clean slate.

Sample clues are authored for the Binary Adder (Easy) and Sequential Binary Adder (Medium); other puzzles can opt in by adding `clues` to their config.

## Test plan

- [ ] Countdown puzzle: reveal a clue → countdown drops by 15/30/60s, separate "Time-taken penalty" pill appears, warning + toast mention both effects.
- [ ] No-countdown puzzle: reveal a clue → elapsed timer jumps forward, embedded `+Ns` badge in the timer, warning + toast mention only time taken.
- [ ] Cancel the warning dialog → no charge.
- [ ] Reveal multiple clues → penalty stacks; the panel grows.
- [ ] Submit wrong → "Try again" keeps clues + timer; resubmit correctly → leaderboard `time_taken` = raw + total penalty.
- [ ] After solving, "Solve again" resets to 0/N.
- [ ] Refresh mid-puzzle → timer + paid clues hydrate correctly.
- [ ] Use up all clues → button disables ("All clues used").
- [ ] Network tab: puzzle GET response has `has_clues`/`clue_count`/`clue_penalty_seconds` but **no** clue text.
- [ ] `pytest` passes (2037 tests, 12 new); `npm run check-types`, `npm run lint`, `npm run build` clean.