### PR TITLE
Polish register page layout & arsenal creator grid (#264)

### DIFF
--- a/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
@@ -577,7 +577,7 @@ export default function ArsenalCreatorPage() {
       </div>
 
       {/* Workstation - Main grid layout (stretches full remaining height) */}
-      <div className="flex-1 px-6 pb-3 flex gap-4 min-h-0">
+      <div className="flex min-h-[calc(100vh-9rem)] flex-1 gap-4 px-6 pb-3">
         <WorkstationMenu
           basic={BASIC_COMPONENTS}
           custom={[]}
@@ -610,6 +610,7 @@ export default function ArsenalCreatorPage() {
           onWiresChange={setWires}
           draggedPaletteComponentId={draggedPaletteComponentId}
           viewportClassName="h-full"
+          emptyHoleClassName="size-2 bg-muted-foreground/35 hover:bg-muted-foreground/60"
         />
       </div>
 

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -204,6 +204,7 @@ export const WorkstationGrid = ({
   isEditMode = false,
   viewportClassName,
   disableZoomPersistence = false,
+  emptyHoleClassName,
 }: {
   puzzleId: string;
   inputs: string[];
@@ -237,6 +238,7 @@ export const WorkstationGrid = ({
   isEditMode?: boolean;
   viewportClassName?: string;
   disableZoomPersistence?: boolean;
+  emptyHoleClassName?: string;
 }) => {
   const gridRows = Math.max(1, boardRows ?? DEFAULT_GRID_ROWS);
   const gridCols = Math.max(1, boardCols ?? DEFAULT_GRID_COLS);
@@ -2334,7 +2336,7 @@ export const WorkstationGrid = ({
                             ? 'size-3 bg-blue-400'
                             : occ
                               ? 'size-3 bg-muted-foreground/50'
-                              : 'size-1 bg-muted-foreground/30 hover:bg-muted-foreground/50',
+                              : (emptyHoleClassName ?? 'size-1 bg-muted-foreground/30 hover:bg-muted-foreground/50'),
                         )}
                         onPointerDown={(e) => {
                           e.stopPropagation();

--- a/apps/nextjs-app/src/app/auth/register/page.tsx
+++ b/apps/nextjs-app/src/app/auth/register/page.tsx
@@ -8,6 +8,7 @@ import { GoogleLogin } from '@react-oauth/google';
 import { useNavigationLoading } from '@/components/ui/navigation-loading/navigation-loading';
 import { useNotifications } from '@/components/ui/notifications';
 import { CircuitBackground } from '@/components/ui/circuit-background/CircuitBackground';
+import { AvatarDisplay } from '@/components/ui/avatar-display';
 import { paths } from '@/config/paths';
 import { useGoogleLogin, useRegister } from '@/lib/auth';
 
@@ -186,7 +187,7 @@ export default function RegisterPage() {
       />
 
       <div
-        className="relative mx-4 w-full max-w-[380px] rounded-2xl px-8 py-10"
+        className="relative mx-4 my-6 w-full max-w-5xl rounded-2xl px-6 py-8 md:px-10 md:py-10"
         style={{
           background: 'rgba(255,255,255,0.03)',
           border: '0.5px solid rgba(56,189,248,0.2)',
@@ -264,7 +265,11 @@ export default function RegisterPage() {
           Join and start solving circuits
         </p>
 
-        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+            {/* Left column: credentials */}
+            <div className="flex h-full flex-col">
+              <div className="flex flex-1 flex-col justify-center space-y-4">
           <div>
             <label
               className="mb-1.5 block text-[11px] uppercase tracking-[0.1em]"
@@ -357,6 +362,37 @@ export default function RegisterPage() {
             )}
           </div>
 
+          {error && (
+            <p
+              className="rounded-lg border px-3 py-2 text-[12px]"
+              style={{
+                borderColor: 'rgba(248,113,113,0.35)',
+                background: 'rgba(127,29,29,0.2)',
+                color: 'rgb(254 202 202)',
+              }}
+            >
+              {error}
+            </p>
+          )}
+              </div>
+            </div>
+
+            {/* Right column: identity picker */}
+            <div className="flex flex-col space-y-4">
+          <div className="flex justify-center pt-1">
+            {selectedAvatar ? (
+              <AvatarDisplay
+                avatarName={selectedAvatar}
+                avatarColor={useCustomColor ? customColor : selectedColor}
+                size="xl"
+              />
+            ) : (
+              <div className="flex h-24 w-24 items-center justify-center rounded-2xl border border-dashed border-sky-400/30 bg-white/5 text-[11px] text-slate-400">
+                Choose avatar
+              </div>
+            )}
+          </div>
+
           <div>
             <label
               className="mb-1.5 block text-[11px] uppercase tracking-[0.1em]"
@@ -432,6 +468,7 @@ export default function RegisterPage() {
                     type="button"
                     onClick={() => {
                       setSelectedColor(color);
+                      setCustomColor(color);
                       setUseCustomColor(false);
                     }}
                     className="w-8 h-8 rounded-lg border-2 transition-all"
@@ -483,99 +520,90 @@ export default function RegisterPage() {
               </div>
             </div>
           </div>
+            </div>
+          </div>
 
-          {error && (
-            <p
-              className="rounded-lg border px-3 py-2 text-[12px]"
+          <div className="mx-auto mt-8 w-full max-w-sm space-y-3">
+            <button
+              type="submit"
+              disabled={register.isPending}
+              className="w-full rounded-lg border py-2.5 text-sm font-semibold tracking-[0.04em] text-sky-300 transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
               style={{
-                borderColor: 'rgba(248,113,113,0.35)',
-                background: 'rgba(127,29,29,0.2)',
-                color: 'rgb(254 202 202)',
+                background: 'rgba(56,189,248,0.12)',
+                borderColor: 'rgba(56,189,248,0.35)',
+              }}
+              onMouseEnter={e => {
+                e.currentTarget.style.background = 'rgba(56,189,248,0.2)';
+                e.currentTarget.style.borderColor = 'rgba(56,189,248,0.6)';
+              }}
+              onMouseLeave={e => {
+                e.currentTarget.style.background = 'rgba(56,189,248,0.12)';
+                e.currentTarget.style.borderColor = 'rgba(56,189,248,0.35)';
               }}
             >
-              {error}
-            </p>
-          )}
+              {register.isPending ? 'Registering...' : 'Register →'}
+            </button>
 
-          <button
-            type="submit"
-            disabled={register.isPending}
-            className="mt-2 w-full rounded-lg border py-2.5 text-sm font-semibold tracking-[0.04em] text-sky-300 transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
-            style={{
-              background: 'rgba(56,189,248,0.12)',
-              borderColor: 'rgba(56,189,248,0.35)',
-            }}
-            onMouseEnter={e => {
-              e.currentTarget.style.background = 'rgba(56,189,248,0.2)';
-              e.currentTarget.style.borderColor = 'rgba(56,189,248,0.6)';
-            }}
-            onMouseLeave={e => {
-              e.currentTarget.style.background = 'rgba(56,189,248,0.12)';
-              e.currentTarget.style.borderColor = 'rgba(56,189,248,0.35)';
-            }}
-          >
-            {register.isPending ? 'Registering...' : 'Register →'}
-          </button>
-        </form>
+            {isGoogleLoginEnabled && (
+              <>
+                <div className="my-1 flex items-center gap-3">
+                  <div className="h-px flex-1" style={{ background: 'rgba(56,189,248,0.1)' }} />
+                  <span
+                    className="text-[11px] tracking-wider"
+                    style={{ fontFamily: "'DM Mono', monospace", color: 'rgba(148,163,184,0.4)' }}
+                  >
+                    or
+                  </span>
+                  <div className="h-px flex-1" style={{ background: 'rgba(56,189,248,0.1)' }} />
+                </div>
 
-        {isGoogleLoginEnabled && (
-          <>
-            <div className="my-5 flex items-center gap-3">
-              <div className="h-px flex-1" style={{ background: 'rgba(56,189,248,0.1)' }} />
-              <span
-                className="text-[11px] tracking-wider"
-                style={{ fontFamily: "'DM Mono', monospace", color: 'rgba(148,163,184,0.4)' }}
+                <div className="flex justify-center">
+                  <GoogleLogin
+                    onSuccess={credentialResponse => {
+                      const credential = credentialResponse.credential;
+                      if (credential) {
+                        setError('');
+                        googleLogin.mutate(credential);
+                      }
+                    }}
+                    onError={() => {
+                      const message = 'Google sign-up failed. Please try again.';
+                      setError(message);
+                      addNotification({
+                        type: 'error',
+                        title: 'Google Sign-Up Failed',
+                        message,
+                      });
+                    }}
+                    theme="filled_black"
+                    shape="rectangular"
+                    text="signup_with"
+                    size="large"
+                    width="240"
+                    locale="en"
+                  />
+                </div>
+              </>
+            )}
+
+            <p className="text-center text-[13px]" style={{ color: 'rgba(148,163,184,0.5)' }}>
+              Already have an account?{' '}
+              <Link
+                href={paths.auth.login.getHref()}
+                className="transition-colors"
+                style={{ color: 'rgba(56,189,248,0.8)' }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.color = 'rgba(56,189,248,1)';
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.color = 'rgba(56,189,248,0.8)';
+                }}
               >
-                or
-              </span>
-              <div className="h-px flex-1" style={{ background: 'rgba(56,189,248,0.1)' }} />
-            </div>
-
-            <div className="flex justify-center">
-              <GoogleLogin
-                onSuccess={credentialResponse => {
-                  const credential = credentialResponse.credential;
-                  if (credential) {
-                    setError('');
-                    googleLogin.mutate(credential);
-                  }
-                }}
-                onError={() => {
-                  const message = 'Google sign-up failed. Please try again.';
-                  setError(message);
-                  addNotification({
-                    type: 'error',
-                    title: 'Google Sign-Up Failed',
-                    message,
-                  });
-                }}
-                theme="filled_black"
-                shape="rectangular"
-                text="signup_with"
-                size="large"
-                width="240"
-                locale="en"
-              />
-            </div>
-          </>
-        )}
-
-        <p className="mt-6 text-center text-[13px]" style={{ color: 'rgba(148,163,184,0.5)' }}>
-          Already have an account?{' '}
-          <Link
-            href={paths.auth.login.getHref()}
-            className="transition-colors"
-            style={{ color: 'rgba(56,189,248,0.8)' }}
-            onMouseEnter={e => {
-              e.currentTarget.style.color = 'rgba(56,189,248,1)';
-            }}
-            onMouseLeave={e => {
-              e.currentTarget.style.color = 'rgba(56,189,248,0.8)';
-            }}
-          >
-            Log in
-          </Link>
-        </p>
+                Log in
+              </Link>
+            </p>
+          </div>
+        </form>
       </div>
 
       <style>{`


### PR DESCRIPTION
## Summary

UX polish across the register page and the arsenal creator, plus a small color-picker bug fix. Closes [#264](https://github.com/DishonMe/EscapeCircuit/issues/264).

### Register page (`/auth/register`)
- **Color preset bug fixed.** Clicking a preset swatch now also updates the hex input and the `<input type="color">` swatch — they were stuck at the initial value before, and the live avatar preview's background didn't follow the preset choice.
- **Two-column layout.** Card widened to `max-w-5xl`. Left column holds credentials (Username, Email, Password) vertically centered. Right column holds the new live avatar preview (reusing `AvatarDisplay`), the animal grid, and the color picker.
- **Shared action block.** Register button, Google login, and "Already have an account? Log in" now sit beneath both columns, horizontally centered in a `max-w-sm` wrapper, so they feel anchored to the form rather than crammed into one side.
- **Mobile preserved.** At `< md` the grid collapses to a single column, no horizontal overflow, animal grid keeps its `grid-cols-4 sm:grid-cols-5` responsive fallback.

### Arsenal creator (`/app/arsenal/creator`)
- **Bigger, scoped grid dots.** Empty cells render at 8 px (`size-2`) with a slightly higher contrast tone — the user reported the previous 4 px dots felt lost in the cells. Implemented via a new optional `emptyHoleClassName` prop on `WorkstationGrid` so puzzle solver, admin create-puzzle, profile/arsenal/solution previews keep their original look.
- **Taller workstation.** Wrapper uses a viewport-based `min-h-[calc(100vh-9rem)]` so the working area matches the puzzle-solver feel instead of collapsing inside the page's flex layout.
- **`CELL_PX` left untouched.** Coordinate units for placed components and wires are unchanged, so existing arsenal pieces keep their saved positions.

## Files touched

- `apps/nextjs-app/src/app/auth/register/page.tsx` — layout restructure, preset sync, `AvatarDisplay` reuse
- `apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx` — added optional `emptyHoleClassName` prop with the original class as the fallback
- `apps/nextjs-app/src/app/app/arsenal/creator/page.tsx` — passes the new prop, switches to viewport-based min-height

## Test plan

- [ ] `/auth/register` desktop (≥ md): credentials centered on the left, identity picker on the right, action block centered below both
- [ ] `/auth/register` mobile (< md): single-column stack, scrollable card, no horizontal overflow
- [ ] Click each preset color → hex text input, color picker swatch, and live avatar preview all update
- [ ] Pick a custom hex via the color picker → preset selection ring clears (`useCustomColor` flips)
- [ ] Submit a valid registration end-to-end (form/validation untouched)
- [ ] Arsenal creator: empty grid dots are visibly larger; working area fills the viewport vertically; place + save + reload a piece, coordinates intact
- [ ] No regression on other `WorkstationGrid` consumers: puzzle solver, admin create-puzzle, profile circuit preview, arsenal preview, solution preview — all should still render the original 4 px dots
- [ ] `yarn check-types`, `yarn lint`, `yarn build` (no new diagnostics introduced; only pre-existing errors remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)