### PR TITLE
fix 500 on first-time solve of another user's puzzle (#274)

### DIFF
--- a/apps/nextjs-app/src/hooks/useAudio.ts
+++ b/apps/nextjs-app/src/hooks/useAudio.ts
@@ -20,7 +20,7 @@ const SOUND_MAP: Record<AudioSoundType, string[]> = {
   drop: ['/sounds/drop.mp3', '/sounds/drop-thud.mp3'],
   wire: ['/sounds/wire.mp3', '/sounds/wire-bloop.mp3'],
   error: ['/sounds/error.mp3', '/sounds/error-buzz.mp3'],
-  success: ['/sounds/success.mp3', '/sounds/success-chime.mp3'],
+  success: ['/sounds/success-chime.mp3'],
 };
 
 const resolvedSources = new Map<AudioSoundType, string | null>();

--- a/src/Backend/ServiceLayer/NotificationService.py
+++ b/src/Backend/ServiceLayer/NotificationService.py
@@ -14,8 +14,15 @@ class NotificationService:
     # --- Called by other services when creator earns XP ---
 
     def notify_creator_solve(self, creator_user_id: int, solver_username: str,
-                             puzzle_name: str, xp_amount: int) -> None:
-        """Create a notification: someone solved your puzzle."""
+                             puzzle_name: str, xp_amount: int,
+                             commit: bool = True) -> None:
+        """Create a notification: someone solved your puzzle.
+
+        Pass commit=False when calling from inside an active transaction
+        (e.g. SolvingService.validate_solution) — otherwise the inner
+        commit closes the outer BEGIN IMMEDIATE and the surrounding
+        context manager's COMMIT raises "no transaction is active".
+        """
         msg = f"🎉 {solver_username} solved your puzzle \"{puzzle_name}\"! You earned {xp_amount} XP."
         self.repo.create(
             user_id=creator_user_id,
@@ -24,6 +31,7 @@ class NotificationService:
             xp_amount=xp_amount,
             puzzle_name=puzzle_name,
             actor_username=solver_username,
+            commit=commit,
         )
 
     def notify_creator_rating(self, creator_user_id: int, rater_username: str,

--- a/src/Backend/ServiceLayer/SolvingService.py
+++ b/src/Backend/ServiceLayer/SolvingService.py
@@ -552,6 +552,7 @@ class SolvingService:
                                     solver_username=solver_name,
                                     puzzle_name=p.name,
                                     xp_amount=xp_awarded_creator,
+                                    commit=False,
                                 )
                     except Exception:
                         pass  # creator XP is best-effort

--- a/src/tests/ServiceLayerTests/test_notification_service.py
+++ b/src/tests/ServiceLayerTests/test_notification_service.py
@@ -1,7 +1,10 @@
 """Tests for NotificationService"""
+import sqlite3
 import pytest
 from unittest.mock import Mock
 from Backend.ServiceLayer.NotificationService import NotificationService
+from Backend.PersistantLayer.NotificationRepo import NotificationRepo
+from Backend.PersistantLayer._db import transaction
 
 
 class TestNotificationServiceInit:
@@ -49,15 +52,74 @@ class TestNotificationServiceNotifyCreatorSolve:
         solver_username = "alice"
         puzzle_name = "Half Adder"
         xp_amount = 25
-        
+
         self.service.notify_creator_solve(creator_id, solver_username, puzzle_name, xp_amount)
-        
+
         call_args = self.mock_notification_repo.create.call_args[1]
         message = call_args["message"]
-        
+
         assert solver_username in message
         assert puzzle_name in message
         assert str(xp_amount) in message
+
+    def test_notify_creator_solve_default_commits(self):
+        self.service.notify_creator_solve(1, "u", "p", 5)
+        assert self.mock_notification_repo.create.call_args[1]["commit"] is True
+
+    def test_notify_creator_solve_commit_false_propagates(self):
+        self.service.notify_creator_solve(1, "u", "p", 5, commit=False)
+        assert self.mock_notification_repo.create.call_args[1]["commit"] is False
+
+
+class TestNotifyCreatorSolveInsideTransaction:
+    """Regression test for the production 500 on first-time solve of another
+    user's puzzle. Reproduces the original bug: notify_creator_solve() called
+    inside an active BEGIN IMMEDIATE used to issue its own commit, which left
+    the outer `with transaction(...)` block's COMMIT with no active txn ->
+    sqlite3.OperationalError -> 500. The fix routes commit=False through
+    NotificationService so the outer transaction stays in charge.
+    """
+
+    def setup_method(self):
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.row_factory = sqlite3.Row
+        self.conn.isolation_level = None  # match production: manual BEGIN/COMMIT
+        self.repo = NotificationRepo(self.conn)
+        self.service = NotificationService(self.repo, Mock())
+
+    def test_notify_inside_transaction_does_not_break_outer_commit(self):
+        # This mirrors SolvingService.validate_solution's transaction:
+        # the inner notify must NOT commit, so the outer COMMIT succeeds.
+        with transaction(self.conn):
+            self.service.notify_creator_solve(
+                creator_user_id=1,
+                solver_username="solver",
+                puzzle_name="Binary Adder",
+                xp_amount=50,
+                commit=False,
+            )
+        # Outer commit succeeded; row is persisted.
+        rows = self.conn.execute(
+            "SELECT user_id, type, message FROM creator_notifications"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["user_id"] == 1
+        assert rows[0]["type"] == "solve"
+
+    def test_notify_inside_transaction_with_default_commit_raises(self):
+        # Without the fix, this is what was happening in prod on first solve:
+        # the inner commit short-circuits the outer BEGIN IMMEDIATE, and the
+        # context manager's COMMIT then errors. Locked in as a regression
+        # guard so we don't regress to commit=True by default from this site.
+        with pytest.raises(sqlite3.OperationalError):
+            with transaction(self.conn):
+                self.service.notify_creator_solve(
+                    creator_user_id=1,
+                    solver_username="solver",
+                    puzzle_name="Binary Adder",
+                    xp_amount=50,
+                    # commit defaults to True — reproduces the original bug
+                )
 
 
 class TestNotificationServiceNotifyCreatorRating:


### PR DESCRIPTION
## Summary
- Fixes the production 500 on `POST /puzzles/{id}/validate` that happens on a user's **first** successful solve of a puzzle they didn't create. Root cause: `NotificationRepo.create` defaulted to `commit=True`, so the creator-notification insert inside `SolvingService.validate_solution`'s `with transaction(...)` block ended the `BEGIN IMMEDIATE` early. The context manager's subsequent `COMMIT` then raised `sqlite3.OperationalError: cannot commit - no transaction is active`. The retry "worked" only because the spurious commit had already persisted the solve, so duplicate-detection short-circuited.
- Threads a `commit` parameter through `NotificationService.notify_creator_solve` and passes `commit=False` from the solve transaction. `RatingService` notifies **after** its transaction exits, so its call site keeps the default — verified in `RatingService.py:130-156`.
- Adds a real-SQLite regression test in `test_notification_service.py` that drives the live `transaction()` context manager and asserts both (a) the fix path commits cleanly, and (b) the pre-fix path still raises `OperationalError` — so anyone flipping the default back from this site will see the test fail.
- Drops the missing `/sounds/success.mp3` entry from `useAudio.ts`. Only `success-chime.mp3` exists on disk; the hook now points straight at it instead of relying on a 404+fallback.

## Test plan
- [x] `pytest` — 2585/2585 passing
- [x] `yarn build` in `apps/nextjs-app/` — succeeds
- [x] New regression test fails on the pre-fix code and passes on the patched code
- [ ] After merge to `release` and `deploy.sh` run: sign in as a non-creator account, solve any puzzle for the first time, confirm 200 (no 500, no second-attempt workaround needed) and no `/sounds/success.mp3` 404 in the browser console
- [ ] Smoke-check the rating flow (creator notification on a first-time rating) since it shares `NotificationService` — unchanged behavior expected

Refs #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)