### PR TITLE
Add first-visit glow aura to puzzle Instructions icon

### DIFF
--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-action-cluster.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-action-cluster.tsx
@@ -17,6 +17,8 @@ import {
 import type { Puzzle } from '@/types/api';
 import { cn } from '@/utils/cn';
 
+import { useInstructionsGlow } from '../hooks/use-instructions-glow';
+
 interface PuzzleActionClusterProps {
   puzzle: Puzzle;
   onInstructions: () => void;
@@ -59,16 +61,27 @@ export const PuzzleActionCluster = ({
     hasRated,
     puzzle.rating_min_attempt_seconds,
   );
+  const { shouldGlow, markClicked } = useInstructionsGlow();
+
+  const handleInstructionsClick = () => {
+    markClicked();
+    onInstructions();
+  };
 
   if (variant === 'card') {
     return (
       <div className="relative z-10 flex items-center gap-1">
         <button
           type="button"
-          // eslint-disable-next-line tailwindcss/no-custom-classname
-          className={cn(iconButtonClass, 'puzzle-instructions-button')}
+          className={cn(
+            iconButtonClass,
+            // eslint-disable-next-line tailwindcss/no-custom-classname
+            'puzzle-instructions-button',
+            // eslint-disable-next-line tailwindcss/no-custom-classname
+            shouldGlow && 'puzzle-instructions-glow',
+          )}
           aria-label="Instructions"
-          onClick={onInstructions}
+          onClick={handleInstructionsClick}
         >
           <BookOpen className="size-4" aria-hidden />
         </button>
@@ -135,7 +148,7 @@ export const PuzzleActionCluster = ({
           <DropdownMenuItem
             // eslint-disable-next-line tailwindcss/no-custom-classname
             className="puzzle-instructions-button flex cursor-pointer items-center gap-2"
-            onSelect={onInstructions}
+            onSelect={handleInstructionsClick}
           >
             <BookOpen className="size-4" aria-hidden />
             Instructions

--- a/apps/nextjs-app/src/features/puzzles/hooks/use-instructions-glow.ts
+++ b/apps/nextjs-app/src/features/puzzles/hooks/use-instructions-glow.ts
@@ -1,55 +1,73 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { create } from 'zustand';
 
-const STORAGE_KEY = 'puzzle-instructions-clicked';
+import { useUser } from '@/lib/auth';
+
+const STORAGE_PREFIX = 'puzzle-instructions-clicked:';
 
 type InstructionsGlowStore = {
-  hasClicked: boolean;
-  hydrated: boolean;
-  markClicked: () => void;
-  hydrate: () => void;
+  clickedByKey: Record<string, boolean>;
+  hydratedKeys: Record<string, boolean>;
+  markClicked: (key: string) => void;
+  hydrate: (key: string) => void;
 };
 
 const useStore = create<InstructionsGlowStore>((set, get) => ({
-  hasClicked: false,
-  hydrated: false,
-  markClicked: () => {
-    if (get().hasClicked) return;
+  clickedByKey: {},
+  hydratedKeys: {},
+  markClicked: (key) => {
+    if (get().clickedByKey[key]) return;
     if (typeof window !== 'undefined') {
       try {
-        window.localStorage.setItem(STORAGE_KEY, '1');
+        window.localStorage.setItem(key, '1');
       } catch {
         // ignore quota / privacy-mode errors
       }
     }
-    set({ hasClicked: true });
+    set((s) => ({
+      clickedByKey: { ...s.clickedByKey, [key]: true },
+    }));
   },
-  hydrate: () => {
-    if (get().hydrated) return;
+  hydrate: (key) => {
+    if (get().hydratedKeys[key]) return;
     let stored = false;
     if (typeof window !== 'undefined') {
       try {
-        stored = window.localStorage.getItem(STORAGE_KEY) === '1';
+        stored = window.localStorage.getItem(key) === '1';
       } catch {
         stored = false;
       }
     }
-    set({ hasClicked: stored, hydrated: true });
+    set((s) => ({
+      clickedByKey: { ...s.clickedByKey, [key]: stored },
+      hydratedKeys: { ...s.hydratedKeys, [key]: true },
+    }));
   },
 }));
 
 export const useInstructionsGlow = () => {
-  const hasClicked = useStore((s) => s.hasClicked);
-  const hydrated = useStore((s) => s.hydrated);
-  const markClicked = useStore((s) => s.markClicked);
-  const hydrate = useStore((s) => s.hydrate);
+  const user = useUser();
+  const username = user.data?.username;
+  const key = useMemo(
+    () => (username ? `${STORAGE_PREFIX}${username}` : null),
+    [username],
+  );
+
+  const hasClicked = useStore((s) => (key ? !!s.clickedByKey[key] : false));
+  const hydrated = useStore((s) => (key ? !!s.hydratedKeys[key] : false));
+  const markClickedFn = useStore((s) => s.markClicked);
+  const hydrateFn = useStore((s) => s.hydrate);
 
   useEffect(() => {
-    hydrate();
-  }, [hydrate]);
+    if (key) hydrateFn(key);
+  }, [key, hydrateFn]);
+
+  const markClicked = useCallback(() => {
+    if (key) markClickedFn(key);
+  }, [key, markClickedFn]);
 
   return {
-    shouldGlow: hydrated && !hasClicked,
+    shouldGlow: !!key && hydrated && !hasClicked,
     markClicked,
   };
 };

--- a/apps/nextjs-app/src/features/puzzles/hooks/use-instructions-glow.ts
+++ b/apps/nextjs-app/src/features/puzzles/hooks/use-instructions-glow.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'puzzle-instructions-clicked';
+
+type InstructionsGlowStore = {
+  hasClicked: boolean;
+  hydrated: boolean;
+  markClicked: () => void;
+  hydrate: () => void;
+};
+
+const useStore = create<InstructionsGlowStore>((set, get) => ({
+  hasClicked: false,
+  hydrated: false,
+  markClicked: () => {
+    if (get().hasClicked) return;
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, '1');
+      } catch {
+        // ignore quota / privacy-mode errors
+      }
+    }
+    set({ hasClicked: true });
+  },
+  hydrate: () => {
+    if (get().hydrated) return;
+    let stored = false;
+    if (typeof window !== 'undefined') {
+      try {
+        stored = window.localStorage.getItem(STORAGE_KEY) === '1';
+      } catch {
+        stored = false;
+      }
+    }
+    set({ hasClicked: stored, hydrated: true });
+  },
+}));
+
+export const useInstructionsGlow = () => {
+  const hasClicked = useStore((s) => s.hasClicked);
+  const hydrated = useStore((s) => s.hydrated);
+  const markClicked = useStore((s) => s.markClicked);
+  const hydrate = useStore((s) => s.hydrate);
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return {
+    shouldGlow: hydrated && !hasClicked,
+    markClicked,
+  };
+};

--- a/apps/nextjs-app/src/styles/globals.css
+++ b/apps/nextjs-app/src/styles/globals.css
@@ -542,6 +542,49 @@
     background-color: hsl(var(--difficulty-hard-bg));
     border-color: hsl(var(--difficulty-hard-border));
   }
+
+  .puzzle-instructions-glow {
+    position: relative;
+    isolation: isolate;
+    color: hsl(var(--primary)) !important;
+    animation: puzzle-instructions-glow-ring 2.4s ease-in-out infinite;
+  }
+
+  .puzzle-instructions-glow::before {
+    content: '';
+    position: absolute;
+    inset: -8px;
+    border-radius: 14px;
+    background: radial-gradient(closest-side, hsl(var(--primary) / 0.65), hsl(var(--primary) / 0.28) 55%, transparent 80%);
+    filter: blur(6px);
+    z-index: -1;
+    pointer-events: none;
+    animation: puzzle-instructions-glow-aura 2.4s ease-in-out infinite;
+  }
+}
+
+@keyframes puzzle-instructions-glow-ring {
+  0%, 100% {
+    box-shadow: 0 0 0 1px hsl(var(--primary) / 0.35), 0 0 8px 1px hsl(var(--primary) / 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 1.5px hsl(var(--primary) / 0.6), 0 0 16px 3px hsl(var(--primary) / 0.65);
+  }
+}
+
+@keyframes puzzle-instructions-glow-aura {
+  0%, 100% { opacity: 0.55; transform: scale(0.9); }
+  50%      { opacity: 1;    transform: scale(1.18); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .puzzle-instructions-glow,
+  .puzzle-instructions-glow::before {
+    animation: none;
+  }
+  .puzzle-instructions-glow::before {
+    opacity: 0.85;
+  }
 }
 
 body {


### PR DESCRIPTION
## Summary
- Adds a soft pulsing blue aura around the Instructions (BookOpen) icon on every puzzle card on the browse page.
- The aura draws attention to where puzzle instructions live; it clears across all cards the first time the user clicks any Instructions icon.
- Dismissal is persisted per-user in `localStorage` (keyed by username), so a different account on the same browser starts fresh.

## Implementation
- `apps/nextjs-app/src/styles/globals.css` — new `.puzzle-instructions-glow` class: layered `box-shadow` ring + radial-gradient `::before` halo with two breathing keyframe animations; honors `prefers-reduced-motion`.
- `apps/nextjs-app/src/features/puzzles/hooks/use-instructions-glow.ts` — small Zustand store + hook; per-username `localStorage` key (`puzzle-instructions-clicked:<username>`); reads on mount, writes on first click, syncs all card instances.
- `apps/nextjs-app/src/features/puzzles/components/puzzle-action-cluster.tsx` — applies the glow class conditionally on the card-variant Instructions button; calls `markClicked()` in both card and row variants so the dismissal sticks regardless of entry point.

## Test plan
- [ ] Open the puzzles browse page as a fresh user — every Instructions icon should pulse with a blue halo.
- [ ] Click any one Instructions icon — all glows clear immediately; icons return to their normal muted appearance.
- [ ] Refresh — glows stay dismissed for that user.
- [ ] Log out and log in as a different user on the same browser — that user sees the glow on their first visit.
- [ ] OS-level "Reduce motion" setting disables the pulse animation but keeps a static halo.

<img width="2276" height="626" alt="image" src="https://github.com/user-attachments/assets/63c229cd-feee-48b7-9ddc-45dbb894193b" />
