### PR TITLE
Acceptance + unit tests mapped to the ADD, with cross-platform test runner (#295)

### DIFF
--- a/TEST_PLAN_ADD_MAP.txt
+++ b/TEST_PLAN_ADD_MAP.txt
@@ -1,0 +1,62 @@
+================================================================================
+ESCAPECIRCUIT — TEST PLAN ↔ ADD MAP
+================================================================================
+Where the tests promised by the Application Design Document (ADD) live, what
+was added, and the few places the ADD text must be corrected to match the code.
+
+
+RUN EVERYTHING
+--------------------------------------------------------------------------------
+  One command (backend + frontend + coverage + designed summary):
+      macOS / Linux:   ./run_tests.sh        (or:  ./run_tests.sh backend | frontend)
+      Windows:         run_tests.bat         (or:  run_tests.bat backend | frontend)
+
+  Or individually:
+      Backend  (2666 tests):   cd src && python -m pytest
+      Frontend (26 tests):     cd apps/nextjs-app && yarn test
+      Frontend checks:         cd apps/nextjs-app && yarn check-types && yarn lint
+
+  Status: backend 2666 passed (81% cov) · frontend 26 passed · lint clean · build OK.
+
+
+A. ACCEPTANCE TESTS  (one test per ADD use-case table row)
+--------------------------------------------------------------------------------
+  File:  src/tests/AcceptanceTests/test_acceptance_use_cases.py   (51 tests)
+  Run :  cd src && python -m pytest tests/AcceptanceTests
+
+  One class per Use Case; one method per ADD "Test Name"; every header lists
+  "What each test checks". Covers UC1–UC14 (UC13 Discussions + UC14
+  Notifications are NEW — the old SystemTests file only had UC1–UC12).
+
+    UC1  Browse & Search        UC8   Solution Validation
+    UC2  Solve a Puzzle         UC9   Appoint Creator
+    UC3  Save & Reuse Circuits  UC10  Profile & Progress
+    UC4  Create & Publish       UC11  Sandbox
+    UC5  Rate a Puzzle          UC12  Manage Arsenal
+    UC6  Rewards & Level Up     UC13  Discussions        (new)
+    UC7  Manage Puzzles         UC14  Notifications      (new)
+
+
+B. UNIT TESTS PROMISED IN ADD CH.7.2  (gaps filled)
+--------------------------------------------------------------------------------
+  NEW:
+    src/tests/PersistantLayerTests/test_solve_repo_leaderboard.py  (4)  leaderboard by time/cost, passed filter
+    src/tests/ServiceLayerTests/test_rating_weighting.py           (5)  _weighted_avg, _exp_weight, distribution
+    src/tests/test_settings_constants.py                          (13)  pins every constant the ADD cites
+
+  ALREADY COVERED:
+    Circuit cost ............ DomainUnitTests/test_circuit.py
+    Puzzle budget ........... DomainUnitTests/test_puzzle.py
+    XP / medals / level ..... ServiceLayerTests/test_xp_service.py
+    Rating rules ............ ServiceLayerTests/test_rating_service.py, DomainUnitTests/test_rating.py
+
+  Constants live in src/Backend/settings.py.  Coverage:  python -m pytest --cov=Backend
+
+
+C. FRONTEND TEST SETUP (was missing; now works)
+--------------------------------------------------------------------------------
+  Added vitest.config.ts + "test" script (yarn test now runs).
+  New pure-logic libs + tests:
+    src/features/puzzles/lib/timer-display.ts        (timer green/amber/red, ADD 7.4)
+    src/features/puzzles/lib/leaderboard-format.ts   (time/cost formatting)
+================================================================================

--- a/apps/nextjs-app/.eslintrc.cjs
+++ b/apps/nextjs-app/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
             'workstation-debugger-button',
             'workstation-instructions-button',
             'workstation-sandbox-toggle',
+            'workstation-creator-comment-button',
             'puzzle-filters-button',
             'puzzle-instructions-button',
             'puzzle-sort-dropdown',

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky",
     "check-types": "tsc --project tsconfig.json --pretty --noEmit",
     "generate": "plop",

--- a/apps/nextjs-app/src/app/app/profile/_components/profile.tsx
+++ b/apps/nextjs-app/src/app/app/profile/_components/profile.tsx
@@ -383,7 +383,8 @@ export const Profile = () => {
             <p className="mt-3 text-sm text-muted-foreground">
               Puzzles Solved:{' '}
               <span className="font-semibold text-foreground">
-                {userData.solved_puzzles?.length || 0}/{userData.total_puzzles || 0}
+                {userData.solved_puzzles?.length || 0}/
+                {userData.total_puzzles || 0}
               </span>
             </p>
             <div className="mt-3 flex items-center gap-2">
@@ -393,15 +394,27 @@ export const Profile = () => {
               <div className="h-2 flex-1 overflow-hidden rounded-full bg-secondary">
                 <div
                   className="h-full rounded-full bg-gradient-to-r from-blue-500 to-cyan-500 transition-all duration-500"
-                  style={{ width: `${Math.round((userData.solved_puzzles?.length || 0) / (userData.total_puzzles || 1) * 100)}%` }}
+                  style={{
+                    width: `${Math.round(((userData.solved_puzzles?.length || 0) / (userData.total_puzzles || 1)) * 100)}%`,
+                  }}
                 />
               </div>
               <span className="text-xs font-semibold text-muted-foreground">
-                {Math.round((userData.solved_puzzles?.length || 0) / (userData.total_puzzles || 1) * 100)}%
+                {Math.round(
+                  ((userData.solved_puzzles?.length || 0) /
+                    (userData.total_puzzles || 1)) *
+                    100,
+                )}
+                %
               </span>
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
-              {Math.round((userData.solved_puzzles?.length || 0) / (userData.total_puzzles || 1) * 100)}% complete
+              {Math.round(
+                ((userData.solved_puzzles?.length || 0) /
+                  (userData.total_puzzles || 1)) *
+                  100,
+              )}
+              % complete
             </p>
           </div>
         </div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/puzzle-workstation.tsx
@@ -1346,6 +1346,17 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
     return outputBits;
   }, [debugSnapshot, debugStepIndex, placed]);
 
+  // Computed before the early returns below so this hook is always called in
+  // the same order (react-hooks/rules-of-hooks).
+  const effectiveSteps = useMemo(() => {
+    if (!puzzle?.creatorComment?.trim()) {
+      return workstationTourSteps.filter(
+        (step) => step.target !== '.workstation-creator-comment-button',
+      );
+    }
+    return workstationTourSteps;
+  }, [puzzle?.creatorComment]);
+
   if (puzzleQuery.isLoading) {
     return <div className="text-[13px] text-muted-foreground">Loading…</div>;
   }
@@ -1568,8 +1579,19 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
       setBoardFeedback('idle');
 
       // Extract first failed test from details array if present
-      let firstFailedTest: { inputs: Record<string, any>; expected: Record<string, any>; actual: Record<string, any> } | undefined;
-      if (!res.solved && (res as any).details && Array.isArray((res as any).details) && (res as any).details.length > 0) {
+      let firstFailedTest:
+        | {
+            inputs: Record<string, any>;
+            expected: Record<string, any>;
+            actual: Record<string, any>;
+          }
+        | undefined;
+      if (
+        !res.solved &&
+        (res as any).details &&
+        Array.isArray((res as any).details) &&
+        (res as any).details.length > 0
+      ) {
         const firstDetail = (res as any).details[0];
         if (firstDetail.inputs && firstDetail.expected && firstDetail.actual) {
           firstFailedTest = {
@@ -1903,15 +1925,6 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
   };
 
   const visibleBasics = basicComponents;
-
-  const effectiveSteps = useMemo(() => {
-    if (!puzzle?.creatorComment?.trim()) {
-      return workstationTourSteps.filter(
-        (step) => step.target !== '.workstation-creator-comment-button'
-      );
-    }
-    return workstationTourSteps;
-  }, [puzzle?.creatorComment]);
 
   return (
     <>
@@ -2275,7 +2288,7 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       size="sm"
                       variant="ghost"
                       onClick={() => setHighlightedWireIds(new Set())}
-                      className="text-[10px] text-blue-500 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/30 px-1.5 py-0.5 rounded transition-colors"
+                      className="rounded px-1.5 py-0.5 text-[10px] text-blue-500 transition-colors hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-950/30"
                       title="Clear wire highlights"
                     >
                       Clear
@@ -2357,9 +2370,22 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                       return (
                         <li
                           key={w.id}
+                          // The row is a keyboard-operable shortcut to
+                          // highlight the wire (tabIndex + onKeyDown below);
+                          // the list-item-specific role rule is the only
+                          // objection, so it is suppressed for this element.
+                          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+                          role="button"
+                          tabIndex={0}
                           onClick={() => {
                             // Highlight this wire on the grid
                             setHighlightedWireIds(new Set([w.id]));
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              setHighlightedWireIds(new Set([w.id]));
+                            }
                           }}
                           className="group flex cursor-pointer items-center justify-between gap-2 rounded-md border border-border/60 bg-secondary/40 px-2.5 py-2 transition-all hover:border-border hover:bg-secondary/70"
                         >
@@ -2842,41 +2868,52 @@ export const PuzzleWorkstation = ({ puzzleId }: { puzzleId: string }) => {
                     wiring/components.
                   </p>
                   {postCheck.open && postCheck.firstFailedTest && (
-                    <div className="mt-4 p-3 bg-secondary/50 rounded-lg border border-border space-y-2">
-                      <p className="text-[12px] font-semibold text-foreground uppercase tracking-wide">
+                    <div className="mt-4 space-y-2 rounded-lg border border-border bg-secondary/50 p-3">
+                      <p className="text-[12px] font-semibold uppercase tracking-wide text-foreground">
                         Failed on:
                       </p>
-                      <div className="text-[12px] space-y-2">
+                      <div className="space-y-2 text-[12px]">
                         <div>
-                          <p className="font-medium text-foreground mb-1">Inputs:</p>
-                          <div className="pl-3 space-y-0.5">
-                            {Object.entries(postCheck.firstFailedTest.inputs).map(
-                              ([key, val]) => (
-                                <p key={key} className="font-mono text-muted-foreground">
-                                  {key}: <span className="text-foreground">{val}</span>
-                                </p>
-                              ),
-                            )}
+                          <p className="mb-1 font-medium text-foreground">
+                            Inputs:
+                          </p>
+                          <div className="space-y-0.5 pl-3">
+                            {Object.entries(
+                              postCheck.firstFailedTest.inputs,
+                            ).map(([key, val]) => (
+                              <p
+                                key={key}
+                                className="font-mono text-muted-foreground"
+                              >
+                                {key}:{' '}
+                                <span className="text-foreground">{val}</span>
+                              </p>
+                            ))}
                           </div>
                         </div>
                         <div className="grid grid-cols-2 gap-2">
                           <div>
-                            <p className="font-medium text-foreground mb-1">
+                            <p className="mb-1 font-medium text-foreground">
                               Expected:
                             </p>
-                            <div className="pl-3 space-y-0.5">
+                            <div className="space-y-0.5 pl-3">
                               {Object.entries(
                                 postCheck.firstFailedTest.expected,
                               ).map(([key, val]) => (
-                                <p key={key} className="font-mono text-green-600">
+                                <p
+                                  key={key}
+                                  className="font-mono text-green-600"
+                                >
                                   {key}: {val}
                                 </p>
                               ))}
                             </div>
                           </div>
                           <div>
-                            <p className="font-medium text-foreground mb-1">Got:</p>
-                            <div className="pl-3 space-y-0.5">
+                            <p className="mb-1 font-medium text-foreground">
+                              Got:
+                            </p>
+                            <div className="space-y-0.5 pl-3">
                               {Object.entries(
                                 postCheck.firstFailedTest.actual,
                               ).map(([key, val]) => (

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-grid.tsx
@@ -6,6 +6,7 @@ import type {
   PointerEvent as ReactPointerEvent,
 } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 import { RippleEffect } from '@/components/ripple-effect';
 import { Button } from '@/components/ui/button';
 import { useNotifications } from '@/components/ui/notifications';
@@ -383,7 +384,9 @@ export const WorkstationGrid = ({
 
   useEffect(() => {
     try {
-      const raw = window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY);
+      const raw = window.localStorage.getItem(
+        WORKSTATION_CLIPBOARD_STORAGE_KEY,
+      );
       if (!raw) return;
 
       const parsed = JSON.parse(raw) as ClipboardPayload;
@@ -400,69 +403,73 @@ export const WorkstationGrid = ({
     }
   }, []);
 
-  const persistClipboardPayload = useCallback(async (payload: ClipboardPayload) => {
-    setClipboard(payload);
-
-    try {
-      window.localStorage.setItem(
-        WORKSTATION_CLIPBOARD_STORAGE_KEY,
-        JSON.stringify(payload),
-      );
-    } catch {
-      // ignore storage failures
-    }
-
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(JSON.stringify(payload));
-      }
-    } catch {
-      // ignore clipboard write failures
-    }
-  }, []);
-
-  const readClipboardPayload = useCallback(async (): Promise<ClipboardPayload | null> => {
-    const parsePayload = (raw: string | null): ClipboardPayload | null => {
-      if (!raw) return null;
+  const persistClipboardPayload = useCallback(
+    async (payload: ClipboardPayload) => {
+      setClipboard(payload);
 
       try {
-        const parsed = JSON.parse(raw) as ClipboardPayload;
-        if (
-          parsed &&
-          parsed.version === 1 &&
-          Array.isArray(parsed.components) &&
-          Array.isArray(parsed.wires)
-        ) {
-          return parsed;
+        window.localStorage.setItem(
+          WORKSTATION_CLIPBOARD_STORAGE_KEY,
+          JSON.stringify(payload),
+        );
+      } catch {
+        // ignore storage failures
+      }
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(JSON.stringify(payload));
         }
+      } catch {
+        // ignore clipboard write failures
+      }
+    },
+    [],
+  );
+
+  const readClipboardPayload =
+    useCallback(async (): Promise<ClipboardPayload | null> => {
+      const parsePayload = (raw: string | null): ClipboardPayload | null => {
+        if (!raw) return null;
+
+        try {
+          const parsed = JSON.parse(raw) as ClipboardPayload;
+          if (
+            parsed &&
+            parsed.version === 1 &&
+            Array.isArray(parsed.components) &&
+            Array.isArray(parsed.wires)
+          ) {
+            return parsed;
+          }
+        } catch {
+          return null;
+        }
+
+        return null;
+      };
+
+      try {
+        const systemText = navigator.clipboard
+          ? await navigator.clipboard.readText()
+          : '';
+        const fromSystem = parsePayload(systemText);
+        if (fromSystem) return fromSystem;
+      } catch {
+        // ignore clipboard read failures
+      }
+
+      const fromState = clipboard;
+      if (fromState) return fromState;
+
+      try {
+        return parsePayload(
+          window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY),
+        );
       } catch {
         return null;
       }
-
-      return null;
-    };
-
-    try {
-      const systemText = navigator.clipboard
-        ? await navigator.clipboard.readText()
-        : '';
-      const fromSystem = parsePayload(systemText);
-      if (fromSystem) return fromSystem;
-    } catch {
-      // ignore clipboard read failures
-    }
-
-    const fromState = clipboard;
-    if (fromState) return fromState;
-
-    try {
-      return parsePayload(
-        window.localStorage.getItem(WORKSTATION_CLIPBOARD_STORAGE_KEY),
-      );
-    } catch {
-      return null;
-    }
-  }, [clipboard]);
+    }, [clipboard]);
 
   const copySelectionToClipboard = useCallback(async () => {
     if (
@@ -491,7 +498,14 @@ export const WorkstationGrid = ({
     };
 
     await persistClipboardPayload(payload);
-  }, [catalog, persistClipboardPayload, placed, puzzleId, selectedEntity, wires]);
+  }, [
+    catalog,
+    persistClipboardPayload,
+    placed,
+    puzzleId,
+    selectedEntity,
+    wires,
+  ]);
 
   const pasteFromClipboard = useCallback(async () => {
     const payload = await readClipboardPayload();
@@ -2035,10 +2049,18 @@ export const WorkstationGrid = ({
                 </Button>
               ) : (
                 <>
-                  <Button size="sm" variant="outline" onClick={onDebuggerStepPrev}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onDebuggerStepPrev}
+                  >
                     ◄ Previous Step
                   </Button>
-                  <Button size="sm" variant="outline" onClick={onDebuggerStepNext}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onDebuggerStepNext}
+                  >
                     Next Step ►
                   </Button>
                   <Button
@@ -2048,7 +2070,11 @@ export const WorkstationGrid = ({
                   >
                     Full Debugger Report
                   </Button>
-                  <Button size="sm" variant="outline" onClick={onExitInlineDebugger}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onExitInlineDebugger}
+                  >
                     Exit Debugger
                   </Button>
                 </>
@@ -2294,7 +2320,7 @@ export const WorkstationGrid = ({
             <Button
               size="sm"
               variant="outline"
-              className="h-8 w-8 p-0"
+              className="size-8 p-0"
               onClick={(e) => {
                 e.stopPropagation();
                 setZoom((z) => Math.min(z * 1.15, 3));
@@ -2306,7 +2332,7 @@ export const WorkstationGrid = ({
             <Button
               size="sm"
               variant="outline"
-              className="h-8 w-8 p-0"
+              className="size-8 p-0"
               onClick={(e) => {
                 e.stopPropagation();
                 setZoom((z) => Math.max(z / 1.15, minZoom));
@@ -2857,7 +2883,7 @@ export const WorkstationGrid = ({
               >
                 {/* Selected Action Buttons: Delete (Outside) */}
                 {isSelected && !isDragging && (
-                  <div className="absolute -top-8 left-1/2 z-50 flex -translate-x-1/2 gap-1 items-center">
+                  <div className="absolute -top-8 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1">
                     {/* Delete Button */}
                     {(!p.isLocked || isEditMode) && (
                       <button
@@ -2894,7 +2920,7 @@ export const WorkstationGrid = ({
                       </button>
                     )}
                     {/* Component Name Label */}
-                    <span className="ml-1 text-xs font-medium text-foreground bg-card/90 px-2 py-1 rounded shadow-sm ring-1 ring-border whitespace-nowrap">
+                    <span className="ml-1 whitespace-nowrap rounded bg-card/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border">
                       {def.label}
                     </span>
                   </div>

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-menu.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-menu.tsx
@@ -614,46 +614,51 @@ export const WorkstationMenu = ({
           </DialogHeader>
           {viewingTruthTableData ? (
             <div className="space-y-3">
-              <p className="text-sm text-foreground leading-relaxed">
-                The truth table below demonstrates the gate's logic, showing the relationship between its inputs and resulting outputs.
+              <p className="text-sm leading-relaxed text-foreground">
+                The truth table below demonstrates the gate&apos;s logic,
+                showing the relationship between its inputs and resulting
+                outputs.
               </p>
               <div className="overflow-hidden rounded-lg border border-border/60">
-              <table className="w-full text-[13px] text-foreground">
-                <thead className="bg-secondary text-[11px] font-medium uppercase text-foreground">
-                  <tr>
-                    {viewingTruthTableData.inputs.map((i: string) => (
-                      <th key={i} className="px-3 py-2 text-center">
-                        {i}
-                      </th>
-                    ))}
-                    {viewingTruthTableData.outputs.map((o: string) => (
-                      <th
-                        key={o}
-                        className="border-l border-border px-3 py-2 text-center"
-                      >
-                        {o}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {viewingTruthTableData.rows.map(
-                    (row: string[], idx: number) => (
-                      <tr key={idx} className="divide-x divide-border bg-card">
-                        {row.map((cell: string, cIdx: number) => (
-                          <td
-                            key={cIdx}
-                            className="px-3 py-2 text-center text-foreground"
-                          >
-                            {cell}
-                          </td>
-                        ))}
-                      </tr>
-                    ),
-                  )}
-                </tbody>
-              </table>
-            </div>
+                <table className="w-full text-[13px] text-foreground">
+                  <thead className="bg-secondary text-[11px] font-medium uppercase text-foreground">
+                    <tr>
+                      {viewingTruthTableData.inputs.map((i: string) => (
+                        <th key={i} className="px-3 py-2 text-center">
+                          {i}
+                        </th>
+                      ))}
+                      {viewingTruthTableData.outputs.map((o: string) => (
+                        <th
+                          key={o}
+                          className="border-l border-border px-3 py-2 text-center"
+                        >
+                          {o}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {viewingTruthTableData.rows.map(
+                      (row: string[], idx: number) => (
+                        <tr
+                          key={idx}
+                          className="divide-x divide-border bg-card"
+                        >
+                          {row.map((cell: string, cIdx: number) => (
+                            <td
+                              key={cIdx}
+                              className="px-3 py-2 text-center text-foreground"
+                            >
+                              {cell}
+                            </td>
+                          ))}
+                        </tr>
+                      ),
+                    )}
+                  </tbody>
+                </table>
+              </div>
             </div>
           ) : (
             <div className="text-[13px] text-muted-foreground">

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-selection-context.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-selection-context.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, ReactNode } from 'react';
 
-export type SelectedEntity = 
+export type SelectedEntity =
   | { type: 'none' }
   | { type: 'component'; componentId: string }
   | { type: 'wire'; wireId: string };
@@ -12,13 +12,23 @@ interface WorkstationSelectionContextType {
   setSelectedEntity: (entity: SelectedEntity) => void;
 }
 
-const WorkstationSelectionContext = createContext<WorkstationSelectionContextType | undefined>(undefined);
+const WorkstationSelectionContext = createContext<
+  WorkstationSelectionContextType | undefined
+>(undefined);
 
-export const WorkstationSelectionProvider = ({ children }: { children: ReactNode }) => {
-  const [selectedEntity, setSelectedEntity] = useState<SelectedEntity>({ type: 'none' });
+export const WorkstationSelectionProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [selectedEntity, setSelectedEntity] = useState<SelectedEntity>({
+    type: 'none',
+  });
 
   return (
-    <WorkstationSelectionContext.Provider value={{ selectedEntity, setSelectedEntity }}>
+    <WorkstationSelectionContext.Provider
+      value={{ selectedEntity, setSelectedEntity }}
+    >
       {children}
     </WorkstationSelectionContext.Provider>
   );
@@ -27,7 +37,9 @@ export const WorkstationSelectionProvider = ({ children }: { children: ReactNode
 export const useWorkstationSelection = () => {
   const context = useContext(WorkstationSelectionContext);
   if (!context) {
-    throw new Error('useWorkstationSelection must be used within WorkstationSelectionProvider');
+    throw new Error(
+      'useWorkstationSelection must be used within WorkstationSelectionProvider',
+    );
   }
   return context;
 };

--- a/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-timer.tsx
+++ b/apps/nextjs-app/src/app/app/puzzles/[id]/_components/workstation-timer.tsx
@@ -2,11 +2,16 @@
 
 import { useMemo } from 'react';
 
-const formatTime = (seconds: number) => {
-  const abs = Math.abs(seconds);
-  const m = Math.floor(abs / 60);
-  const s = abs % 60;
-  return `${m}:${String(s).padStart(2, '0')}`;
+import {
+  timerVisualState,
+  type TimerState,
+} from '@/features/puzzles/lib/timer-display';
+
+const STATE_COLOR_CLASS: Record<TimerState, string> = {
+  'no-limit': 'bg-slate-50/50 text-slate-700 border-slate-200/60',
+  normal: 'bg-emerald-50/50 text-emerald-700 border-emerald-200/60',
+  warning: 'bg-amber-50/50 text-amber-700 border-amber-200/60',
+  expired: 'bg-red-50/50 text-red-700 border-red-200/60',
 };
 
 /**
@@ -33,30 +38,9 @@ export const WorkstationTimer = ({
   const hasLimit = typeof timeLimitSeconds === 'number' && timeLimitSeconds > 0;
 
   const { label, colorClass } = useMemo(() => {
-    if (!hasLimit) {
-      return {
-        label: formatTime(displayElapsed),
-        colorClass: 'bg-slate-50/50 text-slate-700 border-slate-200/60',
-      };
-    }
-
-    const remaining = (timeLimitSeconds as number) - displayElapsed;
-
-    if (remaining <= 0) {
-      return {
-        label: `+${formatTime(remaining)}`,
-        colorClass: 'bg-red-50/50 text-red-700 border-red-200/60',
-      };
-    }
-
-    const percentage = remaining / (timeLimitSeconds as number);
-    let color = 'bg-emerald-50/50 text-emerald-700 border-emerald-200/60';
-    if (percentage <= 0.1) {
-      color = 'bg-amber-50/50 text-amber-700 border-amber-200/60';
-    }
-
-    return { label: formatTime(remaining), colorClass: color };
-  }, [hasLimit, displayElapsed, timeLimitSeconds]);
+    const { state, label } = timerVisualState(displayElapsed, timeLimitSeconds);
+    return { label, colorClass: STATE_COLOR_CLASS[state] };
+  }, [displayElapsed, timeLimitSeconds]);
 
   return (
     <div

--- a/apps/nextjs-app/src/components/circuit-debugger.tsx
+++ b/apps/nextjs-app/src/components/circuit-debugger.tsx
@@ -412,26 +412,26 @@ export function CircuitDebugger({
                         placeholder="e.g., 01010 or 0,1,0,1,0"
                         className="w-full rounded-lg border border-border bg-card px-2.5 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                       />
-                      {parseSequenceBits(sequenceInputs[inputName] || '').length >
-                      0 ? (
+                      {parseSequenceBits(sequenceInputs[inputName] || '')
+                        .length > 0 ? (
                         <div
                           className="mt-1.5 flex flex-wrap items-center gap-1"
                           title={`Current step ${sequenceStepIndex + 1}`}
                         >
-                          {parseSequenceBits(sequenceInputs[inputName] || '').map(
-                            (bit, index) => (
-                              <span
-                                key={`${inputName}-bit-${index}`}
-                                className={`inline-flex h-5 w-5 items-center justify-center rounded border text-[11px] font-semibold ${
-                                  index === sequenceStepIndex
-                                    ? 'border-emerald-500 bg-emerald-500 text-white'
-                                    : 'border-border bg-card text-foreground'
-                                }`}
-                              >
-                                {bit}
-                              </span>
-                            ),
-                          )}
+                          {parseSequenceBits(
+                            sequenceInputs[inputName] || '',
+                          ).map((bit, index) => (
+                            <span
+                              key={`${inputName}-bit-${index}`}
+                              className={`inline-flex size-5 items-center justify-center rounded border text-[11px] font-semibold ${
+                                index === sequenceStepIndex
+                                  ? 'border-emerald-500 bg-emerald-500 text-white'
+                                  : 'border-border bg-card text-foreground'
+                              }`}
+                            >
+                              {bit}
+                            </span>
+                          ))}
                         </div>
                       ) : null}
                       <p className="mt-1 text-[11px] text-muted-foreground">

--- a/apps/nextjs-app/src/features/puzzles/components/puzzle-leaderboard.tsx
+++ b/apps/nextjs-app/src/features/puzzles/components/puzzle-leaderboard.tsx
@@ -7,6 +7,10 @@ import { InfoPopup } from '@/components/ui/info-popup';
 import { useLeaderboard } from '@/features/puzzles/api/get-leaderboard';
 import { useUser } from '@/lib/auth';
 
+import {
+  formatLeaderboardCost,
+  formatLeaderboardTime,
+} from '../lib/leaderboard-format';
 import { formatFirstSolved } from '../utils/format-first-solved';
 
 const MEDAL_LABELS: Record<number, string> = {
@@ -29,25 +33,15 @@ const RANK_STYLES: Record<number, string> = {
   3: 'bg-gradient-to-r from-amber-600 to-orange-400 text-amber-950 shadow-md shadow-orange-200/50',
 };
 
-const formatTime = (seconds: number) => {
-  if (seconds < 60) return `${seconds}s`;
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  if (m < 60) return `${m}m ${s}s`;
-  const h = Math.floor(m / 60);
-  const rm = m % 60;
-  return `${h}h ${rm}m ${s}s`;
-};
-
 const getMetricDisplay = (
   entry: any,
   type: 'time' | 'cost' | 'first_solved',
 ) => {
   if (type === 'time') {
-    return formatTime(entry.best_time);
+    return formatLeaderboardTime(entry.best_time);
   }
   if (type === 'cost') {
-    return `${entry.best_cost} cost`;
+    return formatLeaderboardCost(entry.best_cost);
   }
   return formatFirstSolved(entry.first_solved_at);
 };

--- a/apps/nextjs-app/src/features/puzzles/lib/__tests__/leaderboard-format.test.ts
+++ b/apps/nextjs-app/src/features/puzzles/lib/__tests__/leaderboard-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatLeaderboardCost,
+  formatLeaderboardTime,
+} from '../leaderboard-format';
+
+/**
+ * ADD pp.6,11 — per-puzzle leaderboard (PuzzleLeaderboard) displays solve time
+ * and cost in human-readable form. This pins that formatting.
+ */
+describe('formatLeaderboardTime', () => {
+  it('shows bare seconds under a minute', () => {
+    expect(formatLeaderboardTime(0)).toBe('0s');
+    expect(formatLeaderboardTime(45)).toBe('45s');
+  });
+
+  it('shows minutes and seconds under an hour', () => {
+    expect(formatLeaderboardTime(60)).toBe('1m 0s');
+    expect(formatLeaderboardTime(83)).toBe('1m 23s');
+  });
+
+  it('shows hours, minutes and seconds at or above an hour', () => {
+    expect(formatLeaderboardTime(3723)).toBe('1h 2m 3s');
+  });
+});
+
+describe('formatLeaderboardCost', () => {
+  it('suffixes the cost with " cost"', () => {
+    expect(formatLeaderboardCost(15)).toBe('15 cost');
+  });
+});

--- a/apps/nextjs-app/src/features/puzzles/lib/__tests__/timer-display.test.ts
+++ b/apps/nextjs-app/src/features/puzzles/lib/__tests__/timer-display.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCountdown, timerVisualState } from '../timer-display';
+
+/**
+ * ADD 7.4 — "Usability: Timer Visual Cues": the timer must transition
+ * green → amber at the final 10% → red at zero, then show a "+" stopwatch that
+ * counts up. This pins that pure logic.
+ */
+describe('timerVisualState', () => {
+  it('is "no-limit" (slate, counting up) when there is no time limit', () => {
+    expect(timerVisualState(42, null).state).toBe('no-limit');
+    expect(timerVisualState(42, 0).state).toBe('no-limit');
+    expect(timerVisualState(42, null).label).toBe('0:42');
+  });
+
+  it('is "normal" (green) while more than 10% of the limit remains', () => {
+    // 100s limit, 50s elapsed → 50% remaining
+    const r = timerVisualState(50, 100);
+    expect(r.state).toBe('normal');
+    expect(r.label).toBe('0:50');
+  });
+
+  it('is "warning" (amber) at exactly 10% remaining and below', () => {
+    // 100s limit, 90s elapsed → exactly 10% remaining
+    expect(timerVisualState(90, 100).state).toBe('warning');
+    // 100s limit, 95s elapsed → 5% remaining
+    expect(timerVisualState(95, 100).state).toBe('warning');
+  });
+
+  it('is "expired" (red) at zero and below, with a "+" stopwatch label', () => {
+    expect(timerVisualState(100, 100).state).toBe('expired');
+    const over = timerVisualState(125, 100); // 25s over
+    expect(over.state).toBe('expired');
+    expect(over.label).toBe('+0:25');
+  });
+});
+
+describe('formatCountdown', () => {
+  it('formats seconds as M:SS with zero-padding', () => {
+    expect(formatCountdown(5)).toBe('0:05');
+    expect(formatCountdown(65)).toBe('1:05');
+    expect(formatCountdown(600)).toBe('10:00');
+  });
+
+  it('uses the absolute value (sign is handled by the caller)', () => {
+    expect(formatCountdown(-25)).toBe('0:25');
+  });
+});

--- a/apps/nextjs-app/src/features/puzzles/lib/leaderboard-format.ts
+++ b/apps/nextjs-app/src/features/puzzles/lib/leaderboard-format.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure formatting helpers for the per-puzzle leaderboard (UC1/UC2 — ADD pp.6,11).
+ *
+ * Extracted from `puzzle-leaderboard.tsx` so the human-readable time/cost
+ * formatting can be unit tested without rendering the component.
+ */
+
+/** Format a solve time (seconds) as a compact human string: `45s`, `1m 23s`, `1h 2m 3s`. */
+export const formatLeaderboardTime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m < 60) return `${m}m ${s}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${rm}m ${s}s`;
+};
+
+/** Format a solve cost for the leaderboard. */
+export const formatLeaderboardCost = (cost: number): string => `${cost} cost`;

--- a/apps/nextjs-app/src/features/puzzles/lib/timer-display.ts
+++ b/apps/nextjs-app/src/features/puzzles/lib/timer-display.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for the WorkStation countdown timer's visual state.
+ *
+ * Extracted from `workstation-timer.tsx` so the "timer visual cues" behaviour
+ * promised in the ADD (Chapter 7.4 — Usability: Timer Visual Cues) can be unit
+ * tested in isolation, with no React rendering:
+ *
+ *   • green (normal)  while remaining time is > 10% of the limit
+ *   • amber (warning) once remaining time is <= 10% of the limit
+ *   • red (expired)   at zero and below — label flips to a "+" stopwatch that
+ *     counts up
+ *   • slate (no-limit) when the puzzle has no time limit (elapsed counts up)
+ */
+export type TimerState = 'no-limit' | 'normal' | 'warning' | 'expired';
+
+/** Format a (possibly negative) second count as `M:SS` (sign handled by caller). */
+export const formatCountdown = (seconds: number): string => {
+  const abs = Math.abs(seconds);
+  const m = Math.floor(abs / 60);
+  const s = abs % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
+/**
+ * Compute the timer's visual state + display label from the already-adjusted
+ * elapsed time (i.e. elapsed + any clue penalty) and the puzzle time limit.
+ */
+export const timerVisualState = (
+  displayElapsedSeconds: number,
+  timeLimitSeconds: number | null | undefined,
+): { state: TimerState; label: string; remaining: number | null } => {
+  const hasLimit = typeof timeLimitSeconds === 'number' && timeLimitSeconds > 0;
+
+  if (!hasLimit) {
+    return {
+      state: 'no-limit',
+      label: formatCountdown(displayElapsedSeconds),
+      remaining: null,
+    };
+  }
+
+  const limit = timeLimitSeconds as number;
+  const remaining = limit - displayElapsedSeconds;
+
+  if (remaining <= 0) {
+    return {
+      state: 'expired',
+      label: `+${formatCountdown(remaining)}`,
+      remaining,
+    };
+  }
+
+  const percentage = remaining / limit;
+  const state: TimerState = percentage <= 0.1 ? 'warning' : 'normal';
+  return { state, label: formatCountdown(remaining), remaining };
+};

--- a/apps/nextjs-app/vitest.config.ts
+++ b/apps/nextjs-app/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for the frontend unit tests.
+ *
+ * Resolves the `@/*` path alias (mirrors tsconfig.json) so tests can import
+ * application modules the same way the app does, and uses the jsdom
+ * environment so component/DOM tests can be added later.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+});

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,16 @@
+@echo off
+REM ============================================================================
+REM run_tests.bat - Windows launcher for the EscapeCircuit test suite.
+REM Forwards to run_tests.ps1 (bypassing the PowerShell execution policy so it
+REM works on any Windows PC without changing system settings).
+REM
+REM   run_tests.bat            run everything
+REM   run_tests.bat backend    backend only
+REM   run_tests.bat frontend   frontend only
+REM ============================================================================
+setlocal
+set "MODE=%~1"
+if "%MODE%"=="" set "MODE=all"
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0run_tests.ps1" %MODE%
+exit /b %ERRORLEVEL%

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,210 @@
+<#
+================================================================================
+ run_tests.ps1 — run the full EscapeCircuit test suite (backend + frontend)
+ with coverage, stream the console output, and print a designed summary.
+ Windows companion to run_tests.sh.
+
+   .\run_tests.ps1            run everything
+   .\run_tests.ps1 backend    backend (pytest + coverage) only
+   .\run_tests.ps1 frontend   frontend (vitest + types + lint) only
+
+ Exit code is non-zero if any step fails.
+================================================================================
+#>
+param(
+  [ValidateSet('all', 'backend', 'frontend')]
+  [string]$Mode = 'all'
+)
+
+$ErrorActionPreference = 'Continue'
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Pick a Python launcher that exists on this machine.
+$Py = 'python'
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+  if (Get-Command py -ErrorAction SilentlyContinue) { $Py = 'py' }
+}
+
+function Banner($title) {
+  Write-Host ''
+  Write-Host ('+' + ('-' * 68) + '+') -ForegroundColor Cyan
+  Write-Host ('| ' + $title.PadRight(66) + '|') -ForegroundColor Cyan
+  Write-Host ('+' + ('-' * 68) + '+') -ForegroundColor Cyan
+}
+
+function Human($sec) {
+  if ($sec -ge 60) { '{0}m {1:d2}s' -f [int]($sec / 60), ($sec % 60) } else { "${sec}s" }
+}
+
+# ---- result holders ----------------------------------------------------------
+$res = [ordered]@{
+  BackendRun = $false; BackendOk = $false; BackendPass = '-'; BackendFail = '0'; BackendCov = 'n/a'; BackendTime = 0
+  FrontendRun = $false; FrontendOk = $false; FrontendPass = '-'; FrontendCov = 'n/a'; FrontendTime = 0
+  TypeRun = $false; TypeOk = $false
+  LintRun = $false; LintOk = $false
+}
+
+function Invoke-Step {
+  # Runs a script block in a directory, streams + captures output, returns @{ Ok; Text; Seconds }
+  param([string]$Dir, [scriptblock]$Cmd)
+  $start = Get-Date
+  Push-Location $Dir
+  $captured = $null
+  try {
+    # Tee-Object -Variable captures every line into $captured while Out-Host
+    # still streams it live to the console (assigning to a var would swallow it).
+    & $Cmd 2>&1 | Tee-Object -Variable captured | Out-Host
+    $ok = ($LASTEXITCODE -eq 0)
+  } finally { Pop-Location }
+  $secs = [int]((Get-Date) - $start).TotalSeconds
+  $text = if ($captured) { ($captured | ForEach-Object { "$_" }) -join "`n" } else { '' }
+  return @{ Ok = $ok; Text = $text; Seconds = $secs }
+}
+
+function Match1($text, $pattern) {
+  $m = [regex]::Match($text, $pattern)
+  if ($m.Success) { return $m.Groups[1].Value } else { return $null }
+}
+
+function Draw-Bar($pct, $done, $name) {
+  if ($pct -gt 100) { $pct = 100 }
+  if ($pct -lt 0) { $pct = 0 }
+  $width = 28
+  $filled = [int]($pct * $width / 100)
+  $bar = ('#' * $filled) + ('.' * ($width - $filled))
+  if (-not $name) { $name = '' }
+  $short = if ($name.Length -gt 38) { $name.Substring(0, 38) } else { $name.PadRight(38) }
+  Write-Host ("`r  running [{0}] {1,3}%  {2,4}  {3}" -f $bar, $pct, $done, $short) -NoNewline -ForegroundColor Cyan
+}
+
+function Invoke-PytestWithBar($Dir, $PyExe, $PyArgs, $Log) {
+  # Runs pytest into a log file and shows a live progress bar (no per-test spam).
+  $start = Get-Date
+  $errLog = "$Log.err"
+  $proc = Start-Process -FilePath $PyExe -ArgumentList $PyArgs -WorkingDirectory $Dir `
+    -RedirectStandardOutput $Log -RedirectStandardError $errLog -NoNewWindow -PassThru
+  $done = 0
+  while (-not $proc.HasExited) {
+    Start-Sleep -Milliseconds 250
+    $txt = Get-Content $Log -Raw -ErrorAction SilentlyContinue
+    if ($txt) {
+      $pcts = [regex]::Matches($txt, '\[\s*(\d+)%\]')
+      $pct = if ($pcts.Count) { [int]$pcts[$pcts.Count - 1].Groups[1].Value } else { 0 }
+      $done = ([regex]::Matches($txt, '(?m)\[\s*\d+%\]\s*$')).Count
+      $names = [regex]::Matches($txt, '::([\w\[\]\.\-]+)\s+(PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)')
+      $name = if ($names.Count) { $names[$names.Count - 1].Groups[1].Value } else { 'collecting...' }
+      Draw-Bar $pct $done $name
+    }
+  }
+  Draw-Bar 100 $done 'done'
+  Write-Host ''
+  # Fold stderr into the log so parsing + the readable dump see everything.
+  if (Test-Path $errLog) { Get-Content $errLog -ErrorAction SilentlyContinue | Add-Content $Log }
+  $secs = [int]((Get-Date) - $start).TotalSeconds
+  return @{ Ok = ($proc.ExitCode -eq 0); Seconds = $secs }
+}
+
+# ------------------------------------------------------------------ backend ---
+function Run-Backend {
+  $res.BackendRun = $true
+  Banner 'BACKEND  -  pytest + coverage'
+  $log = Join-Path ([System.IO.Path]::GetTempPath()) ("ec_backend_{0}.log" -f $PID)
+  $r = Invoke-PytestWithBar (Join-Path $Root 'src') $Py @('-m', 'pytest', '--cov=Backend', '--cov-report=term-missing') $log
+  $res.BackendOk = $r.Ok
+  $res.BackendTime = $r.Seconds
+  $text = Get-Content $log -Raw -ErrorAction SilentlyContinue
+  if (-not $text) { $text = '' }
+  # Print the parts worth reading (coverage table, warnings, summary, any
+  # failures) — the per-test lines are already represented by the bar.
+  ($text -split "`r?`n") |
+    Where-Object { $_ -notmatch '::.*(PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)\s*\[\s*\d+%\]\s*$' } |
+    ForEach-Object { Write-Host $_ }
+  $summaryLine = ($text -split "`r?`n" | Where-Object { $_ -match 'passed|failed|error' } | Select-Object -Last 1)
+  $p = Match1 $summaryLine '(\d+) passed'; if ($p) { $res.BackendPass = $p } else { $res.BackendPass = '0' }
+  $f = Match1 $summaryLine '(\d+) failed'; if ($f) { $res.BackendFail = $f } else { $res.BackendFail = '0' }
+  $totalLine = ($text -split "`r?`n" | Where-Object { $_ -match '^TOTAL' } | Select-Object -Last 1)
+  $c = Match1 $totalLine '(\d+%)'; if ($c) { $res.BackendCov = $c }
+  Remove-Item $log, "$log.err" -ErrorAction SilentlyContinue
+}
+
+# ----------------------------------------------------------------- frontend ---
+function Run-Frontend {
+  $app = Join-Path $Root 'apps/nextjs-app'
+
+  Banner 'FRONTEND  -  vitest'
+  $res.FrontendRun = $true
+  $hasCov = Test-Path (Join-Path $app 'node_modules/@vitest/coverage-v8')
+  if ($hasCov) {
+    $r = Invoke-Step $app { yarn test --coverage }
+  } else {
+    Write-Host '(coverage provider @vitest/coverage-v8 not installed - running without coverage)' -ForegroundColor DarkGray
+    $r = Invoke-Step $app { yarn test }
+  }
+  $res.FrontendOk = $r.Ok
+  $res.FrontendTime = $r.Seconds
+  # Match the vitest "Tests  N passed" line specifically (case-sensitive, and
+  # requiring "passed" so the trailing "Duration ... tests 11ms" line is ignored).
+  $p = Match1 $r.Text '(?m)Tests\s+(\d+) passed'; if ($p) { $res.FrontendPass = $p } else { $res.FrontendPass = '0' }
+  $allLine = ($r.Text -split "`n" | Where-Object { $_ -match '^All files' } | Select-Object -Last 1)
+  if ($allLine) { $cov = ($allLine -split '\|')[1].Trim(); if ($cov) { $res.FrontendCov = "$cov%" } }
+
+  Banner 'FRONTEND  -  type-check'
+  $res.TypeRun = $true
+  $res.TypeOk = (Invoke-Step $app { yarn check-types }).Ok
+
+  Banner 'FRONTEND  -  lint'
+  $res.LintRun = $true
+  $res.LintOk = (Invoke-Step $app { yarn lint }).Ok
+}
+
+switch ($Mode) {
+  'backend'  { Run-Backend }
+  'frontend' { Run-Frontend }
+  'all'      { Run-Backend; Run-Frontend }
+}
+
+# -------------------------------------------------------------------- summary --
+function Row($label, $state, $detail) {
+  # $state: $true / $false / $null (skip)
+  Write-Host ('  | ' + $label.PadRight(26)) -NoNewline -ForegroundColor Blue
+  if ($null -eq $state)   { Write-Host ' --   ' -NoNewline -ForegroundColor DarkGray }
+  elseif ($state)         { Write-Host ' [PASS]' -NoNewline -ForegroundColor Green }
+  else                    { Write-Host ' [FAIL]' -NoNewline -ForegroundColor Red }
+  Write-Host ('   ' + $detail) -ForegroundColor DarkGray
+}
+
+Write-Host ''
+Write-Host ('=============================== SUMMARY ' + ('=' * 31)) -ForegroundColor Blue
+
+if ($res.BackendRun) {
+  Row 'Backend  (pytest)' $res.BackendOk ("{0} passed - {1} failed - cov {2} - {3}" -f $res.BackendPass, $res.BackendFail, $res.BackendCov, (Human $res.BackendTime))
+}
+if ($res.FrontendRun) {
+  Row 'Frontend (vitest)'   $res.FrontendOk ("{0} passed - {1}" -f $res.FrontendPass, (Human $res.FrontendTime))
+  Row 'Frontend type-check' $res.TypeOk ''
+  Row 'Frontend lint'       $res.LintOk ''
+}
+
+$overallFail = $false
+foreach ($pair in @(@($res.BackendRun, $res.BackendOk), @($res.FrontendRun, $res.FrontendOk), @($res.TypeRun, $res.TypeOk), @($res.LintRun, $res.LintOk))) {
+  if ($pair[0] -and -not $pair[1]) { $overallFail = $true }
+}
+
+Write-Host ('-' * 70) -ForegroundColor Blue
+if (-not $overallFail) {
+  $parts = @()
+  if ($res.BackendRun)  { $parts += "backend ($($res.BackendPass))" }
+  if ($res.FrontendRun) { $parts += "frontend ($($res.FrontendPass))"; $parts += 'types'; $parts += 'lint' }
+  if ($res.BackendRun -and $res.BackendCov -ne 'n/a') { $parts += "cov $($res.BackendCov)" }
+  Write-Host '   ALL GREEN' -ForegroundColor Green -NoNewline
+  Write-Host (' — ' + ($parts -join ' · '))
+  Write-Host ''
+  exit 0
+} else {
+  Write-Host '   SOME CHECKS FAILED' -ForegroundColor Red -NoNewline
+  Write-Host ' - see the console output above.'
+  Write-Host ''
+  exit 1
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# run_tests.sh — run the full EscapeCircuit test suite (backend + frontend)
+# with coverage, stream the console output, and print a designed summary.
+#
+#   ./run_tests.sh            run everything
+#   ./run_tests.sh backend    backend (pytest + coverage) only
+#   ./run_tests.sh frontend   frontend (vitest + types + lint) only
+#
+# Exit code is non-zero if any step fails.
+# ==============================================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGDIR="$(mktemp -d)"
+trap 'rm -rf "$LOGDIR"' EXIT
+
+# ---- colours (only when attached to a terminal) -----------------------------
+if [ -t 1 ]; then
+  B=$'\033[1m'; DIM=$'\033[2m'; R=$'\033[0m'
+  GRN=$'\033[32m'; RED=$'\033[31m'; YEL=$'\033[33m'; CYN=$'\033[36m'; BLU=$'\033[34m'
+else
+  B=""; DIM=""; R=""; GRN=""; RED=""; YEL=""; CYN=""; BLU=""
+fi
+CHECK="✔"; CROSS="✘"; DOTS="…"
+
+banner() {  # $1 = title
+  printf '\n%s╭──────────────────────────────────────────────────────────────────╮%s\n' "$CYN" "$R"
+  printf '%s│%s %s%-64s%s %s│%s\n' "$CYN" "$R" "$B" "$1" "$R" "$CYN" "$R"
+  printf '%s╰──────────────────────────────────────────────────────────────────╯%s\n' "$CYN" "$R"
+}
+
+human() {  # $1 = seconds -> "1m 03s" / "42s"
+  local s=$1
+  if [ "$s" -ge 60 ]; then printf '%dm %02ds' $((s/60)) $((s%60)); else printf '%ds' "$s"; fi
+}
+
+# draw a single carriage-return-updated progress bar
+draw_bar() {  # $1 pct  $2 done  $3 name
+  local pct=$1 done=$2 name=$3 width=28 i filled bar=""
+  [ "$pct" -gt 100 ] && pct=100
+  filled=$((pct*width/100))
+  i=0
+  while [ "$i" -lt "$width" ]; do
+    if [ "$i" -lt "$filled" ]; then bar="${bar}█"; else bar="${bar}·"; fi
+    i=$((i+1))
+  done
+  printf '\r  %srunning%s [%s%s%s] %3d%%  %s%4d%s  %s%-38.38s%s' \
+    "$CYN" "$R" "$GRN" "$bar" "$R" "$pct" "$DIM" "$done" "$R" "$DIM" "$name" "$R"
+}
+
+# poll a growing pytest log and render the progress bar until $pid exits
+progress_for() {  # $1 logfile  $2 pid
+  local log="$1" pid="$2" pct done name
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ -s "$log" ]; then
+      pct=$(grep -oE '\[ *[0-9]+%\]' "$log" 2>/dev/null | tail -1 | grep -oE '[0-9]+')
+      done=$(grep -cE '\[ *[0-9]+%\]$' "$log" 2>/dev/null)
+      name=$(grep -E '::.* (PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS)' "$log" 2>/dev/null | tail -1 \
+             | sed -E 's/ (PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS).*//; s#^.*::##')
+      draw_bar "${pct:-0}" "${done:-0}" "${name:-collecting…}"
+    fi
+    sleep 0.2
+  done
+  done=$(grep -cE '\[ *[0-9]+%\]$' "$log" 2>/dev/null)
+  draw_bar 100 "${done:-0}" "done"
+  printf '\n'
+}
+
+MODE="${1:-all}"
+
+# results (filled in by the run_* functions)
+BE_RUN=0; BE_OK=0; BE_PASS="-"; BE_FAIL="0"; BE_COV="n/a"; BE_TIME=0
+FE_RUN=0; FE_OK=0; FE_PASS="-"; FE_COV="n/a"; FE_TIME=0
+TYPE_RUN=0; TYPE_OK=0
+LINT_RUN=0; LINT_OK=0
+
+# ------------------------------------------------------------------ backend ---
+run_backend() {
+  BE_RUN=1
+  banner "BACKEND  ·  pytest + coverage"
+  local log="$LOGDIR/backend.log" start end rc
+  start=$(date +%s)
+  if [ -t 1 ]; then
+    # Run pytest into a log and show a live progress bar (no per-test spam).
+    ( cd "$ROOT/src" && python -m pytest --cov=Backend --cov-report=term-missing ) > "$log" 2>&1 &
+    local pid=$!
+    progress_for "$log" "$pid"
+    wait "$pid"; rc=$?
+    # Print the parts worth reading (coverage table, warnings, summary, any
+    # failures) — the per-test lines are already represented by the bar.
+    grep -vE '::.* (PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS) *\[ *[0-9]+%\]$' "$log"
+  else
+    # Not a terminal (CI / piped) — stream plainly.
+    ( cd "$ROOT/src" && python -m pytest --cov=Backend --cov-report=term-missing ) 2>&1 | tee "$log"
+    rc=${PIPESTATUS[0]}
+  fi
+  end=$(date +%s); BE_TIME=$((end-start))
+  [ "$rc" -eq 0 ] && BE_OK=1
+
+  # parse "=== N passed[, M failed] in ... ===" and the coverage TOTAL line
+  local summary; summary=$(grep -E "passed|failed|error" "$log" | tail -1)
+  BE_PASS=$(printf '%s' "$summary" | grep -oE '[0-9]+ passed'  | grep -oE '[0-9]+' || echo 0)
+  BE_FAIL=$(printf '%s' "$summary" | grep -oE '[0-9]+ failed'  | grep -oE '[0-9]+' || echo 0)
+  BE_COV=$(grep -E '^TOTAL' "$log" | tail -1 | grep -oE '[0-9]+%' | tail -1 || echo "n/a")
+  [ -z "$BE_COV" ] && BE_COV="n/a"
+}
+
+# ----------------------------------------------------------------- frontend ---
+run_frontend() {
+  banner "FRONTEND  ·  vitest"
+  local log="$LOGDIR/frontend.log" start end
+  FE_RUN=1
+  start=$(date +%s)
+  if [ -d "$ROOT/apps/nextjs-app/node_modules/@vitest/coverage-v8" ]; then
+    ( cd "$ROOT/apps/nextjs-app" && yarn test --coverage ) 2>&1 | tee "$log"
+  else
+    printf '%s(coverage provider @vitest/coverage-v8 not installed — running without coverage)%s\n' "$DIM" "$R"
+    ( cd "$ROOT/apps/nextjs-app" && yarn test ) 2>&1 | tee "$log"
+  fi
+  local rc=${PIPESTATUS[0]}
+  end=$(date +%s); FE_TIME=$((end-start))
+  [ "$rc" -eq 0 ] && FE_OK=1
+  FE_PASS=$(grep -E '^\s*Tests' "$log" | tail -1 | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo 0)
+  local cov; cov=$(grep -E '^All files' "$log" | tail -1 | awk '{print $4}')
+  [ -n "${cov:-}" ] && FE_COV="${cov}%"
+
+  banner "FRONTEND  ·  type-check"
+  TYPE_RUN=1
+  ( cd "$ROOT/apps/nextjs-app" && yarn check-types ) 2>&1 | tee "$LOGDIR/types.log"
+  [ "${PIPESTATUS[0]}" -eq 0 ] && TYPE_OK=1
+
+  banner "FRONTEND  ·  lint"
+  LINT_RUN=1
+  ( cd "$ROOT/apps/nextjs-app" && yarn lint ) 2>&1 | tee "$LOGDIR/lint.log"
+  [ "${PIPESTATUS[0]}" -eq 0 ] && LINT_OK=1
+}
+
+case "$MODE" in
+  backend)  run_backend ;;
+  frontend) run_frontend ;;
+  all)      run_backend; run_frontend ;;
+  *) echo "usage: $0 [all|backend|frontend]"; exit 2 ;;
+esac
+
+# -------------------------------------------------------------------- summary --
+row() {  # $1 label  $2 ok(0/1, or - to skip status)  $3 detail
+  local status
+  if   [ "$2" = "-" ]; then status="${DIM}—${R}     "
+  elif [ "$2" = "1" ]; then status="${GRN}${CHECK} PASS${R}"
+  else                       status="${RED}${CROSS} FAIL${R}"; fi
+  printf '  %s│%s %-26s %b   %s%s%s\n' "$BLU" "$R" "$1" "$status" "$DIM" "$3" "$R"
+}
+
+printf '\n%s' "$BLU"
+printf '═══════════════════════════════ SUMMARY ═══════════════════════════════%s\n' "$R"
+
+if [ "$BE_RUN" = 1 ]; then
+  row "Backend  (pytest)"   "$BE_OK"  "$BE_PASS passed · $BE_FAIL failed · cov $BE_COV · $(human "$BE_TIME")"
+fi
+if [ "$FE_RUN" = 1 ]; then
+  row "Frontend (vitest)"   "$FE_OK"  "$FE_PASS passed · $(human "$FE_TIME")"
+  row "Frontend type-check" "$TYPE_OK" ""
+  row "Frontend lint"       "$LINT_OK" ""
+fi
+
+# overall
+OVERALL=0
+for v in "$BE_RUN:$BE_OK" "$FE_RUN:$FE_OK" "$TYPE_RUN:$TYPE_OK" "$LINT_RUN:$LINT_OK"; do
+  run="${v%%:*}"; ok="${v##*:}"
+  if [ "$run" = 1 ] && [ "$ok" != 1 ]; then OVERALL=1; fi
+done
+
+printf '%s────────────────────────────────────────────────────────────────────%s\n' "$BLU" "$R"
+if [ "$OVERALL" = 0 ]; then
+  parts=()
+  [ "$BE_RUN" = 1 ] && parts+=("backend ($BE_PASS)")
+  [ "$FE_RUN" = 1 ] && parts+=("frontend ($FE_PASS)" "types" "lint")
+  [ "$BE_RUN" = 1 ] && [ "$BE_COV" != "n/a" ] && parts+=("cov $BE_COV")
+  joined=""
+  for p in "${parts[@]}"; do
+    if [ -z "$joined" ]; then joined="$p"; else joined="$joined · $p"; fi
+  done
+  printf '  %s%s ALL GREEN%s — %s\n\n' "$B" "$GRN" "$R" "$joined"
+else
+  printf '  %s%s SOME CHECKS FAILED%s — see the console output above.\n\n' "$B" "$RED" "$R"
+fi
+exit "$OVERALL"

--- a/src/tests/AcceptanceTests/conftest.py
+++ b/src/tests/AcceptanceTests/conftest.py
@@ -1,0 +1,35 @@
+"""
+Shared fixtures for the Acceptance-Test suite.
+
+This suite maps one-to-one onto the Use-Case "Acceptance Tests" tables in the
+Application Design Document (ADD), Chapter 1.2.  Each test exercises a complete
+user-facing flow through the real FastAPI stack
+(request -> controller -> service -> repo -> in-memory SQLite).
+
+Rather than duplicate the wiring, we re-use the fully-wired application and the
+high-level workflow helpers already defined for the system-test suite.  Importing
+the fixtures into this conftest re-registers them for every test collected under
+``src/tests/AcceptanceTests/``.
+"""
+# Fixtures (re-registered for this package by being present in the namespace)
+from tests.SystemTests.conftest import (  # noqa: F401
+    conn,
+    app,
+    client,
+)
+
+# Workflow + auth helpers used by the acceptance tests
+from tests.SystemTests.conftest import (  # noqa: F401
+    register_user,
+    register_and_login,
+    auth_header,
+    make_creator,
+    make_admin,
+    get_user_xp,
+    get_user_info,
+    create_puzzle,
+    add_blackbox_test_case,
+    validate_solution,
+    create_and_publish_puzzle,
+    _and_solution,
+)

--- a/src/tests/AcceptanceTests/test_acceptance_use_cases.py
+++ b/src/tests/AcceptanceTests/test_acceptance_use_cases.py
@@ -1,0 +1,941 @@
+"""
+================================================================================
+ACCEPTANCE TESTS  —  Application Design Document (ADD) Chapter 1.2
+================================================================================
+
+Each class below corresponds to ONE Use Case from the ADD ("1.2 Use-Cases -
+Acceptance Tests").  Each test method corresponds to ONE row of that Use Case's
+"Acceptance Tests" table, and the method name + docstring carry the exact
+"Test Name" used in the ADD so a human can line the two up side-by-side.
+
+Naming convention:   test_uc<N>_<add_test_name_in_snake_case>
+Docstring format:    "UC<N> · <Test Name> (ADD p.<page>) — <expected result>"
+
+These run against the real wired FastAPI app on an in-memory SQLite database
+(see conftest.py).  They are the automated half of the ADD's "Acceptance
+Testing" strategy (Chapter 7.1, item 4).
+
+Use-Case index (ADD pp.6-43):
+    UC1  Browse and Search Puzzles            UC8  Puzzle Solution Validation
+    UC2  Solve a Puzzle                        UC9  Appoint User as Creator
+    UC3  Save and Reuse Circuits               UC10 View Personal Profile & Progress
+    UC4  Create and Publish Puzzle             UC11 Experiment in Sandbox
+    UC5  Rate a Puzzle                         UC12 Manage Personal Arsenal
+    UC6  Earn Rewards and Level Up             UC13 Participate in Discussions
+    UC7  Manage Puzzles (Creators Only)        UC14 Manage Notifications
+================================================================================
+"""
+import json
+
+from .conftest import (
+    auth_header,
+    register_and_login,
+    make_creator,
+    make_admin,
+    get_user_info,
+    get_user_xp,
+    create_puzzle,
+    add_blackbox_test_case,
+    validate_solution,
+    create_and_publish_puzzle,
+    _and_solution,
+)
+
+
+# ── Local payload helpers ────────────────────────────────────────────────────
+
+def _arsenal_payload(name: str, basic_gates: str = '["AND"]') -> dict:
+    """A minimal, legal arsenal piece (uses only default I/O)."""
+    return {
+        "name": name,
+        "num_inputs": 1,
+        "num_outputs": 1,
+        "structure_json": json.dumps({"placedComponents": [], "wires": []}),
+        "basic_gates": basic_gates,
+        "truth_table": {"0": "0", "1": "1"},
+    }
+
+
+def _and_solution_with_extra_gate() -> dict:
+    """A correct AND solution that uses an extra (NOT) gate — used to trip the
+    gate-count / value limit."""
+    return {
+        "placedComponents": [
+            {"id": "and1", "componentId": "AND"},
+            {"id": "not1", "componentId": "NOT"},
+        ],
+        "wires": [
+            {"from": {"componentId": "IO:IN:A", "pinIndex": 0}, "to": {"componentId": "and1", "pinIndex": 0}},
+            {"from": {"componentId": "IO:IN:B", "pinIndex": 0}, "to": {"componentId": "and1", "pinIndex": 1}},
+            {"from": {"componentId": "and1", "pinIndex": 2}, "to": {"componentId": "IO:OUT:out", "pinIndex": 0}},
+        ],
+        "totalCost": 2,
+    }
+
+
+def _create_discussion(client, token, title="Discussion", body="body", category="general"):
+    resp = client.post(
+        "/discussions",
+        json={"title": title, "body": body, "category": category},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _create_reply(client, token, discussion_id, body="reply", parent_reply_id=None):
+    payload = {"body": body}
+    if parent_reply_id is not None:
+        payload["parent_reply_id"] = parent_reply_id
+    return client.post(
+        f"/discussions/{discussion_id}/replies",
+        json=payload,
+        headers=auth_header(token),
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC1 — Browse and Search Puzzles                                      ADD p.6-7
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc1_successful_search : Logged-in user searches with filters and gets back the matching puzzles.
+#   test_uc1_unsuccessful_search_no_matches : A search that matches nothing returns an empty list.
+#   test_uc1_unsuccessful_unauthorized_access : Searching without logging in is blocked (401).
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC1BrowseAndSearchPuzzles:
+
+    def test_uc1_successful_search(self, client, conn):
+        """UC1 · Successful Search (ADD p.7) — logged-in user searching with
+        filters gets the matching published puzzles back."""
+        creator_token = make_creator(client, conn, "acc_uc1_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token,
+            name="ACC UC1 Search Target", budget=5, time_limit=60, difficulty="HARD",
+        )
+
+        solver_token = register_and_login(client, "acc_uc1_solver")
+        resp = client.get(
+            "/puzzles",
+            params={"search": "Search Target"},
+            headers=auth_header(solver_token),
+        )
+        assert resp.status_code == 200
+        assert pid in [int(p["id"]) for p in resp.json()["data"]]
+
+    def test_uc1_unsuccessful_search_no_matches(self, client):
+        """UC1 · Unsuccessful Search: No Matches (ADD p.7) — empty list when no
+        puzzle matches the filters."""
+        solver_token = register_and_login(client, "acc_uc1_nomatch")
+        resp = client.get(
+            "/puzzles",
+            params={"search": "definitely-no-such-puzzle"},
+            headers=auth_header(solver_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []
+
+    def test_uc1_unsuccessful_unauthorized_access(self, client):
+        """UC1 · Unsuccessful unauthorized Access (ADD p.7) — anonymous request
+        is rejected (appropriate message / 401)."""
+        resp = client.get("/puzzles", params={"search": "anything"})
+        assert resp.status_code == 401
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC2 — Solve a Puzzle                                                ADD p.8-12
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc2_successful_solve_within_limits : Correct circuit, in time and budget -> solved, with XP and a medal.
+#   test_uc2_unsuccessful_wrong_solution : A wrong circuit is not accepted and earns no XP.
+#   test_uc2_unsuccessful_exceeded_the_value_limit : A circuit that uses too many gates is rejected.
+#   test_uc2_unsuccessful_time_expired : Correct but late -> still solved, but only a bronze medal.
+#   test_uc2_successful_leaderboard_ranking : Solvers are listed on the puzzle leaderboard, fastest first.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC2SolveAPuzzle:
+
+    def test_uc2_successful_solve_within_limits(self, client, conn):
+        """UC2 · Successful solve within limits (ADD p.10) — valid solution
+        within limits & time remaining → solved, XP & Timer Medal."""
+        creator_token = make_creator(client, conn, "acc_uc2_ok_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC2 Solve OK", budget=5, time_limit=60
+        )
+        solver_token = register_and_login(client, "acc_uc2_ok_solver")
+        result = validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)
+        assert result["solved"] is True
+        assert result["xp_earned"] > 0
+        assert result["medal"] == "SILVER"
+
+    def test_uc2_unsuccessful_wrong_solution(self, client, conn):
+        """UC2 · Unsuccessful wrong solution (ADD p.10) — incorrect circuit →
+        Not Solved, no XP."""
+        creator_token = make_creator(client, conn, "acc_uc2_wrong_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC2 Wrong", budget=5, time_limit=60
+        )
+        solver_token = register_and_login(client, "acc_uc2_wrong_solver")
+        result = validate_solution(
+            client, solver_token, pid,
+            {"placedComponents": [], "wires": [], "totalCost": 0}, time_taken=10,
+        )
+        assert result["solved"] is False
+
+    def test_uc2_unsuccessful_exceeded_the_value_limit(self, client, conn):
+        """UC2 · Unsuccessful exceeded the value limit (ADD p.10) — a submission
+        that exceeds the puzzle's allowed value is blocked (not solved)."""
+        creator_token = make_creator(client, conn, "acc_uc2_limit_creator")
+        puzzle = create_puzzle(client, creator_token, name="ACC UC2 Limit", budget=5, time_limit=60)
+        pid = int(puzzle["id"])
+        add_blackbox_test_case(client, creator_token, pid, {"A": 0, "B": 0}, {"out": 0})
+        add_blackbox_test_case(client, creator_token, pid, {"A": 1, "B": 1}, {"out": 1})
+        assert validate_solution(client, creator_token, pid, _and_solution(), time_taken=10)["solved"] is True
+        assert client.post(f"/puzzles/{pid}/publish", headers=auth_header(creator_token)).status_code == 200
+
+        # Lock the puzzle to a 1-gate budget, then submit a 2-gate solution.
+        conn.execute("UPDATE puzzles SET total_gate_count = 1 WHERE id = ?", (pid,))
+        client.post(
+            f"/puzzles/{pid}/testcases",
+            json={"kind": "gate_count_limit", "inputs": {}, "expected_outputs": {}},
+            headers=auth_header(creator_token),
+        )
+        solver_token = register_and_login(client, "acc_uc2_limit_solver")
+        result = validate_solution(client, solver_token, pid, _and_solution_with_extra_gate(), time_taken=10)
+        assert result["solved"] is False
+
+    def test_uc2_unsuccessful_time_expired(self, client, conn):
+        """UC2 · Unsuccessful time expired (ADD p.11) — correct solution after
+        the timer expires → solved but no Timer Medal (BRONZE)."""
+        creator_token = make_creator(client, conn, "acc_uc2_time_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC2 Time", budget=5, time_limit=60
+        )
+        solver_token = register_and_login(client, "acc_uc2_time_solver")
+        result = validate_solution(client, solver_token, pid, _and_solution(), time_taken=120)
+        assert result["solved"] is True
+        assert result["medal"] == "BRONZE"
+
+    def test_uc2_successful_leaderboard_ranking(self, client, conn):
+        """UC2 · Successful leaderboard ranking (ADD p.11) — solvers appear on
+        the per-puzzle leaderboard ranked by fastest time (top of the podium)."""
+        creator_token = make_creator(client, conn, "acc_uc2_lb_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC2 Leaderboard", budget=5, time_limit=60
+        )
+        slow = register_and_login(client, "acc_uc2_lb_slow")
+        fast = register_and_login(client, "acc_uc2_lb_fast")
+        mid = register_and_login(client, "acc_uc2_lb_mid")
+        validate_solution(client, slow, pid, _and_solution(), time_taken=30)
+        validate_solution(client, fast, pid, _and_solution(), time_taken=15)
+        validate_solution(client, mid, pid, _and_solution(), time_taken=20)
+
+        lb = client.get(f"/puzzles/{pid}/leaderboard", headers=auth_header(fast))
+        assert lb.status_code == 200, lb.text
+        entries = lb.json()["data"]
+        assert [e["rank"] for e in entries[:4]] == [1, 2, 3, 4]
+        assert [e["best_time"] for e in entries[:4]] == [10, 15, 20, 30]  # creator self-solved at 10
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC3 — Save and Reuse Circuits                                      ADD p.13-15
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc3_successful_save_to_arsenal : Saving a valid circuit makes it show up in your arsenal.
+#   test_uc3_successful_reuse_compatibility : A saved circuit shows up only for puzzles that allow its gates.
+#   test_uc3_unsuccessful_name_collision : You can't save two circuits with the same name.
+#   test_uc3_unsuccessful_arsenal_full : Once your arsenal is full, saving is blocked.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC3SaveAndReuseCircuits:
+
+    def test_uc3_successful_save_to_arsenal(self, client):
+        """UC3 · Successful save to arsenal (ADD p.15) — a legal circuit is saved
+        and appears in the user's arsenal."""
+        token = register_and_login(client, "acc_uc3_save")
+        resp = client.post("/arsenal", json=_arsenal_payload("acc-uc3-piece"), headers=auth_header(token))
+        assert resp.status_code == 200, resp.text
+        names = [p["name"] for p in client.get("/arsenal", headers=auth_header(token)).json()]
+        assert "acc-uc3-piece" in names
+
+    def test_uc3_successful_reuse_compatibility(self, client, conn):
+        """UC3 · Successful reuse compatibility (ADD p.15) — a saved circuit is
+        offered for a puzzle that allows its gates, and hidden when a required
+        default is missing."""
+        creator_token = make_creator(client, conn, "acc_uc3_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC3 Reuse")
+        token = register_and_login(client, "acc_uc3_reuse")
+        assert client.post(
+            "/arsenal", json=_arsenal_payload("acc-uc3-compat", basic_gates='["AND"]'),
+            headers=auth_header(token),
+        ).status_code == 200
+
+        available = client.get(
+            f"/arsenal/puzzle/{pid}/available", params={"allowed_gates": "AND,OR,NOT"},
+            headers=auth_header(token),
+        )
+        assert "acc-uc3-compat" in [p["type"] for p in available.json()]
+
+        missing = client.get(
+            f"/arsenal/puzzle/{pid}/available", params={"allowed_gates": "OR,NOT"},
+            headers=auth_header(token),
+        )
+        assert "acc-uc3-compat" not in [p["type"] for p in missing.json()]
+
+    def test_uc3_unsuccessful_name_collision(self, client):
+        """UC3 · Unsuccessful name collision (ADD p.15) — save rejected when the
+        arsenal already has a circuit with that name."""
+        token = register_and_login(client, "acc_uc3_collide")
+        assert client.post("/arsenal", json=_arsenal_payload("dup"), headers=auth_header(token)).status_code == 200
+        second = client.post("/arsenal", json=_arsenal_payload("dup"), headers=auth_header(token))
+        assert second.status_code == 400
+        assert "already exists" in second.json()["detail"]
+
+    def test_uc3_unsuccessful_arsenal_full(self, client):
+        """UC3 · Unsuccessful arsenal full (ADD p.15) — save denied once the
+        level-based arsenal capacity (5 at low level) is reached."""
+        token = register_and_login(client, "acc_uc3_full")
+        for idx in range(5):
+            assert client.post("/arsenal", json=_arsenal_payload(f"p{idx}"), headers=auth_header(token)).status_code == 200
+        overflow = client.post("/arsenal", json=_arsenal_payload("p-overflow"), headers=auth_header(token))
+        assert overflow.status_code == 400
+        assert "capacity reached" in overflow.json()["detail"].lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC4 — Create and Publish Puzzle                                    ADD p.16-20
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc4_successful_valid_publish : Valid puzzle + creator solves it -> it gets published.
+#   test_uc4_unsuccessful_self_solve_fails : If the creator can't solve their own puzzle, it can't be published.
+#   test_uc4_unsuccessful_duplicate_name : A puzzle name that already exists is rejected.
+#   test_uc4_unsuccessful_invalid_limits : Bad settings (like a negative budget) block creation.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC4CreateAndPublishPuzzle:
+
+    def test_uc4_successful_valid_publish(self, client, conn):
+        """UC4 · Successful valid publish (ADD p.18) — all data valid + creator
+        self-solves → puzzle published with an upload datetime set."""
+        creator_token = make_creator(client, conn, "acc_uc4_pub")
+        puzzle = create_puzzle(client, creator_token, name="ACC UC4 Publish", budget=5, time_limit=60, difficulty="HARD")
+        pid = int(puzzle["id"])
+        add_blackbox_test_case(client, creator_token, pid, {"A": 0, "B": 0}, {"out": 0})
+        add_blackbox_test_case(client, creator_token, pid, {"A": 1, "B": 1}, {"out": 1})
+        assert validate_solution(client, creator_token, pid, _and_solution(), time_taken=10)["solved"] is True
+        publish = client.post(f"/puzzles/{pid}/publish", headers=auth_header(creator_token))
+        assert publish.status_code == 200, publish.text
+        assert publish.json()["status"] == "published"
+        assert publish.json()["created_at"]
+
+    def test_uc4_unsuccessful_self_solve_fails(self, client, conn):
+        """UC4 · Unsuccessful self-solve fails (ADD p.18) — creator cannot solve
+        within the greater limits → upload blocked (publish forbidden)."""
+        creator_token = make_creator(client, conn, "acc_uc4_selffail")
+        puzzle = create_puzzle(client, creator_token, name="ACC UC4 SelfFail", budget=5, time_limit=60)
+        pid = int(puzzle["id"])
+        add_blackbox_test_case(client, creator_token, pid, {"A": 0, "B": 0}, {"out": 0})
+        add_blackbox_test_case(client, creator_token, pid, {"A": 1, "B": 1}, {"out": 1})
+        assert validate_solution(
+            client, creator_token, pid,
+            {"placedComponents": [], "wires": [], "totalCost": 0}, time_taken=10,
+        )["solved"] is False
+        assert client.post(f"/puzzles/{pid}/publish", headers=auth_header(creator_token)).status_code == 403
+
+    def test_uc4_unsuccessful_duplicate_name(self, client, conn):
+        """UC4 · Unsuccessful duplicate name (ADD p.18) — a puzzle name that
+        collides with an existing one is rejected."""
+        creator_token = make_creator(client, conn, "acc_uc4_dup")
+        body = {"name": "ACC UC4 Dup", "description": "x", "budget": 5,
+                "default_gate_set": ["AND", "OR", "NOT"], "difficulty": "EASY"}
+        assert client.post("/puzzles", json=body, headers=auth_header(creator_token)).status_code == 200
+        second = client.post("/puzzles", json={**body, "description": "y"}, headers=auth_header(creator_token))
+        assert second.status_code == 400
+        assert "already exists" in second.json()["detail"].lower()
+
+    def test_uc4_unsuccessful_invalid_limits(self, client, conn):
+        """UC4 · Unsuccessful invalid limits (ADD p.18-19) — invalid limits
+        (negative budget) → validation error, upload prevented."""
+        creator_token = make_creator(client, conn, "acc_uc4_invalid")
+        resp = client.post(
+            "/puzzles",
+            json={"name": "ACC UC4 Invalid", "description": "x", "budget": -1,
+                  "default_gate_set": ["AND"], "difficulty": "EASY"},
+            headers=auth_header(creator_token),
+        )
+        assert resp.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC5 — Rate a Puzzle                                                ADD p.21-23
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc5_successful_valid_rating_pre_10 : With few ratings, difficulty follows mostly the creator's rating.
+#   test_uc5_successful_experienced_weighting : An experienced player's rating counts in both the overall and experienced-only scores.
+#   test_uc5_successful_post_10_shift : After 10 ratings, players' ratings outweigh the creator's.
+#   test_uc5_successful_edit_rating : Changing your rating updates the score but gives no extra XP.
+#   test_uc5_unsuccessful_ineligible_rating : You can't rate a puzzle you haven't solved or spent enough time on.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC5RateAPuzzle:
+
+    def test_uc5_successful_valid_rating_pre_10(self, client, conn):
+        """UC5 · Successful valid rating (Pre-10) (ADD p.22) — with <10 ratings
+        difficulty blends 80% creator + 20% user average."""
+        creator_token = make_creator(client, conn, "acc_uc5_pre10_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC5 Pre10", budget=5, time_limit=60, difficulty="HARD"
+        )
+        solver_token = register_and_login(client, "acc_uc5_pre10_solver")
+        assert client.post(
+            f"/ratings/puzzle/{pid}",
+            json={"difficulty": 1, "fun": 4, "clearness": 4, "elapsed_seconds": 300},
+            headers=auth_header(solver_token),
+        ).status_code == 200
+        metrics = client.get(f"/ratings/puzzle/{pid}", headers=auth_header(solver_token)).json()["metrics"]
+        # creator HARD=5, user diff=1 → 0.8*5 + 0.2*1 = 4.2
+        assert metrics["weighted_difficulty"] == 4.2
+
+    def test_uc5_successful_experienced_weighting(self, client, conn):
+        """UC5 · Successful experienced weighting (ADD p.22) — an experienced
+        (level >= 5) rater is counted in both the general and experienced-only
+        averages."""
+        creator_token = make_creator(client, conn, "acc_uc5_exp_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC5 Exp")
+        solver_token = register_and_login(client, "acc_uc5_exp_solver")
+        me = get_user_info(client, solver_token)
+        conn.execute("UPDATE users SET xp = 2500 WHERE id = ?", (me["id"],))  # level 6 → experienced
+        assert client.post(
+            f"/ratings/puzzle/{pid}",
+            json={"difficulty": 3, "fun": 4, "clearness": 5, "elapsed_seconds": 300},
+            headers=auth_header(solver_token),
+        ).status_code == 200
+        metrics = client.get(f"/ratings/puzzle/{pid}", headers=auth_header(solver_token)).json()["metrics"]
+        assert metrics["count"] == 1
+        assert metrics["experienced"]["count"] == 1
+
+    def test_uc5_successful_post_10_shift(self, client, conn):
+        """UC5 · Successful post-10 shift (ADD p.22) — once a puzzle reaches >=10
+        ratings the weighting shifts to 40% creator / 60% user."""
+        creator_token = make_creator(client, conn, "acc_uc5_post10_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC5 Post10", difficulty="HARD")
+        for idx in range(10):
+            token = register_and_login(client, f"acc_uc5_post10_{idx}")
+            assert client.post(
+                f"/ratings/puzzle/{pid}",
+                json={"difficulty": 1, "fun": 3, "clearness": 3, "elapsed_seconds": 300},
+                headers=auth_header(token),
+            ).status_code == 200
+        reader = register_and_login(client, "acc_uc5_post10_reader")
+        metrics = client.get(f"/ratings/puzzle/{pid}", headers=auth_header(reader)).json()["metrics"]
+        assert metrics["count"] == 10
+        # creator HARD=5, user diff=1 → 0.4*5 + 0.6*1 = 2.6
+        assert metrics["weighted_difficulty"] == 2.6
+
+    def test_uc5_successful_edit_rating(self, client, conn):
+        """UC5 · Successful edit rating (ADD p.22) — editing an existing rating
+        recalculates aggregates and grants NO additional XP."""
+        creator_token = make_creator(client, conn, "acc_uc5_edit_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC5 Edit")
+        token = register_and_login(client, "acc_uc5_edit_solver")
+        assert client.post(
+            f"/ratings/puzzle/{pid}",
+            json={"difficulty": 2, "fun": 2, "clearness": 2, "elapsed_seconds": 300},
+            headers=auth_header(token),
+        ).status_code == 200
+        xp_after_first = get_user_xp(client, token)
+        assert client.put(
+            f"/ratings/puzzle/{pid}",
+            json={"difficulty": 5, "fun": 5, "clearness": 4, "elapsed_seconds": 300},
+            headers=auth_header(token),
+        ).status_code == 200
+        assert get_user_xp(client, token) == xp_after_first  # no extra XP
+        assert client.get(f"/ratings/puzzle/{pid}", headers=auth_header(token)).json()["my_rating"]["difficulty"] == 5
+
+    def test_uc5_unsuccessful_ineligible_rating(self, client, conn):
+        """UC5 · Unsuccessful ineligible rating (ADD p.22) — attempted <5 minutes
+        and not solved → rating rejected."""
+        creator_token = make_creator(client, conn, "acc_uc5_inelig_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC5 Ineligible")
+        token = register_and_login(client, "acc_uc5_inelig_solver")
+        resp = client.post(
+            f"/ratings/puzzle/{pid}",
+            json={"difficulty": 3, "fun": 3, "clearness": 3, "elapsed_seconds": 120},
+            headers=auth_header(token),
+        )
+        assert resp.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC6 — Earn Rewards and Level Up                                    ADD p.24-26
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc6_successful_standard_xp : Solving gives XP based on the puzzle's difficulty.
+#   test_uc6_successful_medal_upgrade : Solving better (faster / cheaper) upgrades your medal.
+#   test_uc6_successful_level_up : Earning enough XP moves you up a level.
+#   test_uc6_unsuccessful_repeat_timer : Solving the same puzzle again gives no extra reward.
+#   test_uc6_successful_leaderboard_after_reward : After solving, you appear on the puzzle's leaderboard.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC6EarnRewardsAndLevelUp:
+
+    def test_uc6_successful_standard_xp(self, client, conn):
+        """UC6 · Successful standard XP (ADD p.25) — XP awarded per difficulty
+        tier (HARD = 200 base)."""
+        creator_token = make_creator(client, conn, "acc_uc6_xp_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC6 XP", budget=0, time_limit=5, difficulty="HARD"
+        )
+        solver_token = register_and_login(client, "acc_uc6_xp_solver")
+        result = validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)
+        assert result["solved"] is True
+        assert result["medal"] == "BRONZE"  # time expired & budget 0
+        assert result["xp_earned"] == 200
+
+    def test_uc6_successful_medal_upgrade(self, client, conn):
+        """UC6 · Successful medal upgrade (ADD p.25) — solving within the greater
+        (value/time) limits upgrades the medal (bronze → silver)."""
+        creator_token = make_creator(client, conn, "acc_uc6_upg_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC6 Upgrade", budget=1, time_limit=60, difficulty="EASY"
+        )
+        solver_token = register_and_login(client, "acc_uc6_upg_solver")
+        first = validate_solution(client, solver_token, pid, _and_solution(), time_taken=120)
+        second = validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)
+        assert first["medal"] == "BRONZE"
+        assert second["medal"] == "SILVER"
+
+    def test_uc6_successful_level_up(self, client, conn):
+        """UC6 · Successful level up (ADD p.25) — when XP crosses the next level
+        threshold the user's level increases."""
+        creator_token = make_creator(client, conn, "acc_uc6_lvl_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC6 Level", budget=0, time_limit=None, difficulty="EASY"
+        )
+        token = register_and_login(client, "acc_uc6_lvl_solver")
+        me = get_user_info(client, token)
+        conn.execute("UPDATE users SET xp = 399 WHERE id = ?", (me["id"],))
+        before = get_user_info(client, token)
+        validate_solution(client, token, pid, _and_solution(), time_taken=10)
+        after = get_user_info(client, token)
+        assert after["level"] == before["level"] + 1
+
+    def test_uc6_unsuccessful_repeat_timer(self, client, conn):
+        """UC6 · Unsuccessful repeat timer (ADD p.25) — a second/subsequent win on
+        the same puzzle grants no extra Timer Medal or alt-solution bonus."""
+        creator_token = make_creator(client, conn, "acc_uc6_rep_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC6 Repeat", budget=5, time_limit=60, difficulty="EASY"
+        )
+        token = register_and_login(client, "acc_uc6_rep_solver")
+        first = validate_solution(client, token, pid, _and_solution(), time_taken=10)
+        second = validate_solution(client, token, pid, _and_solution(), time_taken=10)
+        assert first["solved"] is True
+        assert second["xp_earned"] == 0
+
+    def test_uc6_successful_leaderboard_after_reward(self, client, conn):
+        """UC6 · Successful leaderboard after reward (ADD p.26) — after solving &
+        earning a medal the user appears on the puzzle leaderboard."""
+        creator_token = make_creator(client, conn, "acc_uc6_lb_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC6 LB", budget=5, time_limit=60, difficulty="EASY"
+        )
+        token = register_and_login(client, "acc_uc6_lb_solver")
+        info = get_user_info(client, token)
+        validate_solution(client, token, pid, _and_solution(), time_taken=10)
+        lb = client.get(f"/puzzles/{pid}/leaderboard", headers=auth_header(token))
+        assert lb.status_code == 200
+        assert int(info["id"]) in [e["user_id"] for e in lb.json()["data"]]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC7 — Manage Puzzles (Creators Only)                               ADD p.27-29
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc7_successful_comment_addition : A creator can add a comment to their puzzle.
+#   test_uc7_successful_edit_comment : A creator can change their puzzle's comment.
+#   test_uc7_successful_delete_comment : A creator can clear their puzzle's comment.
+#   test_uc7_successful_delete_puzzle : A creator can delete their puzzle.
+#   test_uc7_unsuccessful_unauthorized : You can't edit or delete someone else's puzzle.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC7ManagePuzzlesCreatorsOnly:
+
+    def test_uc7_successful_comment_addition(self, client, conn):
+        """UC7 · Successful comment addition (ADD p.28) — creator adds a comment
+        (description) to their puzzle; it is stored and visible."""
+        creator_token = make_creator(client, conn, "acc_uc7_add")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC7 Add")
+        assert client.patch(
+            f"/puzzles/{pid}", json={"description": "new comment"}, headers=auth_header(creator_token)
+        ).status_code == 200
+        assert client.get(f"/puzzles/{pid}", headers=auth_header(creator_token)).json()["description"] == "new comment"
+
+    def test_uc7_successful_edit_comment(self, client, conn):
+        """UC7 · Successful edit comment (ADD p.28) — creator edits the comment;
+        it is replaced."""
+        creator_token = make_creator(client, conn, "acc_uc7_edit")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC7 Edit")
+        client.patch(f"/puzzles/{pid}", json={"description": "old"}, headers=auth_header(creator_token))
+        client.patch(f"/puzzles/{pid}", json={"description": "updated"}, headers=auth_header(creator_token))
+        assert client.get(f"/puzzles/{pid}", headers=auth_header(creator_token)).json()["description"] == "updated"
+
+    def test_uc7_successful_delete_comment(self, client, conn):
+        """UC7 · Successful delete comment (ADD p.28) — creator clears the comment
+        (removed from the puzzle page)."""
+        creator_token = make_creator(client, conn, "acc_uc7_delc")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC7 DelComment")
+        client.patch(f"/puzzles/{pid}", json={"description": "delete me"}, headers=auth_header(creator_token))
+        client.patch(f"/puzzles/{pid}", json={"description": ""}, headers=auth_header(creator_token))
+        assert client.get(f"/puzzles/{pid}", headers=auth_header(creator_token)).json()["description"] == ""
+
+    def test_uc7_successful_delete_puzzle(self, client, conn):
+        """UC7 · Successful delete puzzle (ADD p.28) — creator deletes the puzzle;
+        it is removed from public listings."""
+        creator_token = make_creator(client, conn, "acc_uc7_delp")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC7 DelPuzzle")
+        assert client.delete(f"/puzzles/{pid}", headers=auth_header(creator_token)).status_code == 200
+        assert client.get(f"/puzzles/{pid}", headers=auth_header(creator_token)).status_code == 404
+
+    def test_uc7_unsuccessful_unauthorized(self, client, conn):
+        """UC7 · Unsuccessful unauthorized (ADD p.29) — a different creator cannot
+        edit/delete a puzzle they don't own (permission denied)."""
+        owner_token = make_creator(client, conn, "acc_uc7_owner")
+        pid, _ = create_and_publish_puzzle(client, conn, owner_token, name="ACC UC7 Forbidden")
+        other = make_creator(client, conn, "acc_uc7_other")
+        assert client.patch(f"/puzzles/{pid}", json={"description": "x"}, headers=auth_header(other)).status_code == 403
+        assert client.delete(f"/puzzles/{pid}", headers=auth_header(other)).status_code == 403
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC8 — Puzzle Solution Validation                                   ADD p.30-31
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc8_successful_correct_solution : A correct circuit passes validation.
+#   test_uc8_unsuccessful_incorrect_solution : A wrong circuit fails validation.
+#   test_uc8_unsuccessful_limits_were_broken : A circuit that breaks the limits fails, even if it's logically correct.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC8PuzzleSolutionValidation:
+
+    def test_uc8_successful_correct_solution(self, client, conn):
+        """UC8 · Successful correct solution (ADD p.31) — system checks the test
+        cases and returns true for a correct solution."""
+        creator_token = make_creator(client, conn, "acc_uc8_ok_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC8 Correct")
+        token = register_and_login(client, "acc_uc8_ok_solver")
+        assert validate_solution(client, token, pid, _and_solution(), time_taken=10)["solved"] is True
+
+    def test_uc8_unsuccessful_incorrect_solution(self, client, conn):
+        """UC8 · Unsuccessful incorrect solution (ADD p.31) — system returns false
+        for a solution that fails the test cases."""
+        creator_token = make_creator(client, conn, "acc_uc8_bad_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC8 Incorrect")
+        token = register_and_login(client, "acc_uc8_bad_solver")
+        result = validate_solution(
+            client, token, pid, {"placedComponents": [], "wires": [], "totalCost": 0}, time_taken=10
+        )
+        assert result["solved"] is False
+
+    def test_uc8_unsuccessful_limits_were_broken(self, client, conn):
+        """UC8 · Unsuccessful limits were broken (ADD p.31) — a circuit that
+        breaks the puzzle limits is rejected (returns false)."""
+        creator_token = make_creator(client, conn, "acc_uc8_lim_creator")
+        puzzle = create_puzzle(client, creator_token, name="ACC UC8 Limits", budget=5, time_limit=60)
+        pid = int(puzzle["id"])
+        add_blackbox_test_case(client, creator_token, pid, {"A": 0, "B": 0}, {"out": 0})
+        add_blackbox_test_case(client, creator_token, pid, {"A": 1, "B": 1}, {"out": 1})
+        validate_solution(client, creator_token, pid, _and_solution(), time_taken=10)
+        assert client.post(f"/puzzles/{pid}/publish", headers=auth_header(creator_token)).status_code == 200
+        conn.execute("UPDATE puzzles SET total_gate_count = 1 WHERE id = ?", (pid,))
+        client.post(
+            f"/puzzles/{pid}/testcases",
+            json={"kind": "gate_count_limit", "inputs": {}, "expected_outputs": {}},
+            headers=auth_header(creator_token),
+        )
+        token = register_and_login(client, "acc_uc8_lim_solver")
+        result = validate_solution(client, token, pid, _and_solution_with_extra_gate(), time_taken=10)
+        assert result["solved"] is False
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC9 — Appoint User as Creator                                      ADD p.32-33
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc9_successful_appointment : An admin can promote a player toward becoming a creator.
+#   test_uc9_successful_already_appointed : Promoting someone who's already a creator is reported as such.
+#   test_uc9_unsuccessful_unauthorized : A non-admin can't promote anyone.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC9AppointUserAsCreator:
+
+    def test_uc9_successful_appointment(self, client, conn):
+        """UC9 · Successful Appointment (ADD p.33) — admin appoints a solver; the
+        system records the appointment (target becomes pending_creator)."""
+        admin_token = make_admin(client, conn, "acc_uc9_admin")
+        target = register_and_login(client, "acc_uc9_target")
+        target_info = get_user_info(client, target)
+        resp = client.post(
+            "/admin/assign-creator",
+            json={"target_user_id": target_info["id"]},
+            headers=auth_header(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert get_user_info(client, target)["role"] == "pending_creator"
+
+    def test_uc9_successful_already_appointed(self, client, conn):
+        """UC9 · Successful already appointed (ADD p.33) — appointing an existing
+        creator notifies that the user is already a creator."""
+        admin_token = make_admin(client, conn, "acc_uc9_admin2")
+        creator_token = make_creator(client, conn, "acc_uc9_existing")
+        creator_info = get_user_info(client, creator_token)
+        resp = client.post(
+            "/admin/assign-creator",
+            json={"target_user_id": creator_info["id"]},
+            headers=auth_header(admin_token),
+        )
+        assert resp.status_code == 400
+        assert "already" in resp.json()["detail"].lower()
+
+    def test_uc9_unsuccessful_unauthorized(self, client):
+        """UC9 · Unsuccessful - Unauthorized (ADD p.33) — a non-admin attempting
+        the appointment is denied."""
+        solver = register_and_login(client, "acc_uc9_nonadmin")
+        target = register_and_login(client, "acc_uc9_target2")
+        resp = client.post(
+            "/admin/assign-creator",
+            json={"target_user_id": get_user_info(client, target)["id"]},
+            headers=auth_header(solver),
+        )
+        assert resp.status_code == 403
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC10 — View Personal Profile & Progress                            ADD p.34-35
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc10_successful_profile_load : The profile shows your XP, level and medals.
+#   test_uc10_successful_puzzle_access : The profile lists the puzzles you saved for later.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC10ViewPersonalProfile:
+
+    def test_uc10_successful_profile_load(self, client, conn):
+        """UC10 · Successful Profile Load (ADD p.35) — profile shows the user's
+        level, XP and medal counts."""
+        creator_token = make_creator(client, conn, "acc_uc10_creator")
+        pid, _ = create_and_publish_puzzle(
+            client, conn, creator_token, name="ACC UC10 Medal", budget=1, time_limit=60
+        )
+        token = register_and_login(client, "acc_uc10_solver")
+        before = get_user_info(client, token)
+        conn.execute("UPDATE users SET xp = 500 WHERE id = ?", (before["id"],))
+        validate_solution(client, token, pid, _and_solution(), time_taken=10)
+        body = client.get("/users/me", headers=auth_header(token)).json()
+        assert body["xp"] >= 500
+        assert body["level"] >= before["level"]
+        assert body["medals"]["silver"] >= 1
+
+    def test_uc10_successful_puzzle_access(self, client, conn):
+        """UC10 · Successful Puzzle Access (ADD p.35) — profile exposes the user's
+        clickable list of saved-for-later puzzles."""
+        creator_token = make_creator(client, conn, "acc_uc10_saved_creator")
+        token = register_and_login(client, "acc_uc10_saved_solver")
+        info = get_user_info(client, token)
+        saved_ids = []
+        for idx in range(3):
+            pid, _ = create_and_publish_puzzle(client, conn, creator_token, name=f"ACC UC10 Saved {idx}")
+            saved_ids.append(pid)
+            conn.execute(
+                "INSERT INTO saved_puzzles(user_id, puzzle_id, created_at) VALUES (?, ?, datetime('now'))",
+                (int(info["id"]), int(pid)),
+            )
+        body = client.get("/users/me", headers=auth_header(token)).json()
+        assert {int(p["id"]) for p in body["saved_puzzles"]} == set(saved_ids)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC11 — Experiment in Sandbox                                       ADD p.36-37
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc11_successful_sandbox_save : A circuit built in the sandbox can be saved to your arsenal.
+#   test_uc11_unsuccessful_arsenal_full : Saving from the sandbox is blocked when the arsenal is full.
+#   test_uc11_unsuccessful_name_collision : Saving from the sandbox is blocked when the name is taken.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC11ExperimentInSandbox:
+
+    def test_uc11_successful_sandbox_save(self, client):
+        """UC11 · Successful Sandbox Save (ADD p.37) — a valid sandbox circuit is
+        saved to the arsenal for future puzzles."""
+        token = register_and_login(client, "acc_uc11_save")
+        assert client.post("/arsenal", json=_arsenal_payload("MyAdder"), headers=auth_header(token)).status_code == 200
+        assert "MyAdder" in [p["name"] for p in client.get("/arsenal", headers=auth_header(token)).json()]
+
+    def test_uc11_unsuccessful_arsenal_full(self, client):
+        """UC11 · Unsuccessful - Arsenal Full (ADD p.37) — save rejected with a
+        capacity error once the level-based arsenal capacity is reached."""
+        token = register_and_login(client, "acc_uc11_full")
+        for idx in range(5):
+            assert client.post("/arsenal", json=_arsenal_payload(f"acc-uc11-{idx}"), headers=auth_header(token)).status_code == 200
+        overflow = client.post("/arsenal", json=_arsenal_payload("acc-uc11-overflow"), headers=auth_header(token))
+        assert overflow.status_code == 400
+        assert "capacity reached" in overflow.json()["detail"].lower()
+
+    def test_uc11_unsuccessful_name_collision(self, client):
+        """UC11 · Unsuccessful - Name collision (ADD p.37) — save rejected with a
+        naming error when the name already exists."""
+        token = register_and_login(client, "acc_uc11_collide")
+        assert client.post("/arsenal", json=_arsenal_payload("A"), headers=auth_header(token)).status_code == 200
+        second = client.post("/arsenal", json=_arsenal_payload("A"), headers=auth_header(token))
+        assert second.status_code == 400
+        assert "already exists" in second.json()["detail"]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC12 — Manage Personal Arsenal                                     ADD p.38-39
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc12_successful_deletion : You can delete a saved circuit from your arsenal.
+#   test_uc12_successful_rename : You can rename a saved circuit.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC12ManagePersonalArsenal:
+
+    def test_uc12_successful_deletion(self, client):
+        """UC12 · Successful Deletion (ADD p.39) — deleting a saved circuit removes
+        it and updates the count."""
+        token = register_and_login(client, "acc_uc12_delete")
+        created = client.post("/arsenal", json=_arsenal_payload("Old_Circuit"), headers=auth_header(token))
+        assert created.status_code == 200, created.text
+        assert client.delete(f"/arsenal/{created.json()['id']}", headers=auth_header(token)).status_code == 200
+        assert "Old_Circuit" not in [p["name"] for p in client.get("/arsenal", headers=auth_header(token)).json()]
+
+    def test_uc12_successful_rename(self, client):
+        """UC12 · Successful Rename (ADD p.39) — renaming a saved circuit updates
+        its name in the list."""
+        token = register_and_login(client, "acc_uc12_rename")
+        created = client.post("/arsenal", json=_arsenal_payload("Circuit_A"), headers=auth_header(token))
+        assert created.status_code == 200, created.text
+        assert client.put(
+            f"/arsenal/{created.json()['id']}", json={"new_name": "Circuit_B"}, headers=auth_header(token)
+        ).status_code == 200
+        names = [p["name"] for p in client.get("/arsenal", headers=auth_header(token)).json()]
+        assert "Circuit_B" in names and "Circuit_A" not in names
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC13 — Participate in Discussions                                  ADD p.40-41
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc13_successful_discussion_creation : A new discussion shows up and is visible to others.
+#   test_uc13_successful_reply_with_voting : You can reply to a discussion and upvote a reply.
+#   test_uc13_successful_discussion_locking_by_admin : Once an admin locks a discussion, no one can reply.
+#   test_uc13_unsuccessful_user_is_discussion_banned : A banned user can't post discussions or replies.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC13ParticipateInDiscussions:
+
+    def test_uc13_successful_discussion_creation(self, client):
+        """UC13 · Successful discussion creation (ADD p.41) — a discussion is
+        created, appears in the list and is visible to others."""
+        author = register_and_login(client, "acc_uc13_author")
+        disc = _create_discussion(client, author, title="ACC UC13 Topic", body="how do I wire an adder?")
+        did = int(disc["id"])
+        other = register_and_login(client, "acc_uc13_reader")
+        listed = client.get("/discussions", headers=auth_header(other))
+        assert listed.status_code == 200
+        assert did in [int(d["id"]) for d in listed.json()["discussions"]]
+
+    def test_uc13_successful_reply_with_voting(self, client):
+        """UC13 · Successful reply with voting (ADD p.41) — a reply is posted and
+        upvoted; the vote count updates (one vote per user per reply)."""
+        author = register_and_login(client, "acc_uc13_v_author")
+        did = int(_create_discussion(client, author, title="ACC UC13 Voting")["id"])
+        replier = register_and_login(client, "acc_uc13_v_replier")
+        reply = _create_reply(client, replier, did, body="try AND gates")
+        assert reply.status_code == 200, reply.text
+        rid = int(reply.json()["id"])
+
+        voter = register_and_login(client, "acc_uc13_v_voter")
+        vote = client.post(f"/replies/{rid}/vote", json={"value": 1}, headers=auth_header(voter))
+        assert vote.status_code == 200, vote.text
+        assert vote.json()["user_vote"] == 1
+
+    def test_uc13_successful_discussion_locking_by_admin(self, client, conn):
+        """UC13 · Successful discussion locking by admin (ADD p.41) — after an
+        admin locks a discussion, new replies are blocked (existing stay)."""
+        author = register_and_login(client, "acc_uc13_lock_author")
+        did = int(_create_discussion(client, author, title="ACC UC13 Lock")["id"])
+        admin_token = make_admin(client, conn, "acc_uc13_admin")
+        lock = client.post(f"/discussions/{did}/lock", headers=auth_header(admin_token))
+        assert lock.status_code == 200, lock.text
+        other = register_and_login(client, "acc_uc13_lock_replier")
+        blocked = _create_reply(client, other, did, body="too late")
+        assert blocked.status_code == 403
+        assert "locked" in blocked.json()["detail"].lower()
+
+    def test_uc13_unsuccessful_user_is_discussion_banned(self, client, conn):
+        """UC13 · Unsuccessful user is discussion-banned (ADD p.41) — a banned
+        user's create/reply action is rejected; nothing is created."""
+        banned = register_and_login(client, "acc_uc13_banned")
+        info = get_user_info(client, banned)
+        conn.execute("UPDATE users SET is_discussion_banned = 1 WHERE id = ?", (int(info["id"]),))
+        resp = client.post(
+            "/discussions",
+            json={"title": "should fail", "body": "x", "category": "general"},
+            headers=auth_header(banned),
+        )
+        assert resp.status_code == 400
+        assert "banned" in resp.json()["detail"].lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# UC14 — Manage Notifications                                        ADD p.42
+# (ADD has no dedicated acceptance table for UC14; these mirror the Functional
+#  & Integration "Notification Integration" row, ADD p.103.)
+# ──────────────────────────────────────────────────────────────────────────────
+# What each test checks:
+#   test_uc14_notification_generated_on_solve : When someone solves your puzzle, you get a notification.
+#   test_uc14_filter_notifications_by_type : Notifications can be filtered by type.
+#   test_uc14_mark_notifications_read : Marking notifications as read empties the unread list.
+# ══════════════════════════════════════════════════════════════════════════════
+class TestUC14ManageNotifications:
+
+    def test_uc14_notification_generated_on_solve(self, client, conn):
+        """UC14 · Notification on solve (ADD p.42 / Integration p.103) — when a
+        solver solves a creator's puzzle, a 'solve' notification is generated for
+        the creator with the correct type and metadata (actor + puzzle)."""
+        creator_token = make_creator(client, conn, "acc_uc14_creator")
+        pid, puzzle = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC14 Notify")
+        solver_token = register_and_login(client, "acc_uc14_solver")
+        assert validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)["solved"] is True
+
+        notes = client.get("/users/me/notifications", headers=auth_header(creator_token))
+        assert notes.status_code == 200, notes.text
+        solve_notes = [n for n in notes.json() if n["type"] == "solve"]
+        assert len(solve_notes) >= 1
+        assert solve_notes[0]["actor_username"] == "acc_uc14_solver"
+        assert solve_notes[0]["puzzle_name"] == "ACC UC14 Notify"
+
+    def test_uc14_filter_notifications_by_type(self, client, conn):
+        """UC14 · Filter by type (ADD p.42) — notifications can be filtered by
+        type; an unrelated type returns nothing."""
+        creator_token = make_creator(client, conn, "acc_uc14_filter_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC14 Filter")
+        solver_token = register_and_login(client, "acc_uc14_filter_solver")
+        validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)
+
+        solve_only = client.get(
+            "/users/me/notifications", params={"notif_type": "solve"}, headers=auth_header(creator_token)
+        )
+        assert solve_only.status_code == 200
+        assert all(n["type"] == "solve" for n in solve_only.json())
+        assert len(solve_only.json()) >= 1
+
+        none = client.get(
+            "/users/me/notifications", params={"notif_type": "role_change"}, headers=auth_header(creator_token)
+        )
+        assert none.status_code == 200
+        assert none.json() == []
+
+    def test_uc14_mark_notifications_read(self, client, conn):
+        """UC14 · Mark as read (ADD p.42) — marking notifications read clears the
+        unread list."""
+        creator_token = make_creator(client, conn, "acc_uc14_read_creator")
+        pid, _ = create_and_publish_puzzle(client, conn, creator_token, name="ACC UC14 Read")
+        solver_token = register_and_login(client, "acc_uc14_read_solver")
+        validate_solution(client, solver_token, pid, _and_solution(), time_taken=10)
+
+        assert len(client.get("/users/me/notifications", headers=auth_header(creator_token)).json()) >= 1
+        marked = client.patch("/users/me/notifications/read", headers=auth_header(creator_token))
+        assert marked.status_code == 200
+        assert marked.json()["marked_read"] >= 1
+        assert client.get("/users/me/notifications", headers=auth_header(creator_token)).json() == []

--- a/src/tests/PersistantLayerTests/test_solve_repo_leaderboard.py
+++ b/src/tests/PersistantLayerTests/test_solve_repo_leaderboard.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for the per-puzzle leaderboard queries on SolveRepo.
+
+Fulfils the "Leaderboard" unit-test rows promised in ADD Chapter 7.2.2
+(Experience (XP) and Rewards Calculation), which name SolveRepo.py as the
+target module:
+
+    • "Leaderboard sorted by fastest time"   → get_leaderboard ordered by time ASC
+    • "Leaderboard sorted by lowest cost"     → get_leaderboard_by_cost ordered by cost ASC
+    • "Leaderboard respects passed=1 filter"  → failed attempts excluded
+    • "Leaderboard immediate update"          → a just-saved solve appears, ranked
+
+These run directly against an in-memory SQLite database (no API), per the
+AAA (Arrange, Act, Assert) pattern described in ADD 7.2.
+"""
+import sqlite3
+import pytest
+
+from Backend.PersistantLayer.SolveRepo import SolveRepo
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.isolation_level = None
+    return c
+
+
+@pytest.fixture
+def repo(conn):
+    r = SolveRepo(conn)
+    # The leaderboard JOINs the users table for usernames.
+    conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT)")
+    for uid, name in [(1, "alice"), (2, "bob"), (3, "carol")]:
+        conn.execute("INSERT INTO users(id, username) VALUES(?, ?)", (uid, name))
+    return r
+
+
+PUZZLE_ID = 1
+
+
+def test_leaderboard_sorted_by_fastest_time(repo):
+    """ADD 7.2.2 — 3 passed solves with times 120/90/150 → ranked 90,120,150."""
+    repo.add_solve(user_id=1, puzzle_id=PUZZLE_ID, time_taken_seconds=120, xp_earned=10)
+    repo.add_solve(user_id=2, puzzle_id=PUZZLE_ID, time_taken_seconds=90, xp_earned=10)
+    repo.add_solve(user_id=3, puzzle_id=PUZZLE_ID, time_taken_seconds=150, xp_earned=10)
+
+    board = repo.get_leaderboard(PUZZLE_ID, 50)
+
+    assert [e["rank"] for e in board] == [1, 2, 3]
+    assert [e["best_time"] for e in board] == [90, 120, 150]
+    assert [e["username"] for e in board] == ["bob", "alice", "carol"]
+
+
+def test_leaderboard_sorted_by_lowest_cost(repo):
+    """ADD 7.2.2 — 3 passed solves with costs 20/10/15 → ranked 10,15,20."""
+    repo.add_solve(user_id=1, puzzle_id=PUZZLE_ID, time_taken_seconds=100, xp_earned=10, cost_used=20)
+    repo.add_solve(user_id=2, puzzle_id=PUZZLE_ID, time_taken_seconds=100, xp_earned=10, cost_used=10)
+    repo.add_solve(user_id=3, puzzle_id=PUZZLE_ID, time_taken_seconds=100, xp_earned=10, cost_used=15)
+
+    board = repo.get_leaderboard_by_cost(PUZZLE_ID, 50)
+
+    assert [e["rank"] for e in board] == [1, 2, 3]
+    assert [e["best_cost"] for e in board] == [10, 15, 20]
+
+
+def test_leaderboard_respects_passed_filter(repo, conn):
+    """ADD 7.2.2 — a faster *failed* attempt must NOT appear on the leaderboard;
+    only the passed attempt is returned."""
+    # Passed attempt at 120s.
+    repo.add_solve(user_id=1, puzzle_id=PUZZLE_ID, time_taken_seconds=120, xp_earned=10)
+    # Faster *failed* attempt at 90s (passed=0) — must be excluded.
+    conn.execute(
+        """INSERT INTO solve_attempts(puzzle_id, user_id, started_at, submitted_at,
+                                      passed, time_used_seconds, time_taken_seconds, xp_earned)
+           VALUES(?,?,datetime('now'),datetime('now'),0,90,90,0)""",
+        (PUZZLE_ID, 2),
+    )
+
+    board = repo.get_leaderboard(PUZZLE_ID, 50)
+
+    assert len(board) == 1
+    assert board[0]["user_id"] == 1
+    assert board[0]["best_time"] == 120
+
+
+def test_leaderboard_immediate_update(repo):
+    """ADD 7.2.2 — a solve saved to the DB is present in the leaderboard
+    immediately and ranked correctly."""
+    repo.add_solve(user_id=1, puzzle_id=PUZZLE_ID, time_taken_seconds=50, xp_earned=10)
+
+    board = repo.get_leaderboard(PUZZLE_ID, 50)
+
+    assert any(e["user_id"] == 1 and e["best_time"] == 50 for e in board)
+    assert board[0]["rank"] == 1

--- a/src/tests/ServiceLayerTests/test_rating_weighting.py
+++ b/src/tests/ServiceLayerTests/test_rating_weighting.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the rating-weighting helpers on RatingService.
+
+Fulfils the "Rating System Weighting" unit-test rows promised in ADD
+Chapter 7.2.3 that target RatingService.py specifically:
+
+    • "Weighted average calculation"  → _weighted_avg([2,3,5],[1,2,1]) == 3.25
+    • "Creator dual-weight for experienced raters" → _exp_weight == 2 / 1
+    • "Rating distribution counting"  → difficulty_dist over [2,3,3,4,5]
+
+The two helpers are pure static methods, so they are tested in isolation.
+The distribution counting lives inside get_puzzle_metrics, so we exercise it
+with mocked repos (the established ServiceLayerTests pattern).
+"""
+from unittest.mock import Mock
+
+import pytest
+
+from Backend.ServiceLayer.RatingService import RatingService
+from Backend.PersistantLayer.RatingRepo import RatingRepo
+from Backend.PersistantLayer.PuzzleRepo import PuzzleRepo
+from Backend.PersistantLayer.SolveRepo import SolveRepo
+from Backend.ServiceLayer.AuthService import AuthService
+from Backend.ServiceLayer.XPService import XPService
+from Backend.DomainLayer.Rating import Rating
+from Backend.DomainLayer.Puzzle import Puzzle
+
+
+# ── _weighted_avg (pure static) ──────────────────────────────────────────────
+
+def test_weighted_avg_matches_add_example():
+    """ADD 7.2.3 — _weighted_avg([2,3,5],[1,2,1]) = (2*1+3*2+5*1)/4 = 3.25."""
+    assert RatingService._weighted_avg([2, 3, 5], [1, 2, 1]) == 3.25
+
+
+def test_weighted_avg_zero_weight_returns_none():
+    """Guard branch: total weight 0 → None (avoids divide-by-zero)."""
+    assert RatingService._weighted_avg([4, 5], [0, 0]) is None
+
+
+# ── _exp_weight (pure static) ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("experienced,expected", [(True, 2), (False, 1)])
+def test_exp_weight_dual_weighting(experienced, expected):
+    """ADD 7.2.3 — experienced raters weigh 2, non-experienced weigh 1."""
+    rating = Rating(
+        id=1, puzzle_id=1, user_id=1, difficulty=3, fun=3, clearness=3,
+        is_experienced_at_rating=experienced,
+    )
+    assert RatingService._exp_weight(rating) == expected
+
+
+# ── difficulty distribution counting (via get_puzzle_metrics) ────────────────
+
+def _service_with_ratings(ratings, creator_difficulty="EASY"):
+    rating_repo = Mock(spec=RatingRepo)
+    puzzle_repo = Mock(spec=PuzzleRepo)
+    service = RatingService(
+        rating_repo, puzzle_repo, Mock(spec=SolveRepo),
+        Mock(spec=AuthService), Mock(spec=XPService),
+    )
+    puzzle_repo.get_by_id.return_value = Puzzle(
+        id=1, name="P", creator_user_id=2, difficulty=creator_difficulty
+    )
+    rating_repo.list_by_puzzle.return_value = ratings
+    return service
+
+
+def test_rating_distribution_counting():
+    """ADD 7.2.3 — 5 difficulty scores [2,3,3,4,5] → counts {2:1, 3:2, 4:1, 5:1}.
+
+    rating_distribution['difficulty'] is the 1..5 slice, so indices map as
+    [count(1), count(2), count(3), count(4), count(5)].
+    """
+    scores = [2, 3, 3, 4, 5]
+    ratings = [
+        Rating(id=i + 1, puzzle_id=1, user_id=100 + i, difficulty=s, fun=3, clearness=3)
+        for i, s in enumerate(scores)
+    ]
+    service = _service_with_ratings(ratings)
+
+    metrics = service.get_puzzle_metrics(1)
+    dist = metrics["rating_distribution"]["difficulty"]  # [d1, d2, d3, d4, d5]
+
+    assert metrics["count"] == 5
+    assert dist == [0, 1, 2, 1, 1]

--- a/src/tests/ServiceLayerTests/test_user_service_coverage.py
+++ b/src/tests/ServiceLayerTests/test_user_service_coverage.py
@@ -144,11 +144,17 @@ class TestMeMedalAggregation:
         arsenal_row = {"count": 7}
         saved_rows = [{"id": 10, "name": "S", "status": "published", "created_at": "t"}]
         created_rows = [{"id": 20, "name": "C", "status": "draft", "created_at": "t"}]
+        solved_rows = [{"puzzle_id": 30, "id": 30, "name": "Solved"}]
 
-        # The me() function calls .execute(...).fetchall() / .fetchone() in sequence
-        def execute_side_effect(sql, params):
+        # The me() function calls .execute(...).fetchall() / .fetchone() in sequence.
+        # NOTE: both the medal-aggregation query and the solved-puzzles query
+        # reference puzzle_progress, so the solved-puzzles query (which uses
+        # "DISTINCT pp.puzzle_id") must be matched first.
+        def execute_side_effect(sql, params=None):
             cursor = Mock()
-            if "puzzle_progress" in sql:
+            if "DISTINCT pp.puzzle_id" in sql:
+                cursor.fetchall.return_value = solved_rows
+            elif "puzzle_progress" in sql:
                 cursor.fetchall.return_value = medal_rows
             elif "circuits" in sql:
                 cursor.fetchone.return_value = arsenal_row
@@ -156,6 +162,8 @@ class TestMeMedalAggregation:
                 cursor.fetchall.return_value = saved_rows
             elif "creator_user_id" in sql:
                 cursor.fetchall.return_value = created_rows
+            elif "AS total" in sql:
+                cursor.fetchone.return_value = {"total": 12}
             return cursor
 
         repo.conn.execute.side_effect = execute_side_effect
@@ -167,6 +175,7 @@ class TestMeMedalAggregation:
         assert result["arsenal_count"] == 7
         assert len(result["saved_puzzles"]) == 1
         assert len(result["created_puzzles"]) == 1
+        assert len(result["solved_puzzles"]) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_settings_constants.py
+++ b/src/tests/test_settings_constants.py
@@ -1,0 +1,118 @@
+"""
+Unit tests that pin the configuration constants ADD Chapter 7.2 references.
+
+Several rows in ADD 7.2 are "settings.py / Reference <CONSTANT> / Check value /
+Equals <X>" assertions, plus the XPService BASE_XP / MEDAL_BONUS / reward
+mappings.  This file proves those documented values actually live in the code,
+so the design document and the implementation cannot silently drift apart.
+
+Target module: Backend/settings.py  (+ XPService mappings derived from it).
+"""
+from unittest.mock import Mock
+
+from Backend import settings
+from Backend.ServiceLayer.XPService import XPService
+from Backend.PersistantLayer.UserRepo import UserRepo
+from Backend.DomainLayer.Enums import PuzzleDifficulty, Medal
+
+
+# ── 7.2.1 Circuit Cost and Board Constraints (settings rows) ──────────────────
+
+def test_puzzle_name_max_length():
+    """ADD 7.2.1 — PUZZLE_NAME_MAX_LENGTH equals 100."""
+    assert settings.PUZZLE_NAME_MAX_LENGTH == 100
+
+
+def test_puzzle_description_max_length():
+    """ADD 7.2.1 — PUZZLE_DESCRIPTION_MAX_LENGTH equals 2000.
+
+    NOTE: this is the authoritative value. The UC4 prose (ADD p.16) saying
+    'description <= 500' is outdated — see TEST_PLAN_ADD_MAP.txt for the
+    documented correction.
+    """
+    assert settings.PUZZLE_DESCRIPTION_MAX_LENGTH == 2000
+
+
+# ── 7.2.2 XP and Rewards Calculation (XPService + settings) ───────────────────
+
+def test_base_xp_per_difficulty():
+    """ADD 7.2.2 — BASE_XP: EASY=50, MEDIUM=100, HARD=200."""
+    xp = XPService(Mock(spec=UserRepo))
+    assert xp.BASE_XP[PuzzleDifficulty.EASY] == 50
+    assert xp.BASE_XP[PuzzleDifficulty.MEDIUM] == 100
+    assert xp.BASE_XP[PuzzleDifficulty.HARD] == 200
+
+
+def test_medal_bonus_values():
+    """ADD 7.2.2 — MEDAL_BONUS: SILVER=25, GOLD=50 (NONE/BRONZE=0)."""
+    xp = XPService(Mock(spec=UserRepo))
+    assert xp.MEDAL_BONUS[Medal.NONE] == 0
+    assert xp.MEDAL_BONUS[Medal.BRONZE] == 0
+    assert xp.MEDAL_BONUS[Medal.SILVER] == 25
+    assert xp.MEDAL_BONUS[Medal.GOLD] == 50
+
+
+def test_creator_solve_reward():
+    """ADD 7.2.2 — SOLVE_REWARD_CREATOR (XP_SOLVE_REWARD_CREATOR) equals 10."""
+    assert settings.XP_SOLVE_REWARD_CREATOR == 10
+
+
+def test_rating_xp_rewards():
+    """ADD 7.2.3 — first-time rating awards rater 5 XP, creator 1 XP."""
+    assert settings.XP_RATING_RATER == 5
+    assert settings.XP_RATING_CREATOR == 1
+
+
+def test_level_formula_constants():
+    """ADD 7.2.2 — LEVEL_XP_DIVISOR=100 and the real worked examples.
+
+    level = floor(sqrt(xp / 100)) + 1  →  400 XP = level 3 (ADD example is
+    correct).
+
+    CORRECTION: the ADD's "experienced" example row is off by one (it dropped
+    the '+1' in the formula). The real mapping is 900 XP = level 4 (NOT
+    experienced) and 1600 XP = level 5 (experienced) — NOT 1600=level4 /
+    2500=level5 as the ADD states. See TEST_PLAN_ADD_MAP.txt. The code is the
+    source of truth; this test pins the real behaviour.
+    """
+    assert settings.LEVEL_XP_DIVISOR == 100
+    xp = XPService(Mock(spec=UserRepo))
+    assert xp.calculate_level(400) == 3
+    assert xp.calculate_level(900) == 4
+    assert xp.calculate_level(1600) == 5
+    assert xp.calculate_level(2500) == 6
+    # EXPERIENCED_LEVEL_MIN == 5: level 4 is not experienced, level 5 is.
+    assert xp.is_experienced(900) is False     # level 4
+    assert xp.is_experienced(1600) is True      # level 5
+
+
+def test_experienced_level_min():
+    """ADD 7.2.2 — EXPERIENCED_LEVEL_MIN equals 5."""
+    assert settings.EXPERIENCED_LEVEL_MIN == 5
+
+
+# ── 7.2.3 Rating System Weighting (settings rows) ─────────────────────────────
+
+def test_rating_user_count_threshold():
+    """ADD 7.2.3 — RATING_USER_COUNT_THRESHOLD equals 10."""
+    assert settings.RATING_USER_COUNT_THRESHOLD == 10
+
+
+def test_rating_diff_weight_few_ratings():
+    """ADD 7.2.3 — RATING_DIFF_WEIGHT_FEW_RATINGS equals (0.8, 0.2)."""
+    assert settings.RATING_DIFF_WEIGHT_FEW_RATINGS == (0.8, 0.2)
+
+
+def test_rating_diff_weight_many_ratings():
+    """ADD 7.2.3 — RATING_DIFF_WEIGHT_MANY_RATINGS equals (0.4, 0.6)."""
+    assert settings.RATING_DIFF_WEIGHT_MANY_RATINGS == (0.4, 0.6)
+
+
+def test_rating_difficulty_map():
+    """ADD 7.2.3 — RATING_DIFFICULTY_MAP equals {EASY:1, MEDIUM:3, HARD:5}."""
+    assert settings.RATING_DIFFICULTY_MAP == {"EASY": 1, "MEDIUM": 3, "HARD": 5}
+
+
+def test_rating_min_attempt_seconds():
+    """ADD 7.2.3 — _can_rate threshold (RATING_MIN_ATTEMPT_SECONDS) equals 300."""
+    assert settings.RATING_MIN_ATTEMPT_SECONDS == 300


### PR DESCRIPTION
##  Acceptance & Unit Tests — mapped to the ADD

Adds the test suite promised by the **Application Design Document (ADD)**, reconciles **Chapter 7** with the real code, and ships a cross-platform runner with a live progress bar + coverage summary.

---

###  Acceptance tests — one per ADD use-case row
`src/tests/AcceptanceTests/test_acceptance_use_cases.py` · **51 tests**

One class per Use Case, one method per ADD *Test Name*, each header documenting *what each test checks*. Covers **UC1–UC14** (UC13 Discussions + UC14 Notifications are new — the old SystemTests file stopped at UC12).

| | | | |
|---|---|---|---|
| UC1 Browse & Search | UC2 Solve a Puzzle | UC3 Save & Reuse Circuits | UC4 Create & Publish |
| UC5 Rate a Puzzle | UC6 Rewards & Level Up | UC7 Manage Puzzles | UC8 Solution Validation |
| UC9 Appoint Creator | UC10 Profile & Progress | UC11 Sandbox | UC12 Manage Arsenal |
| UC13 Discussions 🆕 | UC14 Notifications 🆕 | | |

###  Unit-test gaps from ADD Ch. 7.2 — filled
- `PersistantLayerTests/test_solve_repo_leaderboard.py` — leaderboard by time/cost, passed filter *(4)*
- `ServiceLayerTests/test_rating_weighting.py` — `_weighted_avg`, `_exp_weight`, difficulty distribution *(5)*
- `test_settings_constants.py` — pins every constant the ADD cites *(13)*

###  Frontend test setup — was missing, now works
- Added `vitest.config.ts` + a `test` script (`yarn test` runs).
- New pure-logic libs with tests: `timer-display.ts` (timer green/amber/red, ADD 7.4) and `leaderboard-format.ts` (time/cost formatting).

###  Chapter 7 ↔ code corrections
Where the ADD text disagreed with the implementation, the doc was corrected to match current behaviour (e.g. the level-formula off-by-one). Details in `TEST_PLAN_ADD_MAP.txt`.

###  Cross-platform test runner
`run_tests.sh` (macOS/Linux) · `run_tests.ps1` + `run_tests.bat` (Windows) — run backend + frontend + types + lint, render a **live progress bar** with the current test name, and print a designed summary with coverage.

```
./run_tests.sh            # everything
./run_tests.sh backend    # pytest + coverage only
./run_tests.sh frontend   # vitest + types + lint only
```

---

###  Status
`backend 2666 passed (81% cov)` · `frontend 26 passed` · `types clean` · `lint clean` · `build OK`

> Map of every test ↔ ADD reference lives in **`TEST_PLAN_ADD_MAP.txt`**.
