### PR TITLE
Shared Arsenal pieces data now saved in config files

### DIFF
--- a/apps/nextjs-app/src/app/app/admin/upload-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/admin/upload-puzzle/page.tsx
@@ -208,6 +208,23 @@ export default function UploadPuzzlePage() {
     "inputs": ["A", "B", "C_in"],
     "outputs": ["S", "C_out"]
   },
+  "shared_arsenal_pieces": [
+    {
+      "name": "wonce",
+      "description": "Write once bit",
+      "cost": 2,
+      "num_inputs": 1,
+      "num_outputs": 1,
+      "structure": {
+        "numInputs": 1,
+        "numOutputs": 1,
+        "placed": [],
+        "wires": []
+      },
+      "basic_gates": ["OR", "DFF"],
+      "truth_table": {}
+    }
+  ],
   "test_cases": [
     {
       "inputs": {"A": 0, "B": 0, "C_in": 0},
@@ -245,6 +262,17 @@ export default function UploadPuzzlePage() {
                   min_gate_limit (min, optional)
                 </li>
               </ul>
+              <p>
+                Shared arsenal pieces can be bundled in
+                <code className="bg-black/20 px-1 rounded ml-1">
+                  shared_arsenal_pieces
+                </code>{' '}
+                and referenced by name in
+                <code className="bg-black/20 px-1 rounded ml-1">
+                  allowed_arsenal_component_ids
+                </code>
+                .
+              </p>
             </div>
           </details>
 

--- a/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
+++ b/apps/nextjs-app/src/app/app/create-puzzle/page.tsx
@@ -675,6 +675,7 @@ export default function CreatePuzzleForm() {
       return {
         id: piece.id,
         name: piece.name,
+        description: piece.description,
         cost: piece.cost,
         // Prefer persisted metadata from backend; fallback to derived values.
         num_inputs: Number(pieceMeta.num_inputs ?? num_inputs),
@@ -1760,6 +1761,7 @@ export default function CreatePuzzleForm() {
       const configData: {
         puzzle: Record<string, unknown>;
         test_cases: unknown[];
+        shared_arsenal_pieces?: Array<Record<string, unknown>>;
         custom_pieces?: Array<{
           name: string;
           cost: number;
@@ -1788,9 +1790,11 @@ export default function CreatePuzzleForm() {
               : undefined,
           allow_arsenal: data.basic.allowArsenal,
           allowed_arsenal_component_ids:
-            data.basic.allowedArsenalComponentIds.length > 0
-              ? data.basic.allowedArsenalComponentIds
-              : undefined,
+            selectedArsenalPieces.length > 0
+              ? selectedArsenalPieces.map((piece) => piece.name)
+              : data.basic.allowedArsenalComponentIds.length > 0
+                ? data.basic.allowedArsenalComponentIds
+                : undefined,
           arsenal_component_display_modes:
             Object.keys(data.basic.arsenalComponentDisplayModes).length > 0
               ? data.basic.arsenalComponentDisplayModes
@@ -1823,6 +1827,41 @@ export default function CreatePuzzleForm() {
                 }
               : undefined,
         },
+        shared_arsenal_pieces:
+          selectedArsenalPieces.length > 0
+            ? selectedArsenalPieces.map((piece) => {
+                let structure: Record<string, unknown> = {};
+                let basicGates: string[] = [];
+
+                try {
+                  structure = piece.structure_json
+                    ? JSON.parse(piece.structure_json)
+                    : {};
+                } catch {
+                  structure = {};
+                }
+
+                try {
+                  basicGates = piece.basic_gates
+                    ? JSON.parse(piece.basic_gates)
+                    : [];
+                } catch {
+                  basicGates = [];
+                }
+
+                return {
+                  name: piece.name,
+                  description: piece.description || 'Shared arsenal piece',
+                  cost: Number(piece.cost ?? 0),
+                  num_inputs: Number(piece.num_inputs ?? 1),
+                  num_outputs: Number(piece.num_outputs ?? 1),
+                  structure,
+                  basic_gates: basicGates,
+                  truth_table: piece.truth_table || {},
+                  visual_style: piece.visual_style || undefined,
+                };
+              })
+            : undefined,
         test_cases: convertedTestCases,
       };
 

--- a/riddles/riddle_07_twice_2_bits_in_3_bits/riddle_07_twice_2_bits_in_3_bits_config.json
+++ b/riddles/riddle_07_twice_2_bits_in_3_bits/riddle_07_twice_2_bits_in_3_bits_config.json
@@ -31,26 +31,10 @@
     },
     "allow_arsenal": true,
     "allowed_arsenal_component_ids": [
-      "40",
-      "41",
-      "43",
-      "44",
-      "45",
-      "46",
-      "47",
-      "48",
-      "49"
+      "wonce"
     ],
     "arsenal_component_display_modes": {
-      "40": "circuit",
-      "41": "circuit",
-      "43": "circuit",
-      "44": "circuit",
-      "45": "circuit",
-      "46": "circuit",
-      "47": "circuit",
-      "48": "circuit",
-      "49": "circuit"
+      "wonce": "circuit"
     },
     "board": {
       "rows": 20,
@@ -58,6 +42,116 @@
     },
     "riddle_base_name": "riddle_07_twice_2_bits_in_3_bits"
   },
+  "shared_arsenal_pieces": [
+    {
+      "name": "wonce",
+      "description": "Write once bit",
+      "cost": 2,
+      "num_inputs": 1,
+      "num_outputs": 1,
+      "structure": {
+        "numInputs": 1,
+        "numOutputs": 1,
+        "placed": [
+          {
+            "id": "IO:IN:IN0",
+            "componentId": "IO:IN:IN0",
+            "origin": {
+              "row": 0,
+              "col": 0
+            },
+            "rotation": 0
+          },
+          {
+            "id": "OR:1",
+            "componentId": "OR",
+            "origin": {
+              "row": 0,
+              "col": 4
+            },
+            "rotation": 0
+          },
+          {
+            "id": "DFF:1",
+            "componentId": "DFF",
+            "origin": {
+              "row": 0,
+              "col": 8
+            },
+            "rotation": 0
+          },
+          {
+            "id": "IO:OUT:OUT0",
+            "componentId": "IO:OUT:OUT0",
+            "origin": {
+              "row": 0,
+              "col": 12
+            },
+            "rotation": 0
+          }
+        ],
+        "wires": [
+          {
+            "id": "wire:in-to-or",
+            "from": {
+              "componentId": "IO:IN:IN0",
+              "pinIndex": 0,
+              "portId": "P0"
+            },
+            "to": {
+              "componentId": "OR:1",
+              "pinIndex": 0,
+              "portId": "IN0"
+            }
+          },
+          {
+            "id": "wire:feedback",
+            "from": {
+              "componentId": "DFF:1",
+              "pinIndex": 1,
+              "portId": "OUT0"
+            },
+            "to": {
+              "componentId": "OR:1",
+              "pinIndex": 1,
+              "portId": "IN1"
+            }
+          },
+          {
+            "id": "wire:or-to-dff",
+            "from": {
+              "componentId": "OR:1",
+              "pinIndex": 2,
+              "portId": "OUT0"
+            },
+            "to": {
+              "componentId": "DFF:1",
+              "pinIndex": 0,
+              "portId": "IN0"
+            }
+          },
+          {
+            "id": "wire:dff-to-out",
+            "from": {
+              "componentId": "DFF:1",
+              "pinIndex": 1,
+              "portId": "OUT0"
+            },
+            "to": {
+              "componentId": "IO:OUT:OUT0",
+              "pinIndex": 0,
+              "portId": "P0"
+            }
+          }
+        ]
+      },
+      "basic_gates": [
+        "OR",
+        "DFF"
+      ],
+      "truth_table": {}
+    }
+  ],
   "test_cases": [
     {
       "kind": "stream",

--- a/src/insert_riddles.py
+++ b/src/insert_riddles.py
@@ -35,10 +35,10 @@ def latex_to_html(latex_text: str) -> str:
     
     # Convert \textit{...} to <em>...</em>
     html = re.sub(r'\\textit\s*\{([^}]+)\}', r'<em>\1</em>', html)
-    
+
     # Convert \texttt{...} to <code>...</code>
     html = re.sub(r'\\texttt\s*\{([^}]+)\}', r'<code>\1</code>', html)
-    
+
     # Handle \begin{itemize}...\end{itemize}
     html = re.sub(r'\\begin\{itemize\}', '<ul>', html)
     html = re.sub(r'\\end\{itemize\}', '</ul>', html)
@@ -339,8 +339,16 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
     # Get description from config file or use instructions_text as fallback
     description = puzzle_data.get('description', instructions_text)
     
+    raw_allowed_arsenal_ids = puzzle_data.get('allowed_arsenal_component_ids') or []
+    if not raw_allowed_arsenal_ids and shared_arsenal_pieces:
+        raw_allowed_arsenal_ids = [
+            piece.get('name')
+            for piece in shared_arsenal_pieces
+            if isinstance(piece, dict) and piece.get('name')
+        ]
+
     allowed_arsenal_component_ids = resolve_shared_arsenal_ids(
-        puzzle_data.get('allowed_arsenal_component_ids') or [],
+        raw_allowed_arsenal_ids,
         shared_piece_ids_by_name,
         conn,
         creator_id,
@@ -595,13 +603,11 @@ def insert_riddle(conn, config_path, instructions_path, creator_id, status='publ
                 ),
             )
 
-    if allowed_arsenal_component_ids and puzzle_data.get('allowed_arsenal_component_ids'):
-        resolved_allowed_ids = allowed_arsenal_component_ids
-        if existing:
-            c.execute(
-                "UPDATE puzzles SET allowed_arsenal_component_ids=? WHERE id=?",
-                (json.dumps(resolved_allowed_ids), puzzle_id),
-            )
+    if allowed_arsenal_component_ids and existing:
+        c.execute(
+            "UPDATE puzzles SET allowed_arsenal_component_ids=? WHERE id=?",
+            (json.dumps(allowed_arsenal_component_ids), puzzle_id),
+        )
         
     conn.commit()
     print(f"Inserted: {puzzle_data['name']}")


### PR DESCRIPTION
This pull request introduces support for "shared arsenal pieces"—custom reusable circuit components that can be defined once and referenced by name in puzzle configurations. The changes enable both the frontend and backend to handle these shared pieces, update the puzzle creation workflow, and provide documentation and examples for their use.

### Related
closes #266 

**Shared Arsenal Pieces Support**

* Added the `shared_arsenal_pieces` field to puzzle configuration files, allowing reusable custom circuit components to be defined and referenced by name in `allowed_arsenal_component_ids`.
* Updated the puzzle creation form to include descriptions for arsenal pieces, serialize selected arsenal pieces into the `shared_arsenal_pieces` field, and ensure `allowed_arsenal_component_ids` references these by name.
* Improved documentation in the upload puzzle page to explain how to use `shared_arsenal_pieces` and reference them in `allowed_arsenal_component_ids`.

**Backend Handling and Migration**

* Updated backend logic to resolve and insert shared arsenal pieces correctly: if no explicit `allowed_arsenal_component_ids` are provided but shared pieces exist, their names are used as allowed component IDs. Also, fixed the update logic for `allowed_arsenal_component_ids` in the database. 

**Example and Data Updates**

* Updated the example riddle configuration (`riddle_07_twice_2_bits_in_3_bits_config.json`) to use the new `shared_arsenal_pieces` format and reference the shared piece by name instead of numeric IDs.

These changes make it easier to define, reuse, and manage custom arsenal components across puzzles, improving both maintainability and clarity.## Sample Pull Request Template Description

This is a sample pull request template. You can customize it to fit your project's needs.

Don't forget to commit your template file to the repository so that it can be used for future pull requests!
