### PR TITLE
Copying components now copies to the clipboard (and pasting as well)

### DIFF
--- a/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
@@ -656,7 +656,6 @@ export default function ArsenalCreatorPage() {
             onPlacedChange={handlePlacedChange}
             onWiresChange={setWires}
             draggedPaletteComponentId={draggedPaletteComponentId}
-            viewportClassName="h-full"
             emptyHoleClassName="size-2 bg-muted-foreground/35 hover:bg-muted-foreground/60"
           />
         </div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -45,6 +45,16 @@ export type PlacedGridComponent = {
   rotation: 0 | 90;
   isLocked?: boolean; // If true, component is immovable, undeletable, and mandatory to use
 };
+type ClipboardComponent = PlacedGridComponent & {
+  label: string;
+};
+type ClipboardPayload = {
+  version: 1;
+  sourcePuzzleId: string;
+  components: ClipboardComponent[];
+  wires: Wire[];
+};
+const normalizeClipboardKey = (value: string) => value.trim().toLowerCase();
 
 export type PortAddress = {
   ownerId: string; // placedId or IO:IN:* / IO:OUT:*
@@ -62,6 +72,8 @@ const DEFAULT_GRID_ROWS = 15;
 const DEFAULT_GRID_COLS = 30;
 const CELL_PX = 18;
 const PUZZLE_IO_Y_OFFSET_PX = 20;
+const WORKSTATION_CLIPBOARD_STORAGE_KEY =
+  'escapecircuit.workstation.clipboard.v1';
 
 // Visual Feature: Dynamic Wire Coloring
 const WIRE_COLORS = ['#3b82f6', '#ef4444', '#10b981', '#a855f7', '#f97316'];
@@ -320,10 +332,7 @@ export const WorkstationGrid = ({
   const [microSparks, setMicroSparks] = useState<
     Array<{ id: string; x: number; y: number; dx: number; dy: number }>
   >([]);
-  const [clipboard, setClipboard] = useState<{
-    components: PlacedGridComponent[];
-    wires: Wire[];
-  } | null>(null);
+  const [clipboard, setClipboard] = useState<ClipboardPayload | null>(null);
   const [bootSequenceActive, setBootSequenceActive] = useState(true);
   const [isWorkingAreaCollapsed, setIsWorkingAreaCollapsed] = useState(false);
 
@@ -333,7 +342,114 @@ export const WorkstationGrid = ({
     clipboard && clipboard.components.length > 0,
   );
 
-  const copySelectionToClipboard = useCallback(() => {
+  const catalogLookup = useMemo(() => {
+    const lookup = new Map<string, string>();
+
+    for (const def of Object.values(catalog)) {
+      lookup.set(normalizeClipboardKey(def.id), def.id);
+      lookup.set(normalizeClipboardKey(def.label), def.id);
+    }
+
+    return lookup;
+  }, [catalog]);
+
+  const resolveCatalogComponentId = useCallback(
+    (component: ClipboardComponent): string | null => {
+      const exact = catalog[component.componentId];
+      if (exact) return exact.id;
+
+      const byLabel = catalogLookup.get(
+        normalizeClipboardKey(component.label || component.componentId),
+      );
+      return byLabel ?? null;
+    },
+    [catalog, catalogLookup],
+  );
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw) as ClipboardPayload;
+      if (
+        parsed &&
+        parsed.version === 1 &&
+        Array.isArray(parsed.components) &&
+        Array.isArray(parsed.wires)
+      ) {
+        setClipboard(parsed);
+      }
+    } catch {
+      // ignore clipboard hydration failures
+    }
+  }, []);
+
+  const persistClipboardPayload = useCallback(async (payload: ClipboardPayload) => {
+    setClipboard(payload);
+
+    try {
+      window.localStorage.setItem(
+        WORKSTATION_CLIPBOARD_STORAGE_KEY,
+        JSON.stringify(payload),
+      );
+    } catch {
+      // ignore storage failures
+    }
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(JSON.stringify(payload));
+      }
+    } catch {
+      // ignore clipboard write failures
+    }
+  }, []);
+
+  const readClipboardPayload = useCallback(async (): Promise<ClipboardPayload | null> => {
+    const parsePayload = (raw: string | null): ClipboardPayload | null => {
+      if (!raw) return null;
+
+      try {
+        const parsed = JSON.parse(raw) as ClipboardPayload;
+        if (
+          parsed &&
+          parsed.version === 1 &&
+          Array.isArray(parsed.components) &&
+          Array.isArray(parsed.wires)
+        ) {
+          return parsed;
+        }
+      } catch {
+        return null;
+      }
+
+      return null;
+    };
+
+    try {
+      const systemText = navigator.clipboard
+        ? await navigator.clipboard.readText()
+        : '';
+      const fromSystem = parsePayload(systemText);
+      if (fromSystem) return fromSystem;
+    } catch {
+      // ignore clipboard read failures
+    }
+
+    const fromState = clipboard;
+    if (fromState) return fromState;
+
+    try {
+      return parsePayload(
+        window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY),
+      );
+    } catch {
+      return null;
+    }
+  }, [clipboard]);
+
+  const copySelectionToClipboard = useCallback(async () => {
     if (
       selectedEntity.type !== 'component' ||
       selectedEntity.placedIds.length === 0
@@ -349,36 +465,77 @@ export const WorkstationGrid = ({
         selectedIds.has(w.to.componentId),
     );
 
-    setClipboard({ components: selectedComps, wires: internalWires });
-  }, [selectedEntity, placed, wires]);
+    const payload: ClipboardPayload = {
+      version: 1,
+      sourcePuzzleId: puzzleId,
+      components: selectedComps.map((component) => ({
+        ...component,
+        label: catalog[component.componentId]?.label ?? component.componentId,
+      })),
+      wires: internalWires,
+    };
 
-  const pasteFromClipboard = useCallback(() => {
-    if (!clipboard || clipboard.components.length === 0) {
+    await persistClipboardPayload(payload);
+  }, [catalog, persistClipboardPayload, placed, puzzleId, selectedEntity, wires]);
+
+  const pasteFromClipboard = useCallback(async () => {
+    const payload = await readClipboardPayload();
+    if (!payload || payload.components.length === 0) {
       return;
     }
 
-    const copiedWithDefs: Array<{
-      comp: PlacedGridComponent;
+    const resolvedComponents: Array<{
+      comp: ClipboardComponent;
+      resolvedComponentId: string;
       def: ComponentDef;
       size: { w: number; h: number };
     }> = [];
+    const missingComponents: string[] = [];
 
-    for (const comp of clipboard.components) {
-      const def = catalog[comp.componentId];
-      if (!def) {
-        notifications.addNotification({
-          type: 'warning',
-          title: 'Cannot paste here',
-          message: 'One or more copied components are unavailable.',
-        });
-        return;
+    for (const comp of payload.components) {
+      const resolvedComponentId = resolveCatalogComponentId(comp);
+      if (!resolvedComponentId) {
+        missingComponents.push(comp.label || comp.componentId);
+        continue;
       }
-      copiedWithDefs.push({
+
+      const def = catalog[resolvedComponentId];
+      if (!def) {
+        missingComponents.push(comp.label || comp.componentId);
+        continue;
+      }
+
+      resolvedComponents.push({
         comp,
+        resolvedComponentId,
         def,
         size: rotatedSize(def.size, comp.rotation),
       });
     }
+
+    if (!resolvedComponents.length) {
+      notifications.addNotification({
+        type: 'warning',
+        title: 'Cannot paste here',
+        message: 'No copied components are available in this workspace.',
+      });
+      return;
+    }
+
+    if (missingComponents.length > 0) {
+      notifications.addNotification({
+        type: 'warning',
+        title: 'Partial paste',
+        message: `Skipped ${missingComponents.length} unavailable component${missingComponents.length === 1 ? '' : 's'}.`,
+      });
+    }
+
+    const copiedWithDefs: Array<{
+      resolvedComponentId: string;
+      comp: PlacedGridComponent;
+      def: ComponentDef;
+      size: { w: number; h: number };
+    }> = resolvedComponents;
 
     const minRow = Math.min(
       ...copiedWithDefs.map(({ comp }) => comp.origin.row),
@@ -517,11 +674,11 @@ export const WorkstationGrid = ({
     const pasteStamp = Date.now();
 
     relativeLayout.forEach((item, idx) => {
-      const newId = `${item.comp.componentId}:${pasteStamp}-${idx}`;
+      const newId = `${item.resolvedComponentId}:${pasteStamp}-${idx}`;
       idMap.set(item.comp.id, newId);
       newComponents.push({
         id: newId,
-        componentId: item.comp.componentId,
+        componentId: item.resolvedComponentId,
         origin: {
           row: chosenAnchor.row + item.rowOffset,
           col: chosenAnchor.col + item.colOffset,
@@ -530,7 +687,7 @@ export const WorkstationGrid = ({
       });
     });
 
-    clipboard.wires.forEach((wire, idx) => {
+    payload.wires.forEach((wire, idx) => {
       const newFromId = idMap.get(wire.from.componentId);
       const newToId = idMap.get(wire.to.componentId);
       if (newFromId && newToId) {
@@ -548,9 +705,7 @@ export const WorkstationGrid = ({
       type: 'component',
       placedIds: Array.from(idMap.values()),
     });
-    setClipboard(null);
   }, [
-    clipboard,
     catalog,
     gridRows,
     gridCols,
@@ -558,6 +713,8 @@ export const WorkstationGrid = ({
     onPlacedChange,
     onWiresChange,
     placed,
+    readClipboardPayload,
+    resolveCatalogComponentId,
     wires,
   ]);
 
@@ -583,12 +740,12 @@ export const WorkstationGrid = ({
 
       if (isCopyKey) {
         e.preventDefault();
-        copySelectionToClipboard();
+        void copySelectionToClipboard();
       }
 
       if (isPasteKey) {
         e.preventDefault();
-        pasteFromClipboard();
+        void pasteFromClipboard();
       }
     };
 


### PR DESCRIPTION
This pull request introduces a robust, cross-session clipboard system for the workstation grid, enabling users to copy and paste circuit components and wires between puzzles and browser sessions. The clipboard data is now stored in both browser local storage and the system clipboard, and includes improved component resolution logic to handle missing or renamed components gracefully.

### Related
Closes #289 

**Clipboard System Enhancements**

* Added a new `ClipboardPayload` type and associated logic to serialize the clipboard contents, including versioning, source puzzle ID, components (with labels), and wires. Clipboard data is now persisted to both `localStorage` and the system clipboard for cross-session and cross-browser support. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxR48-R57](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76R48-R57), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxR75-R76](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76R75-R76), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL336-R452](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L336-R452), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL352-R539](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L352-R539))
* Implemented robust clipboard hydration and parsing, including error handling for invalid or missing clipboard data, and fallback to local storage if the system clipboard is unavailable. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL336-R452](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L336-R452))

**Component Resolution and Pasting Improvements**

* Enhanced component resolution logic during paste operations: pasted components are resolved by both ID and label, with missing components reported to the user via notifications. Partial pastes are supported, and unavailable components are skipped with a warning. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL336-R452](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L336-R452), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL352-R539](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L352-R539))
* Updated paste logic to use resolved component IDs, ensuring pasted components match the current puzzle's catalog even if the original component IDs have changed. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL520-R681](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L520-R681), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL352-R539](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L352-R539))

**Codebase Simplification and UX Improvements**

* Refactored copy and paste handlers to be fully asynchronous and to use the new clipboard system. Keyboard shortcuts for copy and paste now trigger the updated logic. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL586-R748](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L586-R748))
* Removed the now-unnecessary `clipboard` state reset after pasting, since the clipboard is now persistent. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxL551-R717](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76L551-R717))

**Minor UI Change**

* Removed the unused `viewportClassName="h-full"` prop from the arsenal creator page for cleaner markup.