### PR TITLE
V1.2/dishon me/291/feature/debugger qol

### DIFF
--- a/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
+++ b/apps/nextjs-app/src/app/app/arsenal/creator/page.tsx
@@ -656,7 +656,6 @@ export default function ArsenalCreatorPage() {
             onPlacedChange={handlePlacedChange}
             onWiresChange={setWires}
             draggedPaletteComponentId={draggedPaletteComponentId}
-            viewportClassName="h-full"
             emptyHoleClassName="size-2 bg-muted-foreground/35 hover:bg-muted-foreground/60"
           />
         </div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -280,6 +280,9 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   const [debugSequences, setDebugSequences] = useState<Record<string, string>>(
     {},
   );
+  const [debugSequencesCommitted, setDebugSequencesCommitted] = useState<
+    Record<string, string>
+  >({});
   const [debugStepIndex, setDebugStepIndex] = useState(0);
   const [debugIsRunning, setDebugIsRunning] = useState(false);
   const [debugRunKey, setDebugRunKey] = useState(0);
@@ -559,6 +562,14 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   useEffect(() => {
     if (!inputs.length) return;
     setDebugSequences((prev) => {
+      const next: Record<string, string> = {};
+      for (const inputName of inputs) {
+        const current = sanitizeBitSequence(prev[inputName] ?? '');
+        next[inputName] = current || defaultDebugSequence;
+      }
+      return next;
+    });
+    setDebugSequencesCommitted((prev) => {
       const next: Record<string, string> = {};
       for (const inputName of inputs) {
         const current = sanitizeBitSequence(prev[inputName] ?? '');
@@ -1152,7 +1163,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     const parsed: Record<string, string[]> = {};
     let stepCount = 0;
     for (const inputName of inputs) {
-      const bits = parseBitSequence(debugSequences[inputName] ?? '');
+      const bits = parseBitSequence(debugSequencesCommitted[inputName] ?? '');
       if (!bits.length) {
         notifications.addNotification({
           type: 'warning',
@@ -1263,7 +1274,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   }, [
     puzzle?.id,
     inputs,
-    debugSequences,
+    debugSequencesCommitted,
     placed,
     wires,
     currentCost,
@@ -1787,6 +1798,15 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
 
   const onInlineSequenceChange = (inputName: string, rawValue: string) => {
     const edited = sanitizeBitSequence(rawValue);
+
+    setDebugSequences((prev) => ({
+      ...prev,
+      [inputName]: edited,
+    }));
+  };
+
+  const onInlineSequenceCommit = (inputName: string, rawValue: string) => {
+    const edited = sanitizeBitSequence(rawValue);
     const targetLength = Math.max(
       1,
       edited.length || defaultDebugSequence.length || 1,
@@ -1801,6 +1821,20 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     };
 
     setDebugSequences((prev) => {
+      const next: Record<string, string> = {};
+      for (const name of inputs) {
+        if (name === inputName) {
+          next[name] = normalizeToTargetLength(edited || '0');
+        } else {
+          next[name] = normalizeToTargetLength(
+            prev[name] ?? defaultDebugSequence,
+          );
+        }
+      }
+      return next;
+    });
+
+    setDebugSequencesCommitted((prev) => {
       const next: Record<string, string> = {};
       for (const name of inputs) {
         if (name === inputName) {
@@ -2203,6 +2237,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                 debuggerGateBits={currentGateBits}
                 debuggerSequences={debugSequences}
                 onDebuggerSequenceChange={onInlineSequenceChange}
+                onDebuggerSequenceCommit={onInlineSequenceCommit}
                 onInspectComponent={setInspectingPlacedId}
                 arsenalComponentDisplayModes={arsenalComponentDisplayModes}
                 disableZoomPersistence

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -3,8 +3,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import {
   ChevronDown,
-  StepBack,
-  StepForward,
   ArrowRight,
   Trash2,
   CircleAlert,
@@ -34,7 +32,6 @@ import { InfoPopup } from '@/components/ui/info-popup';
 import { useNotifications } from '@/components/ui/notifications';
 import { PageTourLauncher } from '@/components/ui/page-tour-launcher';
 import { PuzzleXPBar } from '@/components/ui/puzzle-xp-bar';
-import { ZigzagBugCanvas } from '@/components/ui/zigzag-bug-canvas';
 import { paths } from '@/config/paths';
 import { workstationTourSteps } from '@/config/tour-steps';
 import { useSettings } from '@/context/settings-context';
@@ -214,7 +211,6 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   // with beginSolveAgain when isSolved flips back to false. Reset by navigating
   // to a different puzzle (the ref value no longer matches puzzle.id).
   const initializedPuzzleIdRef = useRef<string | null>(null);
-  const debuggerButtonRef = useRef<HTMLButtonElement>(null);
   const queryClient = useQueryClient();
   const { playError, playSuccess } = useAudio();
   const { visualEffectsEnabled } = useSettings();
@@ -2004,53 +2000,6 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                   }
                 />
               ) : null}
-              {!isInlineDebugger ? (
-                <div className="relative">
-                  <Button
-                    ref={debuggerButtonRef}
-                    variant="outline"
-                    size="sm"
-                    className="workstation-debugger-button relative overflow-hidden"
-                    onClick={enterInlineDebugger}
-                  >
-                    <ZigzagBugCanvas containerRef={debuggerButtonRef} />
-                    Debugger
-                  </Button>
-                </div>
-              ) : (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onDebuggerStepPrev}
-                  >
-                    <StepBack className="mr-1 size-4" />
-                    Previous Step
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onDebuggerStepNext}
-                  >
-                    <StepForward className="mr-1 size-4" />
-                    Next Step
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowDebugger(true)}
-                  >
-                    View Full Debugger Report
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={exitInlineDebugger}
-                  >
-                    Exit Debugger
-                  </Button>
-                </>
-              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -2238,6 +2187,11 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                 debuggerSequences={debugSequences}
                 onDebuggerSequenceChange={onInlineSequenceChange}
                 onDebuggerSequenceCommit={onInlineSequenceCommit}
+                onEnterInlineDebugger={enterInlineDebugger}
+                onDebuggerStepPrev={onDebuggerStepPrev}
+                onDebuggerStepNext={onDebuggerStepNext}
+                onOpenFullDebuggerReport={() => setShowDebugger(true)}
+                onExitInlineDebugger={exitInlineDebugger}
                 onInspectComponent={setInspectingPlacedId}
                 arsenalComponentDisplayModes={arsenalComponentDisplayModes}
                 disableZoomPersistence

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -2959,6 +2959,7 @@ export const WorkstationGrid = ({
             if (!pt) return null;
             const inputBit = debuggerInputBits[label] ?? '0';
             const sequenceValue = debuggerSequences[label] ?? '';
+            const sequenceBits = sequenceValue.split('');
             return (
               <div key={id}>
                 {debuggerActive ? (
@@ -2988,6 +2989,31 @@ export const WorkstationGrid = ({
                       className="h-5 w-20 rounded border border-green-300 bg-white px-1 text-[10px] text-green-700"
                       title="Input bit sequence"
                     />
+                  </div>
+                ) : null}
+                {debuggerActive && sequenceBits.length > 0 ? (
+                  <div
+                    className="pointer-events-none absolute z-30 flex max-w-[90px] flex-wrap items-center gap-[2px]"
+                    style={{
+                      left: pt.x,
+                      top: pt.y,
+                      transform: 'translate(-102%, -105%)',
+                    }}
+                    title={`Step ${debuggerStepIndex + 1} highlighted in sequence`}
+                  >
+                    {sequenceBits.map((bit, bitIndex) => (
+                      <span
+                        key={`${id}-seq-${bitIndex}`}
+                        className={cn(
+                          'inline-flex h-3 w-3 items-center justify-center rounded border text-[9px] font-bold leading-none',
+                          bitIndex === debuggerStepIndex
+                            ? 'border-emerald-500 bg-emerald-500 text-white shadow-sm'
+                            : 'border-green-200 bg-white/95 text-green-700',
+                        )}
+                      >
+                        {bit}
+                      </span>
+                    ))}
                   </div>
                 ) : null}
                 <button

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -45,6 +45,16 @@ export type PlacedGridComponent = {
   rotation: 0 | 90;
   isLocked?: boolean; // If true, component is immovable, undeletable, and mandatory to use
 };
+type ClipboardComponent = PlacedGridComponent & {
+  label: string;
+};
+type ClipboardPayload = {
+  version: 1;
+  sourcePuzzleId: string;
+  components: ClipboardComponent[];
+  wires: Wire[];
+};
+const normalizeClipboardKey = (value: string) => value.trim().toLowerCase();
 
 export type PortAddress = {
   ownerId: string; // placedId or IO:IN:* / IO:OUT:*
@@ -62,6 +72,8 @@ const DEFAULT_GRID_ROWS = 15;
 const DEFAULT_GRID_COLS = 30;
 const CELL_PX = 18;
 const PUZZLE_IO_Y_OFFSET_PX = 20;
+const WORKSTATION_CLIPBOARD_STORAGE_KEY =
+  'escapecircuit.workstation.clipboard.v1';
 
 // Visual Feature: Dynamic Wire Coloring
 const WIRE_COLORS = ['#3b82f6', '#ef4444', '#10b981', '#a855f7', '#f97316'];
@@ -320,10 +332,7 @@ export const WorkstationGrid = ({
   const [microSparks, setMicroSparks] = useState<
     Array<{ id: string; x: number; y: number; dx: number; dy: number }>
   >([]);
-  const [clipboard, setClipboard] = useState<{
-    components: PlacedGridComponent[];
-    wires: Wire[];
-  } | null>(null);
+  const [clipboard, setClipboard] = useState<ClipboardPayload | null>(null);
   const [bootSequenceActive, setBootSequenceActive] = useState(true);
   const [isWorkingAreaCollapsed, setIsWorkingAreaCollapsed] = useState(false);
 
@@ -333,7 +342,114 @@ export const WorkstationGrid = ({
     clipboard && clipboard.components.length > 0,
   );
 
-  const copySelectionToClipboard = useCallback(() => {
+  const catalogLookup = useMemo(() => {
+    const lookup = new Map<string, string>();
+
+    for (const def of Object.values(catalog)) {
+      lookup.set(normalizeClipboardKey(def.id), def.id);
+      lookup.set(normalizeClipboardKey(def.label), def.id);
+    }
+
+    return lookup;
+  }, [catalog]);
+
+  const resolveCatalogComponentId = useCallback(
+    (component: ClipboardComponent): string | null => {
+      const exact = catalog[component.componentId];
+      if (exact) return exact.id;
+
+      const byLabel = catalogLookup.get(
+        normalizeClipboardKey(component.label || component.componentId),
+      );
+      return byLabel ?? null;
+    },
+    [catalog, catalogLookup],
+  );
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw) as ClipboardPayload;
+      if (
+        parsed &&
+        parsed.version === 1 &&
+        Array.isArray(parsed.components) &&
+        Array.isArray(parsed.wires)
+      ) {
+        setClipboard(parsed);
+      }
+    } catch {
+      // ignore clipboard hydration failures
+    }
+  }, []);
+
+  const persistClipboardPayload = useCallback(async (payload: ClipboardPayload) => {
+    setClipboard(payload);
+
+    try {
+      window.localStorage.setItem(
+        WORKSTATION_CLIPBOARD_STORAGE_KEY,
+        JSON.stringify(payload),
+      );
+    } catch {
+      // ignore storage failures
+    }
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(JSON.stringify(payload));
+      }
+    } catch {
+      // ignore clipboard write failures
+    }
+  }, []);
+
+  const readClipboardPayload = useCallback(async (): Promise<ClipboardPayload | null> => {
+    const parsePayload = (raw: string | null): ClipboardPayload | null => {
+      if (!raw) return null;
+
+      try {
+        const parsed = JSON.parse(raw) as ClipboardPayload;
+        if (
+          parsed &&
+          parsed.version === 1 &&
+          Array.isArray(parsed.components) &&
+          Array.isArray(parsed.wires)
+        ) {
+          return parsed;
+        }
+      } catch {
+        return null;
+      }
+
+      return null;
+    };
+
+    try {
+      const systemText = navigator.clipboard
+        ? await navigator.clipboard.readText()
+        : '';
+      const fromSystem = parsePayload(systemText);
+      if (fromSystem) return fromSystem;
+    } catch {
+      // ignore clipboard read failures
+    }
+
+    const fromState = clipboard;
+    if (fromState) return fromState;
+
+    try {
+      return parsePayload(
+        window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY),
+      );
+    } catch {
+      return null;
+    }
+  }, [clipboard]);
+
+  const copySelectionToClipboard = useCallback(async () => {
     if (
       selectedEntity.type !== 'component' ||
       selectedEntity.placedIds.length === 0
@@ -349,36 +465,77 @@ export const WorkstationGrid = ({
         selectedIds.has(w.to.componentId),
     );
 
-    setClipboard({ components: selectedComps, wires: internalWires });
-  }, [selectedEntity, placed, wires]);
+    const payload: ClipboardPayload = {
+      version: 1,
+      sourcePuzzleId: puzzleId,
+      components: selectedComps.map((component) => ({
+        ...component,
+        label: catalog[component.componentId]?.label ?? component.componentId,
+      })),
+      wires: internalWires,
+    };
 
-  const pasteFromClipboard = useCallback(() => {
-    if (!clipboard || clipboard.components.length === 0) {
+    await persistClipboardPayload(payload);
+  }, [catalog, persistClipboardPayload, placed, puzzleId, selectedEntity, wires]);
+
+  const pasteFromClipboard = useCallback(async () => {
+    const payload = await readClipboardPayload();
+    if (!payload || payload.components.length === 0) {
       return;
     }
 
-    const copiedWithDefs: Array<{
-      comp: PlacedGridComponent;
+    const resolvedComponents: Array<{
+      comp: ClipboardComponent;
+      resolvedComponentId: string;
       def: ComponentDef;
       size: { w: number; h: number };
     }> = [];
+    const missingComponents: string[] = [];
 
-    for (const comp of clipboard.components) {
-      const def = catalog[comp.componentId];
-      if (!def) {
-        notifications.addNotification({
-          type: 'warning',
-          title: 'Cannot paste here',
-          message: 'One or more copied components are unavailable.',
-        });
-        return;
+    for (const comp of payload.components) {
+      const resolvedComponentId = resolveCatalogComponentId(comp);
+      if (!resolvedComponentId) {
+        missingComponents.push(comp.label || comp.componentId);
+        continue;
       }
-      copiedWithDefs.push({
+
+      const def = catalog[resolvedComponentId];
+      if (!def) {
+        missingComponents.push(comp.label || comp.componentId);
+        continue;
+      }
+
+      resolvedComponents.push({
         comp,
+        resolvedComponentId,
         def,
         size: rotatedSize(def.size, comp.rotation),
       });
     }
+
+    if (!resolvedComponents.length) {
+      notifications.addNotification({
+        type: 'warning',
+        title: 'Cannot paste here',
+        message: 'No copied components are available in this workspace.',
+      });
+      return;
+    }
+
+    if (missingComponents.length > 0) {
+      notifications.addNotification({
+        type: 'warning',
+        title: 'Partial paste',
+        message: `Skipped ${missingComponents.length} unavailable component${missingComponents.length === 1 ? '' : 's'}.`,
+      });
+    }
+
+    const copiedWithDefs: Array<{
+      resolvedComponentId: string;
+      comp: PlacedGridComponent;
+      def: ComponentDef;
+      size: { w: number; h: number };
+    }> = resolvedComponents;
 
     const minRow = Math.min(
       ...copiedWithDefs.map(({ comp }) => comp.origin.row),
@@ -517,11 +674,11 @@ export const WorkstationGrid = ({
     const pasteStamp = Date.now();
 
     relativeLayout.forEach((item, idx) => {
-      const newId = `${item.comp.componentId}:${pasteStamp}-${idx}`;
+      const newId = `${item.resolvedComponentId}:${pasteStamp}-${idx}`;
       idMap.set(item.comp.id, newId);
       newComponents.push({
         id: newId,
-        componentId: item.comp.componentId,
+        componentId: item.resolvedComponentId,
         origin: {
           row: chosenAnchor.row + item.rowOffset,
           col: chosenAnchor.col + item.colOffset,
@@ -530,7 +687,7 @@ export const WorkstationGrid = ({
       });
     });
 
-    clipboard.wires.forEach((wire, idx) => {
+    payload.wires.forEach((wire, idx) => {
       const newFromId = idMap.get(wire.from.componentId);
       const newToId = idMap.get(wire.to.componentId);
       if (newFromId && newToId) {
@@ -548,9 +705,7 @@ export const WorkstationGrid = ({
       type: 'component',
       placedIds: Array.from(idMap.values()),
     });
-    setClipboard(null);
   }, [
-    clipboard,
     catalog,
     gridRows,
     gridCols,
@@ -558,6 +713,8 @@ export const WorkstationGrid = ({
     onPlacedChange,
     onWiresChange,
     placed,
+    readClipboardPayload,
+    resolveCatalogComponentId,
     wires,
   ]);
 
@@ -583,12 +740,12 @@ export const WorkstationGrid = ({
 
       if (isCopyKey) {
         e.preventDefault();
-        copySelectionToClipboard();
+        void copySelectionToClipboard();
       }
 
       if (isPasteKey) {
         e.preventDefault();
-        pasteFromClipboard();
+        void pasteFromClipboard();
       }
     };
 

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -212,6 +212,7 @@ export const WorkstationGrid = ({
   debuggerGateBits = {},
   debuggerSequences = {},
   onDebuggerSequenceChange,
+  onDebuggerSequenceCommit,
   isEditMode = false,
   viewportClassName,
   disableZoomPersistence = false,
@@ -244,6 +245,7 @@ export const WorkstationGrid = ({
   debuggerGateBits?: Record<string, string>;
   debuggerSequences?: Record<string, string>;
   onDebuggerSequenceChange?: (inputName: string, sequence: string) => void;
+  onDebuggerSequenceCommit?: (inputName: string, sequence: string) => void;
   onInspectComponent?: (placedId: string) => void;
   arsenalComponentDisplayModes?: Record<string, 'circuit' | 'description'>;
   isEditMode?: boolean;
@@ -2986,6 +2988,21 @@ export const WorkstationGrid = ({
                           e.target.value.replace(/[^01]/g, ''),
                         )
                       }
+                      onBlur={(e) =>
+                        onDebuggerSequenceCommit?.(
+                          label,
+                          e.target.value.replace(/[^01]/g, ''),
+                        )
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key !== 'Enter') return;
+                        const target = e.currentTarget;
+                        onDebuggerSequenceCommit?.(
+                          label,
+                          target.value.replace(/[^01]/g, ''),
+                        );
+                        target.blur();
+                      }}
                       className="h-5 w-20 rounded border border-green-300 bg-white px-1 text-[10px] text-green-700"
                       title="Input bit sequence"
                     />

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -11,6 +11,7 @@ import { RippleEffect } from '@/components/ripple-effect';
 import { Button } from '@/components/ui/button';
 import { useNotifications } from '@/components/ui/notifications';
 import { Spinner } from '@/components/ui/spinner';
+import { ZigzagBugCanvas } from '@/components/ui/zigzag-bug-canvas';
 import { useSettings } from '@/context/settings-context';
 import { useAudio } from '@/hooks/use-audio';
 import type { Wire } from '@/types/api';
@@ -213,6 +214,11 @@ export const WorkstationGrid = ({
   debuggerSequences = {},
   onDebuggerSequenceChange,
   onDebuggerSequenceCommit,
+  onEnterInlineDebugger,
+  onDebuggerStepPrev,
+  onDebuggerStepNext,
+  onOpenFullDebuggerReport,
+  onExitInlineDebugger,
   isEditMode = false,
   viewportClassName,
   disableZoomPersistence = false,
@@ -246,6 +252,11 @@ export const WorkstationGrid = ({
   debuggerSequences?: Record<string, string>;
   onDebuggerSequenceChange?: (inputName: string, sequence: string) => void;
   onDebuggerSequenceCommit?: (inputName: string, sequence: string) => void;
+  onEnterInlineDebugger?: () => void;
+  onDebuggerStepPrev?: () => void;
+  onDebuggerStepNext?: () => void;
+  onOpenFullDebuggerReport?: () => void;
+  onExitInlineDebugger?: () => void;
   onInspectComponent?: (placedId: string) => void;
   arsenalComponentDisplayModes?: Record<string, 'circuit' | 'description'>;
   isEditMode?: boolean;
@@ -260,6 +271,7 @@ export const WorkstationGrid = ({
   const { visualEffectsEnabled } = useSettings();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const debuggerButtonRef = useRef<HTMLButtonElement | null>(null);
   const panAnimationFrameRef = useRef<number | null>(null);
   const [zoom, setZoom] = useState(1);
   const [minZoom, setMinZoom] = useState(1);
@@ -1998,25 +2010,60 @@ export const WorkstationGrid = ({
           <div className="text-sm font-medium text-foreground">
             Working Area
           </div>
-          <button
-            type="button"
-            className="-mr-1 inline-flex items-center justify-center rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-            onClick={() => setIsWorkingAreaCollapsed((prev) => !prev)}
-            aria-expanded={!isWorkingAreaCollapsed}
-            aria-label={
-              isWorkingAreaCollapsed
-                ? 'Expand Working Area info'
-                : 'Collapse Working Area info'
-            }
-            title={isWorkingAreaCollapsed ? 'Expand' : 'Collapse'}
-          >
-            <ChevronRight
-              className={cn(
-                'size-4 transition-transform duration-200',
-                !isWorkingAreaCollapsed && 'rotate-90',
-              )}
-            />
-          </button>
+          <div className="flex items-center gap-2">
+            {onEnterInlineDebugger || onExitInlineDebugger ? (
+              !debuggerActive ? (
+                <Button
+                  ref={debuggerButtonRef}
+                  size="sm"
+                  variant="outline"
+                  className="relative overflow-hidden"
+                  onClick={onEnterInlineDebugger}
+                >
+                  <ZigzagBugCanvas containerRef={debuggerButtonRef} />
+                  Debugger
+                </Button>
+              ) : (
+                <>
+                  <Button size="sm" variant="outline" onClick={onDebuggerStepPrev}>
+                    ◄ Previous Step
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={onDebuggerStepNext}>
+                    Next Step ►
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onOpenFullDebuggerReport}
+                  >
+                    Full Debugger Report
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={onExitInlineDebugger}>
+                    Exit Debugger
+                  </Button>
+                </>
+              )
+            ) : null}
+            <button
+              type="button"
+              className="-mr-1 inline-flex items-center justify-center rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              onClick={() => setIsWorkingAreaCollapsed((prev) => !prev)}
+              aria-expanded={!isWorkingAreaCollapsed}
+              aria-label={
+                isWorkingAreaCollapsed
+                  ? 'Expand Working Area info'
+                  : 'Collapse Working Area info'
+              }
+              title={isWorkingAreaCollapsed ? 'Expand' : 'Collapse'}
+            >
+              <ChevronRight
+                className={cn(
+                  'size-4 transition-transform duration-200',
+                  !isWorkingAreaCollapsed && 'rotate-90',
+                )}
+              />
+            </button>
+          </div>
         </div>
         {!isWorkingAreaCollapsed ? (
           <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">

--- a/apps/nextjs-app/src/components/circuit-debugger.tsx
+++ b/apps/nextjs-app/src/components/circuit-debugger.tsx
@@ -69,6 +69,18 @@ export function CircuitDebugger({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stepCount, setStepCount] = useState(0);
+  const [sequenceStepIndex, setSequenceStepIndex] = useState(0);
+
+  const parseSequenceBits = (value: string): string[] => {
+    if (!value.trim()) return [];
+    if (value.includes(',')) {
+      return value
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part === '0' || part === '1');
+    }
+    return value.split('').filter((ch) => ch === '0' || ch === '1');
+  };
 
   useEffect(() => {
     if (!modeOverride) return;
@@ -87,6 +99,18 @@ export function CircuitDebugger({
     void handleRunSequence();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoRunToken, isOpen]);
+
+  useEffect(() => {
+    if (mode !== 'sequence') {
+      setSequenceStepIndex(0);
+      return;
+    }
+
+    setSequenceStepIndex((prev) => {
+      const maxIndex = Math.max(stepCount - 1, 0);
+      return Math.min(Math.max(prev, 0), maxIndex);
+    });
+  }, [mode, stepCount]);
 
   // Helper: count same component types for numbering
   const getComponentDisplayLabel = (
@@ -198,6 +222,7 @@ export function CircuitDebugger({
       setPuzzleOutputs([puzzleOutputsMap]);
       setHasRun(true);
       setStepCount(1);
+      setSequenceStepIndex(0);
 
       // Call callback if provided
       if (onDebug) {
@@ -309,6 +334,7 @@ export function CircuitDebugger({
       setPuzzleOutputs(allPuzzleOutputs);
       setHasRun(true);
       setStepCount(maxLength);
+      setSequenceStepIndex(0);
     } catch (err: any) {
       setError(err.message || 'Failed to simulate circuit sequence');
       console.error('Debug sequence simulation error:', err);
@@ -386,12 +412,66 @@ export function CircuitDebugger({
                         placeholder="e.g., 01010 or 0,1,0,1,0"
                         className="w-full rounded-lg border border-border bg-card px-2.5 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                       />
+                      {parseSequenceBits(sequenceInputs[inputName] || '').length >
+                      0 ? (
+                        <div
+                          className="mt-1.5 flex flex-wrap items-center gap-1"
+                          title={`Current step ${sequenceStepIndex + 1}`}
+                        >
+                          {parseSequenceBits(sequenceInputs[inputName] || '').map(
+                            (bit, index) => (
+                              <span
+                                key={`${inputName}-bit-${index}`}
+                                className={`inline-flex h-5 w-5 items-center justify-center rounded border text-[11px] font-semibold ${
+                                  index === sequenceStepIndex
+                                    ? 'border-emerald-500 bg-emerald-500 text-white'
+                                    : 'border-border bg-card text-foreground'
+                                }`}
+                              >
+                                {bit}
+                              </span>
+                            ),
+                          )}
+                        </div>
+                      ) : null}
                       <p className="mt-1 text-[11px] text-muted-foreground">
                         Enter binary digits (0,1) or comma-separated values
                       </p>
                     </div>
                   </div>
                 ))}
+
+                {stepCount > 0 ? (
+                  <div className="ml-[5.5rem] flex items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        setSequenceStepIndex((prev) => Math.max(prev - 1, 0))
+                      }
+                      disabled={sequenceStepIndex <= 0}
+                    >
+                      Prev Step
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        setSequenceStepIndex((prev) =>
+                          Math.min(prev + 1, Math.max(stepCount - 1, 0)),
+                        )
+                      }
+                      disabled={sequenceStepIndex >= stepCount - 1}
+                    >
+                      Next Step
+                    </Button>
+                    <span className="text-[12px] text-muted-foreground">
+                      Current Step {sequenceStepIndex + 1}/{stepCount}
+                    </span>
+                  </div>
+                ) : null}
               </div>
             )}
           </div>


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the puzzle workstation and grid components, focusing on enhancing the copy-paste functionality, improving debugger state management, and cleaning up unused code. The most significant changes can be grouped as follows:

### Related:
Closes #291 

### UI Changes:
<img width="1690" height="717" alt="image" src="https://github.com/user-attachments/assets/1997687c-f984-4bbc-9f6c-ff9464ab218a" />


**Debugger State Management and API:**

* Introduced a committed state for debugger input sequences (`debugSequencesCommitted`) to separate editing from committed values, improving consistency and reliability of debugging. All debugger operations now use the committed state. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxR279-R281](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6R279-R281), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxR568-R575](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6R568-R575), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL1155-R1162](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L1155-R1162), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL1266-R1273](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L1266-R1273))
* Refactored the API between `PuzzleWorkstation` and `WorkstationGrid` to pass explicit debugger control callbacks (step prev/next, enter/exit, commit sequence, etc.), making the interface more modular and easier to extend. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxR216-R221](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76R216-R221), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsxR254-R259](diffhunk://#diff-316348e9eb027769536f507568a9bf56c0c3e4ae48545d50ca5a4eb74ced2c76R254-R259), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxR2189-R2194](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6R2189-R2194))

**Code Cleanup and UI Adjustments:**

* Removed unused imports, variables, and the inline debugger button UI from `puzzle-workstation.tsx`, delegating all debugger UI to the grid component for better separation of concerns. ([apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL6-L7](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L6-L7), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL37](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L37), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL217](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L217), [apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsxL1973-L2019](diffhunk://#diff-ca68deb0ec7918e40208fa53dbf29652263797abbf10da3e353c354c0eafc3b6L1973-L2019))
* Removed the `viewportClassName` prop from the arsenal creator page, likely as part of UI simplification.

These changes collectively improve the reliability and user experience of the puzzle workstation, especially for users copying and pasting circuit components between puzzles and using the inline debugger.